### PR TITLE
fix(install): fix has_display() to detect headless Pi with vc4-kms-v3d

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -160,12 +160,15 @@ log_and_tty "========================================="
 # ── Headless detection (for client modes) ─────────────────────────
 has_display() {
     [[ -c /dev/fb0 ]] || return 1
+    local found_status=false
     for card in /sys/class/drm/card*-HDMI-*/status; do
-        [[ -f "$card" ]] && grep -q "^connected" "$card" && return 0
+        [[ -f "$card" ]] || continue
+        found_status=true
+        grep -q "^connected" "$card" && return 0
     done
-    # fb0 exists but no HDMI status files found (some Pi firmware versions
-    # don't expose DRM status). Default to "display present" — worst case,
-    # visual containers start but fail gracefully at runtime.
+    # DRM status files exist but none say "connected" → headless
+    $found_status && return 1
+    # No DRM status files at all (very old firmware) → assume display if fb0 exists
     return 0
 }
 


### PR DESCRIPTION
## Summary

- Fix `has_display()` in firstboot.sh to correctly detect headless Pi 4 with vc4-kms-v3d
- Previous logic returned "display present" when DRM status files existed but none said "connected"
- Now tracks `found_status` flag to distinguish "no DRM files" (old firmware, assume display) from "all say disconnected" (headless)

## Companion PR

Depends on client submodule PR: https://github.com/lollonet/rpi-snapclient-usb/pull/97

That PR adds the same `has_display()` fix as a shared library (`display.sh`) for:
- Client setup.sh (install-time detection)
- Boot-time display detection systemd service

## Test plan

- [ ] Pi 4 headless (HDMI unplugged): `has_display` returns 1
- [ ] Pi 4 with display (HDMI plugged): `has_display` returns 0
- [ ] Pi with old firmware (no DRM status files): falls back to `/dev/fb0` check
- [ ] shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)