### PR TITLE
docs: reorganize Quick Start by skill level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation: Upgrade instructions** — Standard update, backup, and rollback procedures
 
 ### Changed
-- **CLAUDE.md** — Updated project structure to reflect current state (scripts/, tidal, workflows, service counts)
+- **Documentation: Quick Start reorganization** — Split into Beginners (Pi zero-touch) and Advanced (any Linux) sections with clear audience targeting
+- **CLAUDE.md** — Added Deployment Targets section, updated project structure
 - **CI/CD: validate.yml** — Added shellcheck linting for all scripts/ with `-S warning` severity
 - **Service naming** — AirPlay and Spotify use hostname-based names with optional `AIRPLAY_NAME`/`SPOTIFY_NAME` env vars for customization
 - **deploy.sh validation** — Config file validation, PROJECT_ROOT check, and `--profile` argument validation with safe `shift` handling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,17 @@ Italian translations (`*.it.md`) mirror the English docs and must stay in sync.
 - Hardware/network changes → `docs/HARDWARE.md` only
 - README links to docs/ for anything technical — never inline technical details
 
+## Deployment Targets
+
+| Audience | Hardware | Method | Scripts |
+|----------|----------|--------|---------|
+| **Beginners** | Raspberry Pi 4 | Zero-touch SD | `prepare-sd.sh` → `firstboot.sh` → `deploy.sh` |
+| **Advanced** | Pi4 or x86_64 | Automated or Manual | `deploy.sh` (optional) |
+
+**Beginners**: No terminal required. Flash SD card on another computer, insert in Pi, power on. The Pi becomes a dedicated audio appliance.
+
+**Advanced**: Clone repo on any Linux host (Pi, x86_64, VM, NAS). Use `deploy.sh` for automation (hardware detection, directory setup, resource profiles) or skip it and just run `docker compose up`.
+
 ## Project Structure
 
 ```

--- a/README.it.md
+++ b/README.it.md
@@ -24,68 +24,85 @@ Altre sorgenti disponibili — vedi il [Riferimento Sorgenti Audio](docs/SOURCES
 
 ## Avvio Rapido
 
-### Requisiti
+### Principianti: Plug-and-Play (Raspberry Pi)
 
-- Una macchina Linux (x86_64 o ARM64)
+Nessuna competenza tecnica richiesta. Prepara una scheda SD, inseriscila, accendi — fatto.
+
+**Ti serve:**
+- Raspberry Pi 4 (2GB+ RAM consigliati)
+- Scheda microSD (16GB+)
+- Chiavetta USB o NAS con la tua musica
+- Un altro computer per preparare la scheda SD
+
+**Sul tuo computer:**
+```bash
+# 1. Scrivi la scheda SD con Raspberry Pi Imager
+#    - Scegli: Raspberry Pi OS Lite (64-bit)
+#    - Configura: hostname, utente/password, WiFi, SSH
+
+# 2. Mantieni la SD montata, esegui:
+git clone https://github.com/lollonet/snapMULTI.git
+./snapMULTI/scripts/prepare-sd.sh
+
+# 3. Espelli la SD, inseriscila nel Pi, accendi
+```
+
+Il primo avvio installa Docker e snapMULTI automaticamente. Accedi a `http://snapmulti.local:8180`.
+
+---
+
+### Avanzati: Qualsiasi Server Linux
+
+Per utenti che sanno usare terminale e Docker. Funziona su **Raspberry Pi, x86_64, VM, NAS** — qualsiasi cosa esegua Linux e Docker.
+
+**Ti serve:**
+- Una macchina Linux (Pi4, Intel NUC, vecchio laptop, VM, NAS con supporto Docker)
 - Docker e Docker Compose installati
 - Una cartella con i tuoi file musicali
 
-### Opzione A: Deploy automatico (consigliato per Raspberry Pi)
+Scegli il tuo metodo:
+
+#### Opzione A: Automatico (`deploy.sh`)
+
+Rileva l'hardware, crea le directory, imposta i permessi, avvia i servizi.
 
 ```bash
 git clone https://github.com/lollonet/snapMULTI.git
 cd snapMULTI
-sudo ./deploy.sh
+sudo ./scripts/deploy.sh
 ```
 
-Installa Docker se necessario, crea le directory, **rileva automaticamente la tua libreria musicale** e avvia i servizi.
-
-Lo script cerca file audio in `/media/*`, `/mnt/*` e `~/Music`. Se trovati, configura automaticamente. Altrimenti, monta prima la tua musica:
+Lo script cerca file audio in `/media/*`, `/mnt/*` e `~/Music`. Se non trovati, monta prima la tua musica:
 ```bash
 sudo mount /dev/sdX1 /media/music   # Chiavetta USB, NAS, ecc.
 ```
 
-### Opzione B: Configurazione manuale
+#### Opzione B: Manuale
 
-#### 1. Scarica il progetto
+Controllo totale — clona, configura, avvia.
 
 ```bash
 git clone https://github.com/lollonet/snapMULTI.git
 cd snapMULTI
-```
-
-#### 2. Configura
-
-```bash
 cp .env.example .env
 ```
 
 Modifica `.env` con le tue impostazioni:
 
 ```bash
-# Percorso libreria musicale — monta prima la tua musica qui
-MUSIC_PATH=/media/music
-
-# Fuso orario
-TZ=Europe/Rome
-
-# Utente/Gruppo per i processi nel container (corrispondente al tuo utente host)
-PUID=1000
-PGID=1000
+MUSIC_PATH=/media/music      # Percorso della tua libreria musicale
+TZ=Europe/Rome               # Il tuo fuso orario
+PUID=1000                    # Il tuo user ID (esegui: id -u)
+PGID=1000                    # Il tuo group ID (esegui: id -g)
 ```
 
-Monta la tua musica prima di avviare:
-```bash
-sudo mount /dev/sdX1 /media/music   # Chiavetta USB, NAS, ecc.
-```
-
-#### 3. Avvia
+Avvia:
 
 ```bash
 docker compose up -d
 ```
 
-#### 4. Verifica
+Verifica:
 
 ```bash
 docker ps
@@ -93,7 +110,9 @@ docker ps
 
 Dovresti vedere cinque container in esecuzione: `snapserver`, `shairport-sync`, `librespot`, `mpd` e `mympd`.
 
-### 5. Controlla la tua musica
+---
+
+### Controlla la tua musica
 
 Apri `http://<ip-del-server>:8180` nel browser — myMPD ti permette di sfogliare e riprodurre la tua libreria da qualsiasi dispositivo.
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ More source types available — see [Audio Sources Reference](docs/SOURCES.md).
 
 ## Quick Start
 
-### You need
+### Beginners: Plug-and-Play (Raspberry Pi)
 
-- A Linux machine (x86_64 or ARM64)
-- Docker and Docker Compose installed
-- A folder with your music files
+No terminal skills required. Flash an SD card, insert it, power on — done.
 
-### Option A: Zero-touch SD card (Raspberry Pi)
-
-Flash SD → insert → power on → done. No SSH required.
+**You need:**
+- Raspberry Pi 4 (2GB+ RAM recommended)
+- microSD card (16GB+)
+- USB drive or NAS with your music
+- Another computer to flash the SD card
 
 **On your computer:**
 ```bash
@@ -48,64 +48,62 @@ git clone https://github.com/lollonet/snapMULTI.git
 # 3. Eject SD, insert in Pi, power on
 ```
 
-First boot installs Docker and snapMULTI automatically (time depends on network speed). Access at `http://snapmulti.local:8180`.
+First boot installs Docker and snapMULTI automatically. Access at `http://snapmulti.local:8180`.
 
-### Option B: Automated deploy (SSH into existing Pi)
+---
+
+### Advanced: Any Linux Server
+
+For users comfortable with terminal and Docker. Works on **Raspberry Pi, x86_64, VMs, NAS** — anything that runs Linux and Docker.
+
+**You need:**
+- Any Linux machine (Pi4, Intel NUC, old laptop, VM, NAS with Docker support)
+- Docker and Docker Compose installed
+- A folder with your music files
+
+Choose your method:
+
+#### Option A: Automated (`deploy.sh`)
+
+Auto-detects hardware, creates directories, sets permissions, starts services.
 
 ```bash
 git clone https://github.com/lollonet/snapMULTI.git
 cd snapMULTI
-sudo ./deploy.sh
+sudo ./scripts/deploy.sh
 ```
 
-This installs Docker if needed, creates directories, **auto-detects your music library**, and starts services.
-
-The script scans `/media/*`, `/mnt/*`, and `~/Music` for audio files. If found, it configures automatically. If not, mount your music first:
+The script scans `/media/*`, `/mnt/*`, and `~/Music` for audio files. If not found, mount your music first:
 ```bash
 sudo mount /dev/sdX1 /media/music   # USB drive, NAS, etc.
 ```
 
-### Option C: Manual setup
+#### Option B: Manual
 
-#### 1. Get the project
+Full control — just clone, configure, run.
 
 ```bash
 git clone https://github.com/lollonet/snapMULTI.git
 cd snapMULTI
-```
-
-#### 2. Configure
-
-```bash
 cp .env.example .env
 ```
 
 Edit `.env` with your settings:
 
 ```bash
-# Music library path — mount your music here first
-MUSIC_PATH=/media/music
-
-# Timezone
-TZ=Your/Timezone
-
-# User/Group for container processes (match your host user)
-PUID=1000
-PGID=1000
+MUSIC_PATH=/media/music      # Path to your music library
+TZ=Your/Timezone             # e.g., Europe/Rome
+PUID=1000                    # Your user ID (run: id -u)
+PGID=1000                    # Your group ID (run: id -g)
 ```
 
-Mount your music before starting:
-```bash
-sudo mount /dev/sdX1 /media/music   # USB drive, NAS, etc.
-```
-
-#### 3. Start
+Start:
 
 ```bash
 docker compose up -d
 ```
 
-#### 4. Verify
+Verify:
 
 ```bash
 docker ps
@@ -113,7 +111,9 @@ docker ps
 
 You should see five running containers: `snapserver`, `shairport-sync`, `librespot`, `mpd`, and `mympd`.
 
-### 5. Control your music
+---
+
+### Control your music
 
 Open `http://<server-ip>:8180` in a browser — myMPD lets you browse and play your library from any device.
 

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -38,6 +38,8 @@ Il server esegue tutti i servizi audio: Snapcast, MPD, shairport-sync (AirPlay) 
 
 > **Nota:** Raspberry Pi 2 e Pi Zero 2 W possono eseguire il server ma sono al limite. Un Pi 3B+ o superiore è consigliato per tutte e quattro le sorgenti audio.
 
+> **Principianti:** Se è la tua prima volta, usa un Raspberry Pi 4 (4GB) con il [setup zero-touch SD](../README.it.md#principianti-plug-and-play-raspberry-pi). Gestisce tutto automaticamente — nessun terminale richiesto.
+
 ## Requisiti dei Client
 
 I client Snapcast sono leggeri — ricevono audio e lo riproducono attraverso gli altoparlanti.

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -38,6 +38,8 @@ The server runs all audio services: Snapcast, MPD, shairport-sync (AirPlay), and
 
 > **Note:** Raspberry Pi 2 and Pi Zero 2 W can run the server but are borderline. A Pi 3B+ or better is recommended for all four audio sources.
 
+> **Beginners:** If this is your first time, use a Raspberry Pi 4 (4GB) with the [zero-touch SD setup](../README.md#beginners-plug-and-play-raspberry-pi). It handles everything automatically — no terminal required.
+
 ## Client Requirements
 
 Snapcast clients are lightweight — they receive audio and play it through speakers.

--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -234,6 +234,15 @@ ss -tlnp | grep -E "1704|1705|1780"
 
 ## Deployment
 
+### Metodi di Deployment
+
+| Metodo | Destinatari | Hardware | Cosa fa |
+|--------|-------------|----------|---------|
+| **SD Zero-touch** | Principianti | Raspberry Pi | Scrivi SD, inserisci, accendi — completamente automatico |
+| **`deploy.sh`** | Avanzati | Pi o x86_64 | Rileva hardware, crea directory, avvia servizi |
+| **Manuale** | Avanzati | Pi o x86_64 | Clona, modifica `.env`, `docker compose up` |
+| **CI/CD (tag push)** | Manutentori | N/A | Compila immagini, deploya su server via SSH |
+
 ### Deployment Automatico (Consigliato)
 
 Il push di un tag di versione (es. `git tag v1.1.0 && git push origin v1.1.0`) avvia l'intera pipeline CI/CD:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -312,6 +312,15 @@ ss -tlnp | grep -E "1704|1705|1780"
 
 ## Deployment
 
+### Deployment Methods
+
+| Method | Audience | Hardware | What it does |
+|--------|----------|----------|--------------|
+| **Zero-touch SD** | Beginners | Raspberry Pi | Flash SD, insert, power on — fully automatic |
+| **`deploy.sh`** | Advanced | Pi or x86_64 | Detects hardware, creates dirs, starts services |
+| **Manual** | Advanced | Pi or x86_64 | Clone, edit `.env`, `docker compose up` |
+| **CI/CD (tag push)** | Maintainers | N/A | Builds images, deploys to server via SSH |
+
 ### Automated Deployment (Recommended)
 
 Pushing a version tag (e.g. `git tag v1.1.0 && git push origin v1.1.0`) triggers the full CI/CD pipeline:


### PR DESCRIPTION
## Summary

Reorganizes installation documentation around **skill level** rather than hardware:

| Audience | Hardware | Method |
|----------|----------|--------|
| **Beginners** | Pi4 | Zero-touch SD — flash, insert, power on |
| **Advanced** | Pi4 or x86_64 | Automated (`deploy.sh`) or Manual |

## Changes

- **README.md, README.it.md**: Split Quick Start into Beginners/Advanced sections
- **CLAUDE.md**: Added "Deployment Targets" section documenting the two audiences
- **docs/HARDWARE.md, HARDWARE.it.md**: Added beginner callout in Server Examples
- **docs/USAGE.md, USAGE.it.md**: Added deployment methods comparison table

## Test plan
- [ ] Verify beginner path is terminal-free (zero-touch only)
- [ ] Verify advanced path mentions both Pi and x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)