### PR TITLE
fix(snapserver): switch healthcheck to pidof to eliminate log noise

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     command: ["snapserver", "-c", "/etc/snapserver.conf"]
     logging: *default-logging
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:1780/jsonrpc --post-data='{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Server.GetStatus\"}' | grep -q result || exit 1"]
+      test: ["CMD-SHELL", "pidof snapserver || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Switch snapserver healthcheck from HTTP POST (wget to port 1780) to `pidof snapserver`
- The HTTP healthcheck caused "Failed to shudown socket" errors every 30s
- TCP-based checks (`nc -z`) on port 1705 also triggered "End of file" errors
- Process check avoids all socket noise while still verifying the service is running

## Test plan
- [x] Verified `pidof snapserver` works inside the container
- [x] Deployed and confirmed container reports healthy
- [x] Confirmed 0 "End of file" errors from healthcheck after 45s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
