### PR TITLE
fix(mpd): Avahi socket + macOS dotfile filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **MPD: Avahi mDNS errors** — bind-mount `/run/avahi-daemon/socket` into MPD container; eliminates `Failed to create Avahi client: Daemon not running` log spam
+- **MPD: macOS dotfiles indexed** — add `database { filter "~.*" }` to `mpd.conf`; excludes `._filename` resource fork files from the database (~48% noise reduction on NFS shares from macOS)
+
 ### Changed
 - **CI deploy: persist through overlayroot** — `deploy.yml` now bakes config, MPD database, myMPD state, Docker image index, and new image layers to the SD card lower layer (`/media/root-ro`) between `docker compose down` and `up`. Uses bind-mount technique (safe with active overlayfs) so deployments survive Pi reboots. MPD db bake avoids full NFS/SMB rescan on reboot (incremental update only). Verified by checking `SNAPMULTI_VERSION` in baked `.env` before starting containers.
 

--- a/config/mpd.conf
+++ b/config/mpd.conf
@@ -33,6 +33,13 @@ port                    "6600"
 # Auto-update database
 auto_update             "yes"
 
+# Exclude macOS resource fork files (._filename) from the database
+database {
+        plugin          "simple"
+        cache_directory "/data"
+        filter          "~.*"
+}
+
 # Logging (reduce noise from ffmpeg warnings)
 log_level               "notice"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,7 @@ services:
       - ./config/mpd.conf:/etc/mpd.conf:ro
       - ./mpd/playlists:/playlists
       - ./mpd/data:/data
+      - /run/avahi-daemon/socket:/run/avahi-daemon/socket
     environment:
       - TZ=${TZ:-Europe/Berlin}
     logging: *default-logging


### PR DESCRIPTION
## Summary

Two issues found post-reinstall of snapvideo:

- MPD logs `Failed to create Avahi client: Daemon not running` every minute — Avahi runs fine on the host but the D-Bus socket was not visible inside the container
- ~48% of indexed files on NFS shares from macOS are `._filename` resource fork files, causing ffmpeg warnings and database bloat

## Fixes

- **`docker-compose.yml`** — bind-mount `/run/avahi-daemon/socket` into MPD container
- **`config/mpd.conf`** — add `database { filter "~.*" }` to exclude dotfiles from the library

## Test plan

- [ ] `docker compose up -d mpd` on snapvideo
- [ ] `docker logs mpd` — no more `Failed to create Avahi client` errors
- [ ] `mympd` library shows no `._` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)