### PR TITLE
feat: add myMPD web GUI for mobile-ready MPD control

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ mpd/data
 mpd/playlists
 data
 audio
+mympd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **myMPD web GUI** — Mobile-ready web interface for MPD control via [myMPD](https://github.com/jcorporation/myMPD) on port 8180 (PWA, album art, playlists)
+
 ### Changed
 - **CI trigger** — Build & Push workflow now triggers on version tag push (`v*`) instead of every push to `main`; Docker images are tagged with both `:latest` and the version number (e.g. `:1.0.1`)
 - **Deploy script** — Replaced `git pull` with `git fetch && git reset --hard` to prevent conflicts from local config overrides on the server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,12 @@ snapMULTI/
     deploy.yml         # SSH deploy (workflow_call from build-push)
     build-test.yml     # PR-only build validation
     validate.yml       # Config syntax validation
+  mympd/
+    workdir/           # myMPD persistent data
+    cachedir/          # myMPD cache (album art, etc.)
   Dockerfile.snapMULTI # Snapserver + shairport-sync + librespot (Alpine)
   Dockerfile.mpd       # MPD + ffmpeg (Alpine)
-  docker-compose.yml   # App services (ghcr.io images, host networking)
+  docker-compose.yml   # App services (ghcr.io + myMPD images, host networking)
   .env.example         # Environment template
   .dockerignore        # Build context exclusions
   README.md            # Essential user guide (quickstart, connect, links to docs/)
@@ -59,5 +62,5 @@ snapMULTI/
 - **Docker images**: `ghcr.io/lollonet/snapmulti:latest` and `ghcr.io/lollonet/snapmulti-mpd:latest`
 - **Multi-arch**: linux/amd64 (raspy) + linux/arm64 (studio), native builds on self-hosted runners
 - **Config paths**: all config in `config/` directory
-- **Deployment**: push to main triggers build → manifest → deploy (never push directly to main without PR unless explicitly requested)
+- **Deployment**: tag push (`v*`) triggers build → manifest → deploy (never push directly to main without PR unless explicitly requested)
 - **Audio format**: 48000:16:2 (48kHz, 16-bit, stereo) across all sources

--- a/README.it.md
+++ b/README.it.md
@@ -16,7 +16,7 @@ snapMULTI gira su un server domestico e trasmette l'audio agli altoparlanti in t
 |----------|-------------|
 | **Spotify** | Apri l'app Spotify → Connetti a un dispositivo → "snapMULTI" (richiede Premium) |
 | **AirPlay** | iPhone/iPad/Mac → AirPlay → "snapMULTI" |
-| **Libreria musicale** | Usa un'app MPD ([Cantata](https://github.com/CDrummond/cantata), [MPDroid](https://play.google.com/store/apps/details?id=com.namelessdev.mpdroid)) → connettiti al server |
+| **Libreria musicale** | Usa l'interfaccia web [myMPD](http://ip-del-server:8180), oppure un'app MPD ([Cantata](https://github.com/CDrummond/cantata), [MPDroid](https://play.google.com/store/apps/details?id=com.namelessdev.mpdroid)) → connettiti al server |
 | **Qualsiasi app** | Trasmetti audio via TCP al server |
 | **Android / Tidal** | Vedi la [guida allo streaming](docs/SOURCES.it.md#streaming-da-android) |
 
@@ -70,7 +70,11 @@ docker compose up -d
 docker ps
 ```
 
-Dovresti vedere due container in esecuzione: `snapserver` e `mpd`.
+Dovresti vedere tre container in esecuzione: `snapserver`, `mympd` e `mpd`.
+
+### 5. Controlla la tua musica
+
+Apri `http://<ip-del-server>:8180` nel browser — myMPD ti permette di sfogliare e riprodurre la tua libreria da qualsiasi dispositivo.
 
 ## Ascolta sui Tuoi Altoparlanti
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ snapMULTI runs on a home server and streams audio to speakers throughout your ne
 |--------|------------|
 | **Spotify** | Open Spotify app → Connect to a device → "snapMULTI" (Premium required) |
 | **AirPlay** | iPhone/iPad/Mac → AirPlay → "snapMULTI" |
-| **Music library** | Use an MPD app ([Cantata](https://github.com/CDrummond/cantata), [MPDroid](https://play.google.com/store/apps/details?id=com.namelessdev.mpdroid)) → connect to your server |
+| **Music library** | Use [myMPD](http://server-ip:8180) web UI, or an MPD app ([Cantata](https://github.com/CDrummond/cantata), [MPDroid](https://play.google.com/store/apps/details?id=com.namelessdev.mpdroid)) → connect to your server |
 | **Any app** | Stream audio via TCP to the server |
 | **Android / Tidal** | See [streaming guide](docs/SOURCES.md#streaming-from-android) |
 
@@ -70,7 +70,11 @@ docker compose up -d
 docker ps
 ```
 
-You should see two running containers: `snapserver` and `mpd`.
+You should see three running containers: `snapserver`, `mympd`, and `mpd`.
+
+### 5. Control your music
+
+Open `http://<server-ip>:8180` in a browser — myMPD lets you browse and play your library from any device.
 
 ## Listen on Your Speakers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,23 @@ services:
       - TZ=${TZ:-Europe/Berlin}
     command: ["snapserver", "-c", "/etc/snapserver.conf"]
 
+  mympd:
+    image: ghcr.io/jcorporation/mympd/mympd:latest
+    container_name: mympd
+    restart: unless-stopped
+    network_mode: host
+    user: "${PUID:-1000}:${PGID:-1000}"
+    volumes:
+      - ./mympd/workdir:/var/lib/mympd
+      - ./mympd/cachedir:/var/cache/mympd
+      - ${MUSIC_LOSSLESS_PATH}:/music/Lossless:ro
+      - ${MUSIC_LOSSY_PATH}:/music/Lossy:ro
+      - ./mpd/playlists:/playlists:ro
+    environment:
+      - TZ=${TZ:-Europe/Berlin}
+      - MYMPD_HTTP_PORT=8180
+      - MYMPD_SSL=false
+
   mpd:
     image: ghcr.io/lollonet/snapmulti-mpd:latest
     container_name: mpd

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -146,6 +146,7 @@ Formato audio: 48000 Hz, 16-bit, stereo (codec FLAC predefinito).
 | 1704 | TCP | Server → Client | Streaming audio |
 | 1705 | TCP | Bidirezionale | Controllo JSON-RPC |
 | 1780 | HTTP | Bidirezionale | API HTTP |
+| 8180 | HTTP | Bidirezionale | Interfaccia web myMPD |
 | 5353 | UDP | Multicast | Autodiscovery mDNS |
 
 **Requisiti del router:**
@@ -160,6 +161,7 @@ Formato audio: 48000 Hz, 16-bit, stereo (codec FLAC predefinito).
 sudo ufw allow 1704/tcp   # Streaming audio
 sudo ufw allow 1705/tcp   # Controllo JSON-RPC
 sudo ufw allow 1780/tcp   # API HTTP
+sudo ufw allow 8180/tcp   # Interfaccia web myMPD
 sudo ufw allow 5353/udp   # Discovery mDNS
 ```
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -146,6 +146,7 @@ Audio format: 48000 Hz, 16-bit, stereo (default FLAC codec).
 | 1704 | TCP | Server → Clients | Audio streaming |
 | 1705 | TCP | Bidirectional | JSON-RPC control |
 | 1780 | HTTP | Bidirectional | HTTP API |
+| 8180 | HTTP | Bidirectional | myMPD web UI |
 | 5353 | UDP | Multicast | mDNS autodiscovery |
 
 **Router requirements:**
@@ -160,6 +161,7 @@ Audio format: 48000 Hz, 16-bit, stereo (default FLAC codec).
 sudo ufw allow 1704/tcp   # Audio streaming
 sudo ufw allow 1705/tcp   # JSON-RPC control
 sudo ufw allow 1780/tcp   # HTTP API
+sudo ufw allow 8180/tcp   # myMPD web UI
 sudo ufw allow 5353/udp   # mDNS discovery
 ```
 


### PR DESCRIPTION
## Summary
- Add **myMPD** as third Docker service for web-based MPD control (PWA, mobile-ready)
- Uses official `ghcr.io/jcorporation/mympd/mympd:latest` image on **port 8180** (8080 taken by ownCloud)
- SSL disabled for LAN use, host networking like other services
- Full bilingual docs updated (EN+IT): architecture diagrams, port tables, firewall rules, quickstart

## Test plan
- [ ] `docker compose config` validates successfully
- [ ] `docker compose up -d mympd` starts the container
- [ ] Browse to `http://<server-ip>:8180` — myMPD UI loads
- [ ] myMPD connects to MPD and shows music library
- [ ] Play a track from myMPD — audio plays through Snapcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)