### PR TITLE
ci(build-test): only run Docker builds when relevant files change

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,21 @@ name: Test Docker Builds
 
 on:
   pull_request:
+    paths:
+      # Dockerfiles
+      - 'Dockerfile.*'
+      # Files COPYed into images
+      - 'scripts/mpd-entrypoint.sh'
+      - 'scripts/airplay-entrypoint.sh'
+      - 'scripts/meta_shairport.py'
+      - 'scripts/meta_tidal.py'
+      - 'scripts/common/sanitize.sh'
+      - 'scripts/tidal/**'
+      - 'docker/metadata-service/**'
+      - 'patches/meta_mpd.py'
+      - 'config/mpd.conf'
+      - 'config/snapserver.conf'
+      - 'config/shairport-sync.conf'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Problem

`build-test.yml` ran on every PR push regardless of what changed. A config comment fix, CHANGELOG update, or docs edit triggered a full 5-build matrix (~5 min, consumes runner time).

## Fix

Add `paths` filter to the `pull_request` trigger covering only files that are actually `COPY`ed into Docker images:

| Image | Watched paths |
|-------|--------------|
| snapserver | `Dockerfile.snapserver`, `patches/meta_mpd.py`, `scripts/meta_*.py`, `config/snapserver.conf` |
| shairport-sync | `Dockerfile.shairport-sync`, `scripts/airplay-entrypoint.sh`, `scripts/common/sanitize.sh`, `config/shairport-sync.conf` |
| mpd | `Dockerfile.mpd`, `scripts/mpd-entrypoint.sh`, `config/mpd.conf` |
| metadata | `Dockerfile.metadata`, `docker/metadata-service/**` |
| tidal | `Dockerfile.tidal`, `scripts/tidal/**`, `scripts/common/sanitize.sh` |

**Not watched** (no rebuild needed): `docs/`, `CHANGELOG.md`, `.env.example`, `config/go-librespot.yml`, `config/tidal-asound.conf`, `mympd/`, `README*`, `*.it.md`

`workflow_dispatch` is unaffected — manual trigger always runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)