### PR TITLE
fix: socket leak and circuit breaker in metadata-service

### DIFF
--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -52,6 +52,7 @@ GO_LIBRESPOT_PORT = int(os.environ.get("GO_LIBRESPOT_PORT", "24879"))
 # SNAPSERVER_HOST may be 127.0.0.1 (for local socket connections),
 # but artwork URLs must use a host reachable by clients on the network.
 EXTERNAL_HOST = os.environ.get("EXTERNAL_HOST", "") or socket.getfqdn() or SNAPSERVER_HOST
+_POLL_LOOP_MAX_ERRORS = 30
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("metadata-service")
@@ -161,6 +162,7 @@ class MetadataService:
 
     def _create_socket(self, host: str, port: int, timeout: int = 5,
                        log_errors: bool = True) -> socket.socket | None:
+        sock = None
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(timeout)
@@ -169,6 +171,11 @@ class MetadataService:
         except Exception as e:
             if log_errors:
                 logger.error(f"Failed to connect to {host}:{port}: {e}")
+            if sock is not None:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
             return None
 
     def _get_snap_socket(self) -> socket.socket | None:
@@ -1148,6 +1155,7 @@ class MetadataService:
     async def poll_loop(self) -> None:
         """Main loop: poll Snapserver, enrich metadata, broadcast to clients."""
         loop = asyncio.get_running_loop()
+        consecutive_errors = 0
 
         while True:
             try:
@@ -1278,8 +1286,18 @@ class MetadataService:
                         except Exception:
                             ws_clients.discard(sc)
 
+                consecutive_errors = 0
+
             except Exception as e:
-                logger.error(f"Error in poll loop: {e}")
+                consecutive_errors += 1
+                if consecutive_errors >= _POLL_LOOP_MAX_ERRORS:
+                    logger.critical(
+                        f"Poll loop: {consecutive_errors} consecutive errors, exiting"
+                    )
+                    raise SystemExit(1)
+                logger.error(
+                    f"Poll loop error ({consecutive_errors}/{_POLL_LOOP_MAX_ERRORS}): {e}"
+                )
 
             await asyncio.sleep(2)
 


### PR DESCRIPTION
## Summary

Ports 2 bug fixes from rpi-snapclient-usb PR #54 to the server-side `metadata-service.py`.

1. **Socket leak in `_create_socket`** — socket was created but never closed if `connect()` raised, leaking a file descriptor on every failed connection attempt
2. **Circuit breaker in `poll_loop`** — the `while True` loop caught all exceptions and continued forever. Now exits after 30 consecutive errors instead of spinning indefinitely

### Not changed (already handled)
- Cache eviction: already uses `OrderedDict` + `_cache_set()` with LRU
- `_failed_downloads`: already bounded + cleared on track change
- `_read_mpd_response`: already has `if not chunk: break`

## Test plan

- [x] `python -m py_compile` passes
- [ ] Container starts healthy after image rebuild
- [ ] Metadata updates work normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)