### PR TITLE
fix(mpd): log scan failure instead of silent || true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,9 @@ services:
       - TZ=${TZ:-Europe/Berlin}
       - MYMPD_HTTP_PORT=8180
       - MYMPD_SSL=false
+    # service_started (not service_healthy): myMPD retries MPD connection
+    # internally. Using service_healthy would block on MPD's 60s healthcheck
+    # interval, adding unnecessary delay on large NFS/SMB libraries.
     depends_on:
       mpd:
         condition: service_started

--- a/scripts/mpd-entrypoint.sh
+++ b/scripts/mpd-entrypoint.sh
@@ -17,7 +17,9 @@ until echo 'ping' | nc -w 1 127.0.0.1 6600 2>/dev/null | grep -q OK; do
     sleep 1
 done
 
-# Trigger full library scan and wait for completion (blocks until MPD idle event)
-mpc -p 6600 update --wait 2>/dev/null || true
+# Trigger full library scan and wait for completion (blocks until MPD idle event).
+# Don't exit on failure — scan errors shouldn't prevent MPD from serving
+# already-indexed music (e.g., NFS temporarily unreachable).
+mpc -p 6600 update --wait 2>/dev/null || echo "WARNING: library scan failed or incomplete"
 wait $MPD_PID
 exit $?


### PR DESCRIPTION
## Summary
- **mpd-entrypoint.sh**: Replace silent `|| true` on `mpc update --wait` with a warning log. Scan failures (NFS timeout, permissions) now appear in `docker logs mpd` instead of being swallowed
- **docker-compose.yml**: Add comment explaining why myMPD uses `service_started` (not `service_healthy`) for MPD dependency — myMPD retries internally, `service_healthy` would add 60s delay

## Test plan
- [ ] Deploy — verify MPD starts and completes library scan
- [ ] Simulate scan failure (empty music dir) — confirm warning in `docker logs mpd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)