### PR TITLE
feat(ci): use GitHub Environments for deploy

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -206,8 +206,9 @@ jobs:
   deploy:
     needs: manifest
     uses: ./.github/workflows/deploy.yml
+    with:
+      environment_name: snapvideo
     secrets:
-      HOST: ${{ secrets.HOST }}
       USER: ${{ secrets.USER }}
       SSH_KEY: ${{ secrets.SSH_KEY }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,18 @@ name: Deploy to Home Server
 
 on:
   workflow_dispatch:
-    # Manual dispatch uses repository secrets directly (no inputs needed).
-    # Requires DOCKERHUB_USERNAME, DOCKERHUB_TOKEN, HOST, USER, SSH_KEY
-    # to be configured as repository secrets.
+    # Manual dispatch: HOST comes from the snapvideo environment secret.
+    inputs:
+      environment_name:
+        description: 'Target environment'
+        required: false
+        default: 'snapvideo'
   workflow_call:
-    secrets:
-      HOST:
+    inputs:
+      environment_name:
+        type: string
         required: true
+    secrets:
       USER:
         required: true
       SSH_KEY:
@@ -21,6 +26,10 @@ on:
 jobs:
   deploy:
     runs-on: snapcast-runner
+    environment: ${{ inputs.environment_name }}
+    concurrency:
+      group: deploy-${{ inputs.environment_name }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- `deploy.yml`: accepts `environment_name` input (string for `workflow_call`, text input for `workflow_dispatch`); sets `environment:` and `concurrency:` on the deploy job
- `build-push.yml`: passes `environment_name: snapvideo`; removes `HOST` from secrets (now from environment)

## Why
`HOST` secret moved from repository-level to GitHub Environment scope. Concurrency group (`deploy-snapvideo`) queues deploys rather than canceling in-progress ones — prevents mid-deploy device corruption.

## Prerequisites
In repo Settings → Environments → `snapvideo` → Secrets: add `HOST` pointing to the server's IP/hostname.
Remove the old `HOST` repository secret once confirmed working.

## Test plan
- [ ] Push a `v*` tag and verify deploy job uses `snapvideo` environment
- [ ] Confirm `HOST` resolves from environment secret
- [ ] Trigger two deploys back-to-back; second should queue, not cancel
- [ ] `workflow_dispatch` with default `snapvideo` environment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)