### PR TITLE
fix: remove dev-only bind mounts that break fresh deploys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,6 @@ services:
       - ./config:/config:ro
       - ./data:/data
       - ./audio:/audio
-      - ./scripts/meta_tidal.py:/usr/share/snapserver/plug-ins/meta_tidal.py:ro  # Overrides image copy for hot-update without rebuild
       - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
     environment:
       - TZ=${TZ:-Europe/Berlin}
@@ -310,8 +309,6 @@ services:
     volumes:
       - ./audio:/audio
       - ./config/tidal-asound.conf:/userconfig/asound.conf:ro
-      - ./scripts/tidal/common.sh:/common.sh:ro              # Override baked-in script for ALSA tmpfs path
-      - ./scripts/tidal/tidal-meta-bridge.sh:/tidal-meta-bridge.sh:ro  # Metadata scraper
       - /var/run/dbus:/var/run/dbus
       - /etc/hostname:/etc/hostname:ro
     environment:


### PR DESCRIPTION
## Summary
- Remove 3 bind mounts in docker-compose.yml that reference host scripts not present on fresh SD card deploys
- `meta_tidal.py`, `common.sh`, and `tidal-meta-bridge.sh` are already baked into Docker images via COPY in Dockerfiles

## Root cause
On fresh `prepare-sd.sh` → `firstboot.sh` → `deploy.sh` installs, the `scripts/` directory only contains `deploy.sh` and `status.sh`. Docker creates missing bind-mount sources as directories, causing OCI "not a directory" errors that prevent snapserver from starting.

## Test plan
- [ ] `docker compose config --quiet` passes
- [ ] Fresh SD card deploy completes without mount errors
- [ ] Snapserver starts and serves all streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)