### PR TITLE
fix: pin Alpine to 3.23-stable and protect user env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation: Upgrade instructions** — Standard update, backup, and rollback procedures
 
 ### Changed
+- **Dockerfiles** — Pin Alpine base image to `3.23` for reproducible builds
 - **Documentation: Quick Start reorganization** — Split into Beginners (Pi zero-touch) and Advanced (any Linux) sections with clear audience targeting
 - **CLAUDE.md** — Added Deployment Targets section, updated project structure
 - **CI/CD: validate.yml** — Added shellcheck linting for all scripts/ with `-S warning` severity
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **prepare-sd.sh** — Support Bookworm cloud-init user-data and rpi-snapclient-usb boot pattern
 - **firstboot.sh directory structure** — Create `scripts/` subdirectory expected by deploy.sh
 - **firstboot.sh healthcheck grep** — Fix `(unhealthy)` containers being counted as healthy due to substring match
+- **deploy.sh profile update** — Use BEGIN/END block markers instead of deleting to EOF (preserves user custom env vars)
 
 ### Security
 - **DEVICE_NAME sanitization** — Entrypoint script strips shell metacharacters to prevent command injection ([#40](https://github.com/lollonet/snapMULTI/pull/40))

--- a/Dockerfile.librespot
+++ b/Dockerfile.librespot
@@ -19,7 +19,7 @@ RUN git apply /tmp/librespot-ipv4-fallback.patch
 RUN cargo build --release --no-default-features \
       --features "with-avahi,rustls-tls-webpki-roots"
 
-FROM alpine:latest
+FROM alpine:3.23
 
 RUN apk add --no-cache \
     avahi-libs \

--- a/Dockerfile.mpd
+++ b/Dockerfile.mpd
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.23
 
 # Install MPD and ffmpeg for codec support
 RUN apk add --no-cache \

--- a/Dockerfile.shairport-sync
+++ b/Dockerfile.shairport-sync
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.23
 
 RUN apk add --no-cache shairport-sync
 

--- a/Dockerfile.snapserver
+++ b/Dockerfile.snapserver
@@ -1,4 +1,4 @@
-FROM alpine:latest AS builder
+FROM alpine:3.23 AS builder
 
 RUN apk add --no-cache \
     alsa-lib-dev \
@@ -26,7 +26,7 @@ RUN git clone --branch develop https://github.com/lollonet/santcasp.git . && \
     make -j$(nproc) && \
     make install
 
-FROM alpine:latest
+FROM alpine:3.23
 
 RUN apk add --no-cache \
     alsa-lib \

--- a/Dockerfile.tidal
+++ b/Dockerfile.tidal
@@ -1,7 +1,7 @@
 # Dockerfile.tidal — Tidal streaming bridge for snapMULTI
 # Streams Tidal audio to snapserver via tidalapi + ffmpeg
 
-FROM python:3.12-alpine
+FROM python:3.12-alpine3.23
 
 # Install ffmpeg and build dependencies
 RUN apk add --no-cache \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -124,7 +124,8 @@ apply_resource_profile() {
             # Total container memory: ~450MB
             cat >> "$ENV_FILE" <<'EOF'
 
-# Hardware Profile: minimal (auto-detected)
+# Hardware Profile: BEGIN
+# Profile: minimal (auto-detected)
 # For: Pi Zero 2 W, Pi 3, systems with <2GB RAM
 SNAPSERVER_MEM_LIMIT=128M
 SNAPSERVER_MEM_RESERVE=64M
@@ -141,6 +142,7 @@ MPD_CPU_LIMIT=0.5
 MYMPD_MEM_LIMIT=64M
 MYMPD_MEM_RESERVE=32M
 MYMPD_CPU_LIMIT=0.25
+# Hardware Profile: END
 EOF
             ;;
         standard)
@@ -148,7 +150,8 @@ EOF
             # Total container memory: ~900MB
             cat >> "$ENV_FILE" <<'EOF'
 
-# Hardware Profile: standard (auto-detected)
+# Hardware Profile: BEGIN
+# Profile: standard (auto-detected)
 # For: Pi 4 2GB, systems with 2-4GB RAM
 SNAPSERVER_MEM_LIMIT=256M
 SNAPSERVER_MEM_RESERVE=128M
@@ -165,6 +168,7 @@ MPD_CPU_LIMIT=1.0
 MYMPD_MEM_LIMIT=128M
 MYMPD_MEM_RESERVE=64M
 MYMPD_CPU_LIMIT=0.5
+# Hardware Profile: END
 EOF
             ;;
         performance)
@@ -172,7 +176,8 @@ EOF
             # Total container memory: ~1.8GB
             cat >> "$ENV_FILE" <<'EOF'
 
-# Hardware Profile: performance (auto-detected)
+# Hardware Profile: BEGIN
+# Profile: performance (auto-detected)
 # For: Pi 4 4GB+, Pi 5, systems with 8GB+ RAM
 SNAPSERVER_MEM_LIMIT=512M
 SNAPSERVER_MEM_RESERVE=256M
@@ -189,6 +194,7 @@ MPD_CPU_LIMIT=2.0
 MYMPD_MEM_LIMIT=256M
 MYMPD_MEM_RESERVE=128M
 MYMPD_CPU_LIMIT=1.0
+# Hardware Profile: END
 EOF
             ;;
         *)
@@ -209,16 +215,16 @@ setup_env() {
 
     if [[ -f "$ENV_FILE" ]]; then
         # Check if profile already set
-        if grep -q "Hardware Profile:" "$ENV_FILE"; then
+        if grep -q "# Hardware Profile: BEGIN" "$ENV_FILE"; then
             local current_profile
-            current_profile=$(grep "Hardware Profile:" "$ENV_FILE" | awk '{print $4}')
+            current_profile=$(grep "# Profile:" "$ENV_FILE" | awk '{print $3}')
             if [[ "$current_profile" == "$profile" ]]; then
                 info "Profile '$profile' already configured"
                 return 0
             else
                 warn "Existing profile: $current_profile, updating to: $profile"
-                # Remove old profile settings
-                sed -i.bak '/# Hardware Profile:/,$d' "$ENV_FILE"
+                # Remove old profile settings (block between BEGIN/END markers)
+                sed -i.bak '/# Hardware Profile: BEGIN/,/# Hardware Profile: END/d' "$ENV_FILE"
                 rm -f "$ENV_FILE.bak"
             fi
         fi


### PR DESCRIPTION
## Summary

- Pin all Dockerfiles to `alpine:3.23` for reproducible builds (was `alpine:latest`)
- Fix destructive `sed` in `deploy.sh` that deleted from `# Hardware Profile:` to EOF — now uses `BEGIN`/`END` block markers to preserve user custom environment variables

## Changes

| File | Change |
|------|--------|
| `Dockerfile.snapserver` | `alpine:latest` → `alpine:3.23` |
| `Dockerfile.shairport-sync` | `alpine:latest` → `alpine:3.23` |
| `Dockerfile.librespot` | `alpine:latest` → `alpine:3.23` |
| `Dockerfile.mpd` | `alpine:latest` → `alpine:3.23` |
| `Dockerfile.tidal` | `python:3.12-alpine` → `python:3.12-alpine3.23` |
| `scripts/deploy.sh` | Block markers for profile section |
| `CHANGELOG.md` | Updated |

## Test plan

- [ ] Verify Docker builds succeed with `alpine:3.23`
- [ ] Run `deploy.sh` twice with different profiles, confirm custom vars after `# Hardware Profile: END` are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)