### PR TITLE
docs: add hardware & network guide (EN + IT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Operations guide** — `docs/USAGE.md` with architecture, services, MPD control, mDNS setup, deployment, CI/CD, and configuration reference — Jan 30
 - **Italian translations** — Bilingual repo: `README.it.md`, `docs/USAGE.it.md`, `docs/SOURCES.it.md` with language switchers on all docs — Jan 30
+- **Hardware & network guide** — `docs/HARDWARE.md` (EN + IT) with server/client requirements, Raspberry Pi models, audio output options, network bandwidth calculations, WiFi vs Ethernet, recommended setups (budget/mid/enthusiast), and known limitations — Jan 30
 
 ### Changed
 - **Essential README** — Slimmed README from 435 to ~100 lines; technical content moved to `docs/USAGE.md`; README now reads as a simple appliance manual for non-technical users — Jan 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Each topic has ONE authoritative document. Other files link to it — never dupl
 | User quickstart | `README.md` | How to get running (essential steps only) |
 | Client basic setup | `README.md` | Install snapclient + connect (minimal) |
 | Changelog | `CHANGELOG.md` | Historical log, not duplicated |
+| Hardware requirements, network, setups | `docs/HARDWARE.md` | Server/client specs, Pi models, bandwidth, configs |
 | Source config (inline) | `config/snapserver.conf` | Comments per-source, links to docs/ |
 
 **Rules:**
@@ -25,6 +26,7 @@ Each topic has ONE authoritative document. Other files link to it — never dupl
 - When adding a new source type: update `docs/SOURCES.md` (full details) + `config/snapserver.conf` (commented example) + `README.md` source table (one-liner)
 - When changing source parameters: update `docs/SOURCES.md` only
 - When changing services, ports, deployment, mDNS: update `docs/USAGE.md` only
+- When changing hardware specs, network, or recommended setups: update `docs/HARDWARE.md` only
 - README links to docs/ for anything technical — never inline technical details
 
 ## Project Structure
@@ -35,6 +37,7 @@ snapMULTI/
     snapserver.conf    # Snapcast server config (4 active + 4 commented sources)
     mpd.conf           # MPD config (FIFO + HTTP outputs)
   docs/
+    HARDWARE.md        # Hardware & network guide (server/client specs, Pi, bandwidth, setups)
     USAGE.md           # Technical operations guide (architecture, services, MPD, mDNS, CI/CD)
     SOURCES.md         # Audio sources technical reference (SSOT for sources)
   .github/workflows/

--- a/README.it.md
+++ b/README.it.md
@@ -102,6 +102,7 @@ snapclient --host <ip-del-server>
 
 | Guida | Contenuto |
 |-------|-----------|
+| [Hardware e Rete](docs/HARDWARE.it.md) | Requisiti server/client, configurazioni Raspberry Pi, banda di rete, setup consigliati |
 | [Uso e Operazioni](docs/USAGE.it.md) | Architettura, servizi, controllo MPD, configurazione mDNS, deployment, CI/CD |
 | [Sorgenti Audio](docs/SOURCES.it.md) | Tutti i tipi di sorgente, parametri, API JSON-RPC, streaming da Android/Tidal |
 | [Changelog](CHANGELOG.md) | Cronologia delle versioni |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ snapclient --host <server-ip>
 
 | Guide | What's inside |
 |-------|---------------|
+| [Hardware & Network](docs/HARDWARE.md) | Server/client requirements, Raspberry Pi setups, network bandwidth, recommended configs |
 | [Usage & Operations](docs/USAGE.md) | Architecture, services, MPD control, mDNS setup, deployment, CI/CD |
 | [Audio Sources](docs/SOURCES.md) | All source types, parameters, JSON-RPC API, Android/Tidal streaming |
 | [Changelog](CHANGELOG.md) | Version history |

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -1,0 +1,220 @@
+🇬🇧 [English](HARDWARE.md) | 🇮🇹 **Italiano**
+
+# Guida Hardware e Rete
+
+Requisiti hardware, configurazioni consigliate e considerazioni sulla rete per snapMULTI.
+
+## Requisiti del Server
+
+Il server esegue tutti i servizi audio: Snapcast, MPD, shairport-sync (AirPlay) e librespot (Spotify Connect) all'interno di container Docker.
+
+### Hardware Minimo del Server
+
+| Componente | Minimo | Consigliato |
+|------------|--------|-------------|
+| CPU | 2 core, ARMv7+ o x86_64 | 4 core |
+| RAM | 1 GB | 2 GB+ |
+| Storage | 16 GB (SO + Docker) | 32 GB+ |
+| Rete | Ethernet 100 Mbps | Gigabit Ethernet |
+| Architettura | `linux/amd64` o `linux/arm64` | Entrambe |
+
+### Cosa Determina i Requisiti del Server
+
+- **shairport-sync** è il componente più esigente — richiede almeno una CPU di livello Raspberry Pi 2 o Pi Zero 2 W ([fonte](https://github.com/mikebrady/shairport-sync))
+- **librespot** usa ~20% della CPU su un Pi 3 con backend ALSA ([fonte](https://github.com/librespot-org/librespot/issues/343))
+- **MPD** usa 2–3 MB di RAM a riposo; la decodifica FLAC è leggera, ma il ricampionamento è intensivo per la CPU ([fonte](https://mpd.readthedocs.io/en/stable/user.html))
+- **Snapserver** usa <2% della CPU su un Pi 4 a riposo ([fonte](https://github.com/badaix/snapcast/issues/1336))
+- L'uso della CPU scala linearmente con il numero di client connessi
+
+### Esempi di Server
+
+| Hardware | Idoneità | Note |
+|----------|----------|------|
+| Raspberry Pi 4 (4 GB) | Buono | Gestisce tutte e 4 le sorgenti + 10 client comodamente |
+| Raspberry Pi 3B+ | Adeguato | Funziona ma potrebbe avere difficoltà con tutte le sorgenti attive contemporaneamente |
+| Intel NUC / mini PC | Eccellente | Sovradimensionato ma ideale per installazioni grandi |
+| Vecchio laptop / desktop | Eccellente | Qualsiasi macchina x86_64 con 2+ GB di RAM funziona bene |
+| NAS con Docker | Buono | Se supporta Docker e ha 2+ core |
+
+> **Nota:** Raspberry Pi 2 e Pi Zero 2 W possono eseguire il server ma sono al limite. Un Pi 3B+ o superiore è consigliato per tutte e quattro le sorgenti audio.
+
+## Requisiti dei Client
+
+I client Snapcast sono leggeri — ricevono audio e lo riproducono attraverso gli altoparlanti.
+
+### Hardware Minimo del Client
+
+| Componente | Minimo | Note |
+|------------|--------|------|
+| CPU | Qualsiasi ARMv6+ o x86_64 | Anche il Pi Zero W (originale) funziona |
+| RAM | 256 MB | Snapclient usa pochissima memoria |
+| Storage | 8 GB microSD | 16 GB consigliati |
+| Uscita audio | 3.5mm, HDMI, DAC USB o HAT I2S | Vedi sezione uscita audio |
+
+### Dispositivi Client
+
+| Dispositivo | Prezzo Indicativo | Uscita Audio | Consumo | Note |
+|-------------|-------------------|--------------|---------|------|
+| **Raspberry Pi Zero 2 W** | ~15€ | DAC USB o HAT I2S | 0,75 W | Miglior opzione economica, WiFi integrato |
+| **Raspberry Pi Zero W** (v1) | ~10€ | DAC USB o HAT I2S | 0,5 W | Funziona ma più lento; nessun jack audio integrato |
+| **Raspberry Pi 3B/3B+** | ~35€ | Jack 3.5mm, HDMI, DAC USB | 2,5 W | Uscita audio integrata, WiFi + Ethernet |
+| **Raspberry Pi 4** | ~35–55€ | Jack 3.5mm, HDMI, DAC USB | 3–6 W | Più potenza del necessario per un client |
+| **Raspberry Pi 5** | ~60–80€ | HDMI, DAC USB | 4–8 W | Sovradimensionato per uso client |
+| **Vecchio telefono Android** | Gratis | Altoparlante integrato | Batteria | Tramite app Snapcast Android |
+| **Qualsiasi PC Linux** | Varia | Audio integrato | Varia | `apt install snapclient` |
+
+### Qualità dell'Uscita Audio
+
+| Metodo di Uscita | Qualità | Costo | Note |
+|------------------|---------|-------|------|
+| **DAC HAT I2S** (HiFiBerry, IQAudio) | Eccellente | 20–50€ | Migliore qualità audio, si collega direttamente al GPIO del Pi |
+| **DAC USB** | Molto buona | 10–100€ | Ampia gamma di opzioni, funziona con Pi Zero |
+| **HDMI** | Buona | Gratis | Usa il tuo TV/ricevitore come altoparlante |
+| **Jack 3.5mm** (Pi 3/4) | Adeguata | Gratis | Fruscio percepibile su alcuni modelli; va bene per ascolto casual |
+
+> **Suggerimento:** Per la migliore esperienza audio su Raspberry Pi, usa un HiFiBerry DAC+ Zero (~20€) o qualsiasi DAC USB. Il jack 3.5mm integrato nel Pi 3/4 è adeguato ma non di qualità audiofila.
+
+### Docker vs Installazione Nativa (Client)
+
+Per i dispositivi **client**, l'installazione nativa è consigliata rispetto a Docker:
+
+- Minor overhead sui dispositivi con risorse limitate
+- Accesso diretto all'hardware audio
+- Configurazione più semplice
+
+```bash
+# Installazione nativa (consigliata per i client)
+sudo apt install snapclient
+
+# Docker (solo se preferisci la containerizzazione)
+docker run -d --name snapclient --device /dev/snd sweisgerber/snapcast:latest
+```
+
+Docker è consigliato per il **server** dove si beneficia della gestione container e della riproducibilità.
+
+## Requisiti di Rete
+
+### Banda
+
+Formato audio: 48000 Hz, 16-bit, stereo (codec FLAC predefinito).
+
+| Metrica | Valore |
+|---------|--------|
+| Bitrate PCM grezzo | 1,536 Mbps (192 KB/s) |
+| FLAC compresso (tipico) | ~0,9 Mbps (~115 KB/s) |
+| Overhead protocollo per client | ~14 kbps (trascurabile) |
+
+**Banda totale per numero di client:**
+
+| Client | Banda FLAC | Rete Necessaria |
+|--------|------------|-----------------|
+| 5 | ~4,5 Mbps | Qualsiasi rete moderna |
+| 10 | ~9 Mbps | Qualsiasi rete moderna |
+| 20 | ~18 Mbps | Ethernet 100 Mbps o WiFi 5 GHz |
+| 50 | ~45 Mbps | Gigabit Ethernet consigliato |
+
+> **La banda NON è un collo di bottiglia** per le tipiche configurazioni domestiche. Anche il WiFi 2,4 GHz (throughput pratico ~20–50 Mbps) gestisce 10+ client.
+
+### WiFi vs Ethernet
+
+| Fattore | WiFi (2,4 GHz) | WiFi (5 GHz) | Ethernet |
+|---------|-----------------|---------------|----------|
+| Banda | 20–50 Mbps pratica | 150–400 Mbps | 100–1000 Mbps |
+| Latenza | 2–10 ms | 1–5 ms | <1 ms |
+| Affidabilità | Variabile (interferenze) | Buona | Eccellente |
+| Capacità client | 10–15 client | 20+ client | 50+ client |
+| Ideale per | Client in stanze senza Ethernet | Client che necessitano affidabilità | Server, client critici |
+
+**Raccomandazioni:**
+- **Server**: Ethernet quando possibile
+- **Client**: il WiFi funziona bene; usa 5 GHz se disponibile
+- **Configurazioni sensibili alla latenza**: Ethernet riduce il jitter di sincronizzazione
+
+### Sincronizzazione
+
+- Snapcast raggiunge una **sincronizzazione sub-millisecondo** tra i client
+- Buffer predefinito: 1000 ms (configurabile in `snapserver.conf`)
+- Buffer più grande = più stabile su reti scadenti, ma aggiunge ritardo alla riproduzione
+- Il jitter WiFi è compensato automaticamente — i client regolano la velocità di riproduzione
+
+### Configurazione di Rete
+
+**Porte necessarie:**
+
+| Porta | Protocollo | Direzione | Scopo |
+|-------|------------|-----------|-------|
+| 1704 | TCP | Server → Client | Streaming audio |
+| 1705 | TCP | Bidirezionale | Controllo JSON-RPC |
+| 1780 | HTTP | Bidirezionale | API HTTP |
+| 5353 | UDP | Multicast | Autodiscovery mDNS |
+
+**Requisiti del router:**
+- Client e server devono essere sulla stessa sottorete (o mDNS deve essere inoltrato)
+- Supporto IGMP snooping consigliato per reti più grandi
+- Nessuna funzionalità speciale del router necessaria per l'uso domestico tipico
+
+### Regole Firewall
+
+```bash
+# Consenti il traffico Snapcast
+sudo ufw allow 1704/tcp   # Streaming audio
+sudo ufw allow 1705/tcp   # Controllo JSON-RPC
+sudo ufw allow 1780/tcp   # API HTTP
+sudo ufw allow 5353/udp   # Discovery mDNS
+```
+
+## Storage
+
+### Immagini Docker
+
+| Immagine | Dimensione |
+|----------|------------|
+| `ghcr.io/lollonet/snapmulti:latest` | ~80–120 MB |
+| `ghcr.io/lollonet/snapmulti-mpd:latest` | ~50–80 MB |
+
+### Libreria Musicale
+
+| Formato | Dimensione Album Tipica | 1000 Album |
+|---------|-------------------------|------------|
+| FLAC (lossless) | 300–500 MB | 300–500 GB |
+| MP3 320 kbps | 80–120 MB | 80–120 GB |
+| MP3 192 kbps | 50–80 MB | 50–80 GB |
+
+**Consigli per lo storage:**
+- Librerie FLAC: disco USB esterno o mount NAS
+- Librerie MP3: microSD 256 GB+ o disco interno
+- File database MPD: <100 MB indipendentemente dalla dimensione della libreria
+
+## Configurazioni Consigliate
+
+### Configurazione Economica (~50€)
+
+| Ruolo | Hardware | Costo |
+|-------|----------|-------|
+| Server | Raspberry Pi 3B+ (usato) | ~25€ |
+| Client (1 stanza) | Raspberry Pi Zero 2 W + DAC USB | ~25€ |
+
+### Configurazione Media (~150€)
+
+| Ruolo | Hardware | Costo |
+|-------|----------|-------|
+| Server | Raspberry Pi 4 (4 GB) | ~55€ |
+| Client (3 stanze) | 3× Raspberry Pi Zero 2 W + HiFiBerry DAC+ Zero | ~105€ |
+
+### Configurazione Entusiasta (~300€+)
+
+| Ruolo | Hardware | Costo |
+|-------|----------|-------|
+| Server | Intel NUC o mini PC | ~150€+ |
+| Client (5 stanze) | Mix di Pi Zero 2 W con HAT HiFiBerry | ~175€ |
+| Rete | Switch gestito + Ethernet al server | ~30€ |
+
+## Limitazioni Note
+
+| Limitazione | Dettagli |
+|-------------|----------|
+| **Pi Zero W (v1) come server** | Troppo lento per shairport-sync + librespot contemporaneamente |
+| **librespot su ARMv6** | Non ufficialmente supportato su Pi Zero v1 / Pi 1 ([dettagli](https://github.com/librespot-org/librespot/pull/1457)). Cross-compilazione possibile ma non supportata |
+| **Audio 3.5mm su Pi** | Rumore di fondo percepibile; usa DAC HAT o DAC USB per qualità |
+| **WiFi 2,4 GHz** | Funziona ma soggetto a interferenze; 5 GHz preferito per >10 client |
+| **Docker su Pi OS 32-bit** | In via di deprecazione; usa Pi OS 64-bit per deployment Docker |

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,0 +1,220 @@
+🇬🇧 **English** | 🇮🇹 [Italiano](HARDWARE.it.md)
+
+# Hardware & Network Guide
+
+Hardware requirements, recommended setups, and network considerations for snapMULTI.
+
+## Server Requirements
+
+The server runs all audio services: Snapcast, MPD, shairport-sync (AirPlay), and librespot (Spotify Connect) inside Docker containers.
+
+### Minimum Server Hardware
+
+| Component | Minimum | Recommended |
+|-----------|---------|-------------|
+| CPU | 2 cores, ARMv7+ or x86_64 | 4 cores |
+| RAM | 1 GB | 2 GB+ |
+| Storage | 16 GB (OS + Docker) | 32 GB+ |
+| Network | 100 Mbps Ethernet | Gigabit Ethernet |
+| Architecture | `linux/amd64` or `linux/arm64` | Either |
+
+### What Drives Server Requirements
+
+- **shairport-sync** is the most demanding component — requires at minimum a Raspberry Pi 2 or Pi Zero 2 W level of CPU ([source](https://github.com/mikebrady/shairport-sync))
+- **librespot** uses ~20% CPU on a Pi 3 with ALSA backend ([source](https://github.com/librespot-org/librespot/issues/343))
+- **MPD** uses 2–3 MB RAM idle; FLAC decoding is lightweight, but resampling is CPU-intensive ([source](https://mpd.readthedocs.io/en/stable/user.html))
+- **Snapserver** uses <2% CPU on a Pi 4 when idle ([source](https://github.com/badaix/snapcast/issues/1336))
+- CPU scales linearly with number of connected clients
+
+### Server Examples
+
+| Hardware | Suitability | Notes |
+|----------|-------------|-------|
+| Raspberry Pi 4 (4 GB) | Good | Handles all 4 sources + 10 clients comfortably |
+| Raspberry Pi 3B+ | Adequate | Works but may struggle with all sources active simultaneously |
+| Intel NUC / mini PC | Excellent | Overkill but ideal for large deployments |
+| Old laptop / desktop | Excellent | Any x86_64 machine with 2+ GB RAM works well |
+| NAS with Docker | Good | If it supports Docker and has 2+ cores |
+
+> **Note:** Raspberry Pi 2 and Pi Zero 2 W can run the server but are borderline. A Pi 3B+ or better is recommended for all four audio sources.
+
+## Client Requirements
+
+Snapcast clients are lightweight — they receive audio and play it through speakers.
+
+### Minimum Client Hardware
+
+| Component | Minimum | Notes |
+|-----------|---------|-------|
+| CPU | Any ARMv6+ or x86_64 | Even Pi Zero W (original) works |
+| RAM | 256 MB | Snapclient uses very little memory |
+| Storage | 8 GB microSD | 16 GB recommended |
+| Audio output | 3.5mm, HDMI, USB DAC, or I2S HAT | See audio output section |
+
+### Client Device Options
+
+| Device | Price Range | Audio Output | Power | Notes |
+|--------|-------------|--------------|-------|-------|
+| **Raspberry Pi Zero 2 W** | ~$15 | USB DAC or I2S HAT | 0.75 W | Best budget option, WiFi built-in |
+| **Raspberry Pi Zero W** (v1) | ~$10 | USB DAC or I2S HAT | 0.5 W | Works but slower; no built-in audio jack |
+| **Raspberry Pi 3B/3B+** | ~$35 | 3.5mm jack, HDMI, USB DAC | 2.5 W | Built-in audio output, WiFi + Ethernet |
+| **Raspberry Pi 4** | ~$35–55 | 3.5mm jack, HDMI, USB DAC | 3–6 W | More power than needed for a client |
+| **Raspberry Pi 5** | ~$60–80 | HDMI, USB DAC | 4–8 W | Overkill for client use |
+| **Old Android phone** | Free | Built-in speaker | Battery | Via Snapcast Android app |
+| **Any Linux PC** | Varies | Built-in audio | Varies | `apt install snapclient` |
+
+### Audio Output Quality
+
+| Output Method | Quality | Cost | Notes |
+|---------------|---------|------|-------|
+| **I2S DAC HAT** (HiFiBerry, IQAudio) | Excellent | $20–50 | Best audio quality, connects directly to Pi GPIO |
+| **USB DAC** | Very good | $10–100 | Wide range of options, works with Pi Zero |
+| **HDMI** | Good | Free | Use your TV/receiver as speaker |
+| **3.5mm jack** (Pi 3/4) | Adequate | Free | Noticeable hiss on some models; fine for casual listening |
+
+> **Tip:** For the best audio experience on Raspberry Pi, use a HiFiBerry DAC+ Zero (~$20) or any USB DAC. The built-in 3.5mm jack on Pi 3/4 is adequate but not audiophile-grade.
+
+### Docker vs Native Install (Clients)
+
+For **client** devices, native installation is recommended over Docker:
+
+- Lower overhead on resource-constrained devices
+- Direct access to audio hardware
+- Simpler configuration
+
+```bash
+# Native install (recommended for clients)
+sudo apt install snapclient
+
+# Docker (only if you prefer containerization)
+docker run -d --name snapclient --device /dev/snd sweisgerber/snapcast:latest
+```
+
+Docker is recommended for the **server** where you benefit from container management and reproducibility.
+
+## Network Requirements
+
+### Bandwidth
+
+Audio format: 48000 Hz, 16-bit, stereo (default FLAC codec).
+
+| Metric | Value |
+|--------|-------|
+| Raw PCM bitrate | 1.536 Mbps (192 KB/s) |
+| FLAC compressed (typical) | ~0.9 Mbps (~115 KB/s) |
+| Protocol overhead per client | ~14 kbps (negligible) |
+
+**Total bandwidth by number of clients:**
+
+| Clients | FLAC Bandwidth | Network Needed |
+|---------|---------------|----------------|
+| 5 | ~4.5 Mbps | Any modern network |
+| 10 | ~9 Mbps | Any modern network |
+| 20 | ~18 Mbps | 100 Mbps Ethernet or 5 GHz WiFi |
+| 50 | ~45 Mbps | Gigabit Ethernet recommended |
+
+> **Bandwidth is NOT a bottleneck** for typical home setups. Even 2.4 GHz WiFi (practical throughput ~20–50 Mbps) handles 10+ clients.
+
+### WiFi vs Ethernet
+
+| Factor | WiFi (2.4 GHz) | WiFi (5 GHz) | Ethernet |
+|--------|-----------------|---------------|----------|
+| Bandwidth | 20–50 Mbps practical | 150–400 Mbps | 100–1000 Mbps |
+| Latency | 2–10 ms | 1–5 ms | <1 ms |
+| Reliability | Variable (interference) | Good | Excellent |
+| Client capacity | 10–15 clients | 20+ clients | 50+ clients |
+| Best for | Clients in rooms without Ethernet | Clients needing reliability | Server, critical clients |
+
+**Recommendations:**
+- **Server**: Ethernet whenever possible
+- **Clients**: WiFi works fine; use 5 GHz if available
+- **Latency-sensitive setups**: Ethernet reduces sync jitter
+
+### Synchronization
+
+- Snapcast achieves **sub-millisecond sync** across clients
+- Default buffer: 1000 ms (configurable in `snapserver.conf`)
+- Larger buffer = more stable on poor networks, but adds playback delay
+- WiFi jitter is compensated automatically — clients adjust playback speed
+
+### Network Configuration
+
+**Required ports:**
+
+| Port | Protocol | Direction | Purpose |
+|------|----------|-----------|---------|
+| 1704 | TCP | Server → Clients | Audio streaming |
+| 1705 | TCP | Bidirectional | JSON-RPC control |
+| 1780 | HTTP | Bidirectional | HTTP API |
+| 5353 | UDP | Multicast | mDNS autodiscovery |
+
+**Router requirements:**
+- Clients and server must be on the same subnet (or mDNS must be forwarded)
+- IGMP snooping support recommended for larger networks
+- No special router features needed for typical home use
+
+### Firewall Rules
+
+```bash
+# Allow Snapcast traffic
+sudo ufw allow 1704/tcp   # Audio streaming
+sudo ufw allow 1705/tcp   # JSON-RPC control
+sudo ufw allow 1780/tcp   # HTTP API
+sudo ufw allow 5353/udp   # mDNS discovery
+```
+
+## Storage
+
+### Docker Images
+
+| Image | Size |
+|-------|------|
+| `ghcr.io/lollonet/snapmulti:latest` | ~80–120 MB |
+| `ghcr.io/lollonet/snapmulti-mpd:latest` | ~50–80 MB |
+
+### Music Library
+
+| Format | Typical Album Size | 1000 Albums |
+|--------|--------------------|-------------|
+| FLAC (lossless) | 300–500 MB | 300–500 GB |
+| MP3 320 kbps | 80–120 MB | 80–120 GB |
+| MP3 192 kbps | 50–80 MB | 50–80 GB |
+
+**Storage recommendations:**
+- FLAC libraries: external USB drive or NAS mount
+- MP3 libraries: 256 GB+ microSD or internal drive
+- MPD database file: <100 MB regardless of library size
+
+## Recommended Setups
+
+### Budget Setup (~$50)
+
+| Role | Hardware | Cost |
+|------|----------|------|
+| Server | Raspberry Pi 3B+ (used) | ~$25 |
+| Client (1 room) | Raspberry Pi Zero 2 W + USB DAC | ~$25 |
+
+### Mid-Range Setup (~$150)
+
+| Role | Hardware | Cost |
+|------|----------|------|
+| Server | Raspberry Pi 4 (4 GB) | ~$55 |
+| Client (3 rooms) | 3× Raspberry Pi Zero 2 W + HiFiBerry DAC+ Zero | ~$105 |
+
+### Enthusiast Setup (~$300+)
+
+| Role | Hardware | Cost |
+|------|----------|------|
+| Server | Intel NUC or mini PC | ~$150+ |
+| Client (5 rooms) | Mix of Pi Zero 2 W with HiFiBerry HATs | ~$175 |
+| Network | Managed switch + Ethernet to server | ~$30 |
+
+## Known Limitations
+
+| Limitation | Details |
+|------------|---------|
+| **Pi Zero W (v1) as server** | Too slow for shairport-sync + librespot simultaneously |
+| **librespot on ARMv6** | Not officially supported on Pi Zero v1 / Pi 1 ([details](https://github.com/librespot-org/librespot/pull/1457)). Cross-compilation possible but unsupported |
+| **3.5mm audio on Pi** | Noticeable noise floor; use DAC HAT or USB DAC for quality |
+| **2.4 GHz WiFi** | Works but susceptible to interference; 5 GHz preferred for >10 clients |
+| **Docker on 32-bit Pi OS** | Being deprecated; use 64-bit Pi OS for Docker deployments |


### PR DESCRIPTION
## Summary
- New `docs/HARDWARE.md` and `docs/HARDWARE.it.md` — comprehensive hardware and network guide
- Researched from official sources: Snapcast GitHub, shairport-sync README, librespot wiki, MPD docs
- Bandwidth math double-checked (research agent initially confused bits/bytes — corrected)
- ARMv6/librespot limitation verified against upstream PRs

## Contents
- Server requirements (minimum specs, per-component CPU/RAM usage with sources)
- Client device options (Pi Zero W through Pi 5, Android, any Linux PC)
- Audio output quality comparison (I2S HAT > USB DAC > HDMI > 3.5mm)
- Network: PCM = 1.536 Mbps, FLAC ≈ 0.9 Mbps per client, protocol overhead ≈ 14 kbps
- WiFi vs Ethernet with client capacity estimates
- 3 recommended setups: budget ($50), mid-range ($150), enthusiast ($300+)
- Known limitations section
- Docker vs native install guidance for clients

## Test plan
- [ ] HARDWARE.md renders correctly on GitHub
- [ ] HARDWARE.it.md renders correctly on GitHub
- [ ] Language switcher links work (EN↔IT)
- [ ] README doc tables include hardware guide link (both languages)
- [ ] All external source links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)