### PR TITLE
chore(deps): bump Snapweb builder from Node 22 to Node 24 LTS

### DIFF
--- a/Dockerfile.snapserver
+++ b/Dockerfile.snapserver
@@ -30,7 +30,7 @@ RUN git clone --branch develop https://github.com/lollonet/santcasp.git . && \
 # bindings for rollup + swc not installed cross-platform). Removing the lockfile
 # and using npm install is the documented workaround. Version pinning comes from
 # the fixed v0.9.3 tag instead.
-FROM node:22.14-alpine3.21@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944 AS snapweb-builder
+FROM node:24-alpine3.21@sha256:b8f7c9056af700568c1ce76173f1c93743fb64ca1343e18cdf3a6ded8985ad3d AS snapweb-builder
 WORKDIR /build
 RUN apk add --no-cache git && \
     git clone --depth 1 --branch v0.9.3 https://github.com/snapcast/snapweb.git . && \


### PR DESCRIPTION
## Summary

Bump the Snapweb builder stage in `Dockerfile.snapserver` from Node 22 (Maintenance LTS) to Node 24 (Active LTS).

- `node:22.14-alpine3.21` → `node:24-alpine3.21` (same Alpine base)
- Node 24 "Krypton" is the current Active LTS (Oct 2025 – Apr 2028)
- Node 22 "Jod" moved to Maintenance LTS
- Closes #82 (Dependabot wanted Node 25 non-LTS, this uses 24 LTS instead)

References:
- [Node.js Release Schedule](https://nodejs.org/en/about/previous-releases)
- [Docker Hub node:24-alpine3.21](https://hub.docker.com/_/node/tags?name=24-alpine3.21)

## Test plan

- [ ] CI Docker build passes (`Dockerfile.snapserver`)
- [ ] Snapweb UI loads at `:1780` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)