### PR TITLE
fix(security): harden containers — drop SETUID/SETGID, watchtower, USER 1000

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -12,7 +12,7 @@ RUN uv pip install --system --no-cache "websockets==14.2" "aiohttp==3.11.12"
 COPY docker/metadata-service/metadata-service.py /app/
 
 # Default assets (stored outside /app/artwork which is bind-mounted at runtime)
-RUN mkdir -p /app/defaults /app/artwork
+RUN mkdir -p /app/defaults /app/artwork && chown -R 1000:1000 /app
 COPY docker/metadata-service/default-radio.png /app/defaults/
 
 # Health check endpoint
@@ -20,5 +20,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8083/health', timeout=3)" || exit 1
 
 ENV PYTHONDONTWRITEBYTECODE=1
+
+USER 1000
 
 CMD ["python3", "/app/metadata-service.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,7 @@ x-security: &default-security
   cap_drop:
     - ALL
   cap_add:
-    - DAC_OVERRIDE      # File access as non-root
-    - SETUID
-    - SETGID
+    - DAC_OVERRIDE      # File access as non-root (FIFOs in /audio may be root-owned)
 
 # Resource profiles (set HARDWARE_PROFILE in .env)
 x-resources-minimal: &resources-minimal
@@ -362,6 +360,13 @@ services:
     restart: unless-stopped
     profiles:
       - auto-update
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=16M
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:


### PR DESCRIPTION
## Summary

Tightens container security without changing any runtime behaviour (compose already sets `user:` and `cap_drop`).

- **Remove `SETUID` + `SETGID`** from `x-security` anchor — snapserver, shairport-sync and librespot are audio daemons that never call `setuid()/setgid()` at runtime. Keeping them was unnecessary attack surface
- **Harden `watchtower`** — add `no-new-privileges:true`, `cap_drop: ALL`, `read_only: true`, `tmpfs /tmp`. It only needs `/var/run/docker.sock` access, not process capability escalation
- **`Dockerfile.metadata`** — `chown -R 1000:1000 /app` + `USER 1000`. Defense-in-depth: image now defaults to non-root even if run without `user:` override

## What stays the same

- `DAC_OVERRIDE` retained — needed when `/audio` FIFO files are root-owned on first deploy
- `apparmor:unconfined` retained — needed for D-Bus socket access (Avahi/mDNS)
- All `user: "${PUID:-1000}:${PGID:-1000}"` overrides in compose unchanged
- Functional runtime behaviour unchanged

## Test plan
- [ ] `docker compose up` — all services start normally
- [ ] snapserver, shairport-sync, librespot: music plays through
- [ ] watchtower (if enabled): polls and updates images
- [ ] `docker inspect metadata | jq '.[].Config.User'` → `"1000"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)