### PR TITLE
fix(tidal): complete C1 range in strip_escapes — add missing ]

### DIFF
--- a/scripts/tidal/tidal-meta-bridge.sh
+++ b/scripts/tidal/tidal-meta-bridge.sh
@@ -48,13 +48,14 @@ extract_field() {
 
 # Strip ANSI/VT100 escape sequences and tmux 8-bit C1 representations.
 # speaker_controller_application sets the terminal to 8-bit mode; tmux encodes
-# C1 control chars (U+0080–U+009F) as ~@~X in 7-bit captures, e.g. SS3 → ~@~S.
+# C1 control chars (U+0080–U+009F) as ~@~X in 7-bit captures where X = char - 0x40,
+# so the X character ranges from @ (0x40) to _ (0x5F), matched by [@-_].
 strip_escapes() {
     sed \
         -e 's/\x1b\[[0-9;]*[A-Za-z]//g' \
         -e 's/\x1b[()][AB01]//g' \
         -e 's/\x1b.//g' \
-        -e 's/~@~[A-Za-z@\[\\^_]//g'
+        -e 's/~@~[@-_]//g'
 }
 
 # Escape a string for safe JSON embedding.


### PR DESCRIPTION
## Problem

`strip_escapes()` matched `~@~X` where X was in `[A-Za-z@\[\\^_]`. This was missing `]` (0x5D), so any C1 character mapping to `~@~]` leaked through into artist/title fields.

## Root Cause

tmux encodes C1 chars (0x80–0x9F) as `~@~X` where X = original − 0x40, so X spans 0x40–0x5F:

| hex | char |
|-----|------|
| 0x40 | `@` |
| 0x41–0x5A | `A-Z` |
| 0x5B | `[` |
| 0x5C | `\` |
| **0x5D** | **`]` ← was missing** |
| 0x5E | `^` |
| 0x5F | `_` |

## Fix

Replace `[A-Za-z@\[\\^_]` with the range `[@-_]` — covers 0x40–0x5F completely, no escaping issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)