### PR TITLE
docs: fix audit findings across EN and IT documentation

### DIFF
--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -87,7 +87,7 @@ Per i dispositivi **client**, l'installazione nativa è consigliata rispetto a D
 sudo apt install snapclient
 
 # Docker (solo se preferisci la containerizzazione)
-docker run -d --name snapclient --device /dev/snd sweisgerber/snapcast:latest
+docker run -d --name snapclient --network host --device /dev/snd ghcr.io/badaix/snapcast:latest snapclient
 ```
 
 Docker è consigliato per il **server** dove si beneficia della gestione container e della riproducibilità.
@@ -146,6 +146,8 @@ Formato audio: 48000 Hz, 16-bit, stereo (codec FLAC predefinito).
 | 1704 | TCP | Server → Client | Streaming audio |
 | 1705 | TCP | Bidirezionale | Controllo JSON-RPC |
 | 1780 | HTTP | Bidirezionale | API HTTP |
+| 6600 | TCP | Bidirezionale | Protocollo MPD (controllo client) |
+| 8000 | HTTP | Bidirezionale | Stream audio HTTP MPD |
 | 8180 | HTTP | Bidirezionale | Interfaccia web myMPD |
 | 5353 | UDP | Multicast | Autodiscovery mDNS |
 
@@ -161,6 +163,8 @@ Formato audio: 48000 Hz, 16-bit, stereo (codec FLAC predefinito).
 sudo ufw allow 1704/tcp   # Streaming audio
 sudo ufw allow 1705/tcp   # Controllo JSON-RPC
 sudo ufw allow 1780/tcp   # API HTTP
+sudo ufw allow 6600/tcp   # Protocollo MPD
+sudo ufw allow 8000/tcp   # Stream HTTP MPD
 sudo ufw allow 8180/tcp   # Interfaccia web myMPD
 sudo ufw allow 5353/udp   # Discovery mDNS
 ```
@@ -171,7 +175,9 @@ sudo ufw allow 5353/udp   # Discovery mDNS
 
 | Immagine | Dimensione |
 |----------|------------|
-| `ghcr.io/lollonet/snapmulti:latest` | ~80–120 MB |
+| `ghcr.io/lollonet/snapmulti-server:latest` | ~80–120 MB |
+| `ghcr.io/lollonet/snapmulti-airplay:latest` | ~30–50 MB |
+| `ghcr.io/lollonet/snapmulti-spotify:latest` | ~30–50 MB |
 | `ghcr.io/lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 
 ### Libreria Musicale

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -87,7 +87,7 @@ For **client** devices, native installation is recommended over Docker:
 sudo apt install snapclient
 
 # Docker (only if you prefer containerization)
-docker run -d --name snapclient --device /dev/snd sweisgerber/snapcast:latest
+docker run -d --name snapclient --network host --device /dev/snd ghcr.io/badaix/snapcast:latest snapclient
 ```
 
 Docker is recommended for the **server** where you benefit from container management and reproducibility.
@@ -146,6 +146,8 @@ Audio format: 48000 Hz, 16-bit, stereo (default FLAC codec).
 | 1704 | TCP | Server → Clients | Audio streaming |
 | 1705 | TCP | Bidirectional | JSON-RPC control |
 | 1780 | HTTP | Bidirectional | HTTP API |
+| 6600 | TCP | Bidirectional | MPD protocol (client control) |
+| 8000 | HTTP | Bidirectional | MPD HTTP audio stream |
 | 8180 | HTTP | Bidirectional | myMPD web UI |
 | 5353 | UDP | Multicast | mDNS autodiscovery |
 
@@ -161,6 +163,8 @@ Audio format: 48000 Hz, 16-bit, stereo (default FLAC codec).
 sudo ufw allow 1704/tcp   # Audio streaming
 sudo ufw allow 1705/tcp   # JSON-RPC control
 sudo ufw allow 1780/tcp   # HTTP API
+sudo ufw allow 6600/tcp   # MPD protocol
+sudo ufw allow 8000/tcp   # MPD HTTP stream
 sudo ufw allow 8180/tcp   # myMPD web UI
 sudo ufw allow 5353/udp   # mDNS discovery
 ```
@@ -171,7 +175,9 @@ sudo ufw allow 5353/udp   # mDNS discovery
 
 | Image | Size |
 |-------|------|
-| `ghcr.io/lollonet/snapmulti:latest` | ~80–120 MB |
+| `ghcr.io/lollonet/snapmulti-server:latest` | ~80–120 MB |
+| `ghcr.io/lollonet/snapmulti-airplay:latest` | ~30–50 MB |
+| `ghcr.io/lollonet/snapmulti-spotify:latest` | ~30–50 MB |
 | `ghcr.io/lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 
 ### Music Library

--- a/docs/SOURCES.it.md
+++ b/docs/SOURCES.it.md
@@ -32,7 +32,7 @@ Legge audio PCM da una pipe FIFO con nome. MPD scrive il suo output su `/audio/s
 
 **Configurazione:**
 ```ini
-source = pipe:////audio/snapcast_fifo?name=MPD
+source = pipe:////audio/snapcast_fifo?name=MPD&controlscript=meta_mpd.py
 ```
 
 **Parametri:**
@@ -41,6 +41,7 @@ source = pipe:////audio/snapcast_fifo?name=MPD
 |-----------|--------|-------------|
 | `name` | `MPD` | ID dello stream per uso client/API |
 | `mode` | `create` (predefinito) | Snapserver crea la FIFO se mancante |
+| `controlscript` | `meta_mpd.py` | Recupera metadati in riproduzione (titolo, artista, album, copertina) da MPD |
 
 **Formato campionamento:** Ereditato dal globale `sampleformat = 48000:16:2`
 
@@ -482,7 +483,7 @@ Riferimento leggibile da macchina per ogni tipo di sorgente. Usare per costruire
 | **Binari richiesti** | Nessuno |
 | **Requisiti Docker** | Mount del volume per il percorso FIFO |
 | **Formato campionamento** | Configurabile (predefinito: globale) |
-| **Parametri** | `name` (obbligatorio), `mode` (create\|read) |
+| **Parametri** | `name` (obbligatorio), `mode` (create\|read), `controlscript` (opzionale) |
 
 ### tcp
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -483,7 +483,7 @@ Machine-readable reference for each source type. Use this to build configuration
 | **Required binaries** | None |
 | **Docker requirements** | Volume mount for FIFO path |
 | **Sample format** | Configurable (default: global) |
-| **Parameters** | `name` (required), `mode` (create\|read) |
+| **Parameters** | `name` (required), `mode` (create\|read), `controlscript` (optional) |
 
 ### tcp
 

--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -79,7 +79,7 @@ Per i tipi di sorgente audio e l'API JSON-RPC, vedi [SOURCES.it.md](SOURCES.it.m
 
 **Configurazione**: `config/mpd.conf`
 - Output: FIFO verso `/audio/snapcast_fifo`
-- Directory musicali: `/music/Lossless`, `/music/Lossy`
+- Directory musicale: `/music` (con sottodirectory `Lossless` e `Lossy` tramite mount dei volumi)
 - Database: `/data/mpd.db`
 
 ## Controllare MPD
@@ -249,7 +249,7 @@ tag v* → build-push.yml → build (amd64 + arm64) → manifest (:latest + :ver
 ### Deployment Manuale
 
 ```bash
-cd /home/claudio/Code/snapMULTI
+cd /path/to/snapMULTI
 docker compose pull
 docker compose up -d
 ```
@@ -396,8 +396,9 @@ snapclient --host <ip-del-server> --daemon
 **Tramite Docker**:
 ```bash
 docker run -d --name snapclient \
+  --network host \
   --device /dev/snd \
-  sweisgerber/snapcast:latest
+  ghcr.io/badaix/snapcast:latest snapclient
 ```
 
 **Browser come client** (solo stream HTTP di MPD):

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -78,7 +78,7 @@ For audio source types and JSON-RPC API, see [SOURCES.md](SOURCES.md).
 
 **Configuration**: `config/mpd.conf`
 - Output: FIFO to `/audio/snapcast_fifo`
-- Music directories: `/music/Lossless`, `/music/Lossy`
+- Music directory: `/music` (with `Lossless` and `Lossy` subdirectories via volume mounts)
 - Database: `/data/mpd.db`
 
 ## Control MPD
@@ -248,7 +248,7 @@ tag v* → build-push.yml → build (amd64) → manifest (:latest + :version) �
 ### Manual Deployment
 
 ```bash
-cd /home/claudio/Code/snapMULTI
+cd /path/to/snapMULTI
 docker compose pull
 docker compose up -d
 ```
@@ -395,8 +395,9 @@ snapclient --host <server-ip> --daemon
 **Using Docker**:
 ```bash
 docker run -d --name snapclient \
+  --network host \
   --device /dev/snd \
-  sweisgerber/snapcast:latest
+  ghcr.io/badaix/snapcast:latest snapclient
 ```
 
 **Browser as client** (MPD HTTP stream only):


### PR DESCRIPTION
## Summary

- **HARDWARE.md**: Correct Docker image names in storage table (4 separate images, not monolith), add missing ports 6600/8000 to network table and firewall rules, update snapclient Docker example to `ghcr.io/badaix/snapcast:latest` with `--network host`
- **USAGE.md**: Fix MPD music directory description (`/music` with subdirs via volume mounts), replace hardcoded `/home/claudio` path with `/path/to/snapMULTI`, same snapclient fix
- **SOURCES.md**: Add `controlscript (optional)` to pipe source schema reference

All fixes applied to both English and Italian translations (6 files total).

Found via cross-referencing docs against `docker-compose.yml`, `config/mpd.conf`, and `config/snapserver.conf`, verified with two-pass review.

## Test plan

- [ ] Verify all doc links resolve correctly
- [ ] Cross-check port tables against `docker-compose.yml` and config files
- [ ] Confirm Docker image names match `docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)