### PR TITLE
fix(docs): second coherence audit — fix counts and sync Italian README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Full-screen TUI on `/dev/tty1` (HDMI console), no-op when run via SSH.
 snapMULTI/
   client/                    # Git submodule: rpi-snapclient-usb (audio player)
   config/
-    snapserver.conf          # Snapcast server config (4 active + 4 commented sources)
+    snapserver.conf          # Snapcast server config (5 active + 4 commented sources)
     mpd.conf                 # MPD config (FIFO + HTTP outputs)
     shairport-sync.conf      # shairport-sync pipe backend config
     tidal-asound.conf        # ALSA config for Tidal Connect FIFO output (ARM only)
@@ -126,7 +126,7 @@ snapMULTI/
   Dockerfile.mpd             # MPD + ffmpeg (Alpine)
   Dockerfile.metadata        # Metadata service (Python 3.13, aiohttp + websockets)
   Dockerfile.tidal           # Tidal Connect (extends edgecrush3r base with ALSA plugins)
-  docker-compose.yml         # 7 services, host networking
+  docker-compose.yml         # 8 service definitions (6 core + tidal [ARM] + watchtower [opt-in]), host networking
   .env.example               # Environment template
 ```
 

--- a/README.it.md
+++ b/README.it.md
@@ -71,6 +71,8 @@ git clone --recurse-submodules https://github.com/lollonet/snapMULTI.git
 
 Il primo avvio installa tutto automaticamente (~5-10 min). L'HDMI mostra una schermata di progresso. Il Pi si riavvia quando ha finito.
 
+> **Istruzioni passo-passo complete** (screenshot di Imager, punti di montaggio SD, tutti e tre i SO): **[docs/INSTALL.md](docs/INSTALL.md)**
+
 #### Collega la Tua Musica
 
 Quando scegli Music Server o Server+Player, l'installer chiede dove si trova la tua musica:
@@ -143,7 +145,7 @@ Verifica:
 docker ps
 ```
 
-Dovresti vedere sei container in esecuzione: `snapserver`, `shairport-sync`, `librespot`, `mpd`, `mympd` e `metadata`. Su ARM (Raspberry Pi), vedrai anche `tidal-connect`.
+Dovresti vedere sei container in esecuzione: `snapserver`, `shairport-sync`, `librespot`, `mpd`, `mympd` e `metadata`. Su ARM (Raspberry Pi), vedrai anche `tidal-connect` (sette in totale).
 
 ---
 
@@ -218,6 +220,7 @@ Per aggiornamenti di versioni maggiori, controlla [CHANGELOG.md](CHANGELOG.md) p
 
 | Guida | Contenuto |
 |-------|-----------|
+| [**Installazione**](docs/INSTALL.md) | Passo-passo completo: Raspberry Pi Imager, preparazione SD, primo avvio, verifica — macOS/Linux/Windows |
 | [Hardware e Rete](docs/HARDWARE.it.md) | Requisiti server/client, configurazioni Raspberry Pi, banda di rete, setup consigliati |
 | [Uso e Operazioni](docs/USAGE.it.md) | Architettura, servizi, controllo MPD, configurazione mDNS, deployment, CI/CD |
 | [Sorgenti Audio](docs/SOURCES.it.md) | Tutti i tipi di sorgente, parametri, API JSON-RPC, streaming da Android/Tidal |


### PR DESCRIPTION
## Summary
- Fix `CLAUDE.md` snapserver.conf source count (4→5 active sources) and docker-compose.yml service count (7→8 definitions)
- Add "(sette in totale)" ARM container count to `README.it.md` (matches English)
- Add missing INSTALL.md reference note and Installation row to `README.it.md` documentation table

## Test plan
- [ ] Verify CLAUDE.md counts match actual `config/snapserver.conf` and `docker-compose.yml`
- [ ] Verify README.it.md matches README.md structure and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)