### PR TITLE
fix(deploy): change to PROJECT_ROOT before validating config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **firstboot.sh network check** — Detects default gateway each iteration, falls back to 1.1.1.1 and 8.8.8.8 (works behind restrictive firewalls)
 
 ### Fixed
+- **deploy.sh validate_config** — Change to PROJECT_ROOT before running `docker compose config` (fixes first-run failures when script invoked from a different directory)
 - **prepare-sd.sh** — Support Bookworm cloud-init user-data and rpi-snapclient-usb boot pattern
 - **firstboot.sh directory structure** — Create `scripts/` subdirectory expected by deploy.sh
 - **firstboot.sh healthcheck grep** — Fix `(unhealthy)` containers being counted as healthy due to substring match

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -465,6 +465,7 @@ EOF
 validate_config() {
     step "Validating configuration"
 
+    cd "$PROJECT_ROOT"
     local errors=0
 
     # Check docker-compose.yml exists
@@ -488,8 +489,8 @@ validate_config() {
     done
 
     # Validate docker-compose.yml syntax
-    if ! docker compose -f "$PROJECT_ROOT/docker-compose.yml" config --quiet 2>/dev/null; then
-        error "docker-compose.yml has syntax errors"
+    if ! docker compose config --quiet; then
+        error "docker-compose.yml has syntax errors (run 'docker compose config' for details)"
         errors=$((errors + 1))
     fi
 


### PR DESCRIPTION
## Summary
Fixes first-run failure in `validate_config()` when script is invoked from a different directory.

## Root Cause
`docker compose config` resolves relative volume paths (`./config/snapserver.conf`, etc.) from the **current working directory**, not the compose file's location. On first run from a different directory, validation failed silently (error suppressed by `2>/dev/null`). On second run from the project directory, it worked.

## Changes
- Add `cd "$PROJECT_ROOT"` at start of `validate_config()`
- Remove `2>/dev/null` to make errors visible
- Simplify to `docker compose config` (already in right directory)

## Test plan
- [ ] Run `sudo ./scripts/deploy.sh` from project directory
- [ ] Run `sudo /path/to/scripts/deploy.sh` from a different directory
- [ ] Verify validation works in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)