### PR TITLE
fix: address PR review issues for zero-touch SD script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Zero-touch SD preparation** ([#25](https://github.com/lollonet/snapMULTI/pull/25)) — `scripts/prepare-sd.sh` prepares a freshly-flashed Raspberry Pi OS SD card for automatic snapMULTI installation on first boot; no SSH required - just flash, run script, insert SD, power on
 - **Native Tidal streaming** ([#10](https://github.com/lollonet/snapMULTI/issues/10)) — Fifth audio source via [tidalapi](https://github.com/EbbLabs/python-tidal); fetches stream URLs from Tidal API and pipes decoded audio to snapserver TCP input. Requires Tidal HiFi/HiFi+ subscription. CLI-driven playback: `docker compose --profile tidal run --rm tidal play <url>`
 - **Deploy script** — `deploy.sh` bootstraps a fresh Linux machine (Raspberry Pi or x86_64) as a snapMULTI server: installs Docker, creates directories, auto-detects timezone/user, pulls images, starts services
 - **Music library auto-detection** ([#20](https://github.com/lollonet/snapMULTI/issues/20)) — `deploy.sh` scans `/media/*`, `/mnt/*`, and `~/Music` for audio files and configures `MUSIC_PATH` automatically; no manual mount required if music is already accessible

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git clone https://github.com/lollonet/snapMULTI.git
 # 3. Eject SD, insert in Pi, power on
 ```
 
-First boot installs Docker and snapMULTI automatically (~5-10 min). Access at `http://snapmulti.local:8180`.
+First boot installs Docker and snapMULTI automatically (time depends on network speed). Access at `http://snapmulti.local:8180`.
 
 ### Option B: Automated deploy (SSH into existing Pi)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -249,7 +249,37 @@ Pushing a version tag (e.g. `git tag v1.1.0 && git push origin v1.1.0`) triggers
 tag v* → build-push.yml → build (amd64 + arm64) → manifest (:latest + :version) → deploy.yml → server updated
 ```
 
-### Automated Deployment (Fresh Install)
+### Zero-Touch SD Card (Raspberry Pi)
+
+Prepare an SD card that automatically installs snapMULTI on first boot. No SSH required.
+
+**On your computer:**
+
+1. Flash SD card with **Raspberry Pi Imager**:
+   - Choose: Raspberry Pi OS Lite (64-bit)
+   - Configure (gear icon): hostname, username/password, WiFi, enable SSH
+
+2. Keep SD card mounted and run:
+   ```bash
+   git clone https://github.com/lollonet/snapMULTI.git
+   ./snapMULTI/scripts/prepare-sd.sh
+   ```
+
+3. Eject SD card, insert into Pi, power on
+
+**What happens on first boot:**
+- Waits for network connectivity
+- Installs Docker via official convenience script
+- Clones snapMULTI to `/opt/snapmulti`
+- Auto-detects music library and timezone
+- Starts all services
+- Shows progress on HDMI output
+
+Installation log saved to `/var/log/snapmulti-install.log`.
+
+**Supported OS versions:** Raspberry Pi OS Bookworm (recommended) and Bullseye. The script auto-detects the version and uses the correct boot paths.
+
+### Automated Deployment (SSH)
 
 ```bash
 git clone https://github.com/lollonet/snapMULTI.git


### PR DESCRIPTION
## Summary
Fixes critical issues from Claude review on PR #25.

## Changes

### 🔴 CRITICAL Fixes
1. **Boot path detection** - Auto-detect Bookworm vs Bullseye and use correct path (`/boot/firmware` vs `/boot`) in cmdline.txt
2. **CHANGELOG.md** - Added entry for zero-touch SD preparation

### 🟡 MEDIUM Fixes
3. **docs/USAGE.md** - Added comprehensive zero-touch deployment section
4. **README.md** - Removed time estimate per project conventions

## Detection Logic
The script now detects Pi OS version by checking:
- `kernel_2712.img` presence (Bookworm with Pi 5 support)
- `camera_auto_detect` in config.txt (Bookworm marker)
- Falls back to Bullseye for older images

🤖 Generated with [Claude Code](https://claude.com/claude-code)