### PR TITLE
ci: add shellcheck to validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,11 +33,18 @@ jobs:
       - name: Install shellcheck
         run: |
           if ! command -v shellcheck &>/dev/null; then
-            apk add --no-cache shellcheck 2>/dev/null || apt-get install -y shellcheck 2>/dev/null || true
+            apk add --no-cache shellcheck 2>/dev/null || apt-get install -y shellcheck || {
+              echo "ERROR: Failed to install shellcheck"
+              exit 1
+            }
           fi
 
       - name: Shellcheck scripts
         run: |
+          if ! ls scripts/*.sh 1>/dev/null 2>&1; then
+            echo "No shell scripts found in scripts/"
+            exit 0
+          fi
           echo "Running shellcheck on shell scripts..."
           FAILED=0
           for f in scripts/*.sh; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation: Upgrade instructions** — Standard update, backup, and rollback procedures
 
 ### Changed
+- **CI/CD: validate.yml** — Added shellcheck linting for all scripts/ with `-S warning` severity
 - **Service naming** — AirPlay and Spotify use hostname-based names with optional `AIRPLAY_NAME`/`SPOTIFY_NAME` env vars for customization
 - **deploy.sh validation** — Config file validation, PROJECT_ROOT check, and `--profile` argument validation with safe `shift` handling
 - **deploy.sh service verification** — Retry loop (6 attempts x 10s) instead of fixed sleep for slow-starting services

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -380,7 +380,7 @@ docker compose up -d
 |----------|---------|---------|
 | **Build & Push** | Tag push (`v*`) | Build 5 multi-arch images (amd64 + arm64), push to ghcr.io, trigger deploy |
 | **Deploy** | Called by Build & Push | Pull images and restart 5 core containers on server via SSH (tidal is optional, requires manual pull) |
-| **Validate** | Push to any branch, pull requests | Check docker-compose syntax and environment template |
+| **Validate** | Push to any branch, pull requests | Check docker-compose syntax, shellcheck scripts/, and environment template |
 | **Build Test** | Pull requests | Validate Docker images build correctly (no push) |
 
 ### Container Registry


### PR DESCRIPTION
## Summary
- Adds shellcheck lint step to `validate.yml` (runs on every push and PR)
- Checks all `scripts/*.sh` with `-S warning` severity
- Auto-installs shellcheck if not present on runner (Alpine or Debian)

All scripts already pass — this prevents regressions.

## Test plan
- [ ] CI workflow runs and passes on this PR
- [ ] Intentionally break a script to verify shellcheck catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)