### PR TITLE
fix: add buffer overflow protection to controlscripts

### DIFF
--- a/scripts/meta_tidal.py
+++ b/scripts/meta_tidal.py
@@ -283,6 +283,7 @@ def main() -> None:
     fcntl.fcntl(sys.stdin.fileno(), fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
     stdin_buffer = ""
+    MAX_BUFFER = 65536  # 64 KB safety cap — snapserver sends small JSON-RPC messages
 
     while True:
         try:
@@ -303,6 +304,9 @@ def main() -> None:
                     while True:
                         time.sleep(60)
                 stdin_buffer += chunk
+                if len(stdin_buffer) > MAX_BUFFER:
+                    log("warning", "stdin buffer overflow, discarding")
+                    stdin_buffer = ""
                 while "\n" in stdin_buffer:
                     line, stdin_buffer = stdin_buffer.split("\n", 1)
                     if line.strip():


### PR DESCRIPTION
## Summary
- Add safety caps to `stdin_buffer` and `pipe_buffer` in `meta_tidal.py` and `meta_shairport.py` to prevent unbounded memory growth
- `meta_tidal.py`: 64 KB cap on stdin buffer
- `meta_shairport.py`: 64 KB cap on stdin buffer + 1 MB cap on pipe buffer (larger to accommodate cover art PICT items)

Found during full codebase review (15 Ollama review passes across all project files). These were the only MEDIUM severity issues in the entire codebase — all remaining findings are LOW.

## Test plan
- [ ] Deploy to Pi, play AirPlay + Tidal tracks, verify metadata still flows correctly
- [ ] Confirm no "buffer overflow" warnings in normal operation (`docker logs snapserver`)
- [ ] Verify cover art still appears (pipe buffer large enough for PICT items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)