### PR TITLE
fix(snapserver): suppress harmless client polling log noise

### DIFF
--- a/config/snapserver.conf
+++ b/config/snapserver.conf
@@ -85,4 +85,6 @@ initial_volume = 100
 
 [logging]
 sink = stdout
-filter = *:info
+# Suppress EOF errors from clients polling control port (normal behavior)
+# ControlSessionTCP errors are harmless - clients connect/disconnect for status
+filter = *:info,ControlSessionTCP:warning


### PR DESCRIPTION
## Summary
- Add logging filter to suppress ControlSessionTCP info-level messages
- Clients polling TCP:1705 for status cause harmless EOF errors every ~2s
- Filter `*:info,ControlSessionTCP:warning` keeps real errors visible

## Context
Investigation found snap-video (192.168.63.104) polling the control port every 2 seconds, causing noisy EOF errors in logs. This is normal client behavior - not actual errors.

## Test plan
- [ ] Deploy config to raspy
- [ ] Verify snapserver logs are cleaner
- [ ] Confirm actual errors still appear (warnings/errors level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)