### PR TITLE
fix(mpd): increase start_period to 300s, mympd to service_started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **MPD healthcheck timeout on large NFS/SMB libraries** — increase `MPD_START_PERIOD` default from 60s to 300s; switch mympd dependency to `service_started` (mympd retries MPD connection internally)
 - **MPD: Avahi mDNS errors** — bind-mount `/run/avahi-daemon/socket` into MPD container; eliminates `Failed to create Avahi client: Daemon not running` log spam
 - **MPD: macOS dotfiles indexed** — add `database { filter "~.*" }` to `mpd.conf`; excludes `._filename` resource fork files from the database (~48% noise reduction on NFS shares from macOS)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,14 +201,14 @@ services:
       - MYMPD_SSL=false
     depends_on:
       mpd:
-        condition: service_healthy
+        condition: service_started
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8180/ || exit 1"]
       interval: 60s
       timeout: 10s
       retries: 3
-      start_period: ${MPD_START_PERIOD:-60s}
+      start_period: ${MPD_START_PERIOD:-300s}
     deploy:
       resources:
         limits:
@@ -248,7 +248,7 @@ services:
       interval: 60s
       timeout: 10s
       retries: 3
-      start_period: ${MPD_START_PERIOD:-60s}
+      start_period: ${MPD_START_PERIOD:-300s}
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

`docker compose up -d` failed during deploy to snapvideo because MPD's NFS library scan (~9min) exceeded the healthcheck timeout (start_period=60s + 3×interval=180s = **4min**), causing mympd's `service_healthy` dependency to fail.

## Fixes

- **`MPD_START_PERIOD` default**: 60s → 300s (covers large NFS/SMB libraries)
- **mympd `depends_on`**: `service_healthy` → `service_started` — mympd retries MPD connection internally; it does not need MPD to be healthy before starting

## Test plan

- [ ] `docker compose up -d` completes without error even while MPD is scanning
- [ ] mympd starts immediately after MPD container starts (not after healthcheck passes)
- [ ] mympd connects to MPD once scan completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)