### PR TITLE
fix(prepare-sd): include display detection scripts in boot partition

### DIFF
--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -280,7 +280,7 @@ function Copy-ClientFiles {
         }
     }
 
-    # Setup script
+    # Setup scripts
     $scriptsDest = Join-Path $clientDest 'scripts'
     New-Item -ItemType Directory -Path $scriptsDest -Force | Out-Null
     Copy-Item (Join-Path $ClientDir 'common\scripts\setup.sh') -Destination $scriptsDest
@@ -288,6 +288,23 @@ function Copy-ClientFiles {
     $roMode = Join-Path $ClientDir 'common\scripts\ro-mode.sh'
     if (Test-Path $roMode) {
         Copy-Item $roMode -Destination $scriptsDest
+    }
+
+    $displaySh = Join-Path $ClientDir 'common\scripts\display.sh'
+    if (Test-Path $displaySh) {
+        Copy-Item $displaySh -Destination $scriptsDest
+    }
+
+    $displayDetect = Join-Path $ClientDir 'common\scripts\display-detect.sh'
+    if (Test-Path $displayDetect) {
+        Copy-Item $displayDetect -Destination $scriptsDest
+    }
+
+    # Systemd service files (display detection boot service)
+    $systemdSrc = Join-Path $ClientDir 'common\systemd'
+    if (Test-Path $systemdSrc) {
+        $systemdDest = Join-Path $clientDest 'systemd'
+        Copy-Item $systemdSrc -Destination $systemdDest -Recurse -Force
     }
 }
 

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -229,10 +229,17 @@ copy_client_files() {
         fi
     done
 
-    # Setup script
+    # Setup scripts
     mkdir -p "$dest/scripts"
     cp "$CLIENT_DIR/common/scripts/setup.sh" "$dest/scripts/"
     [[ -f "$CLIENT_DIR/common/scripts/ro-mode.sh" ]] && cp "$CLIENT_DIR/common/scripts/ro-mode.sh" "$dest/scripts/"
+    [[ -f "$CLIENT_DIR/common/scripts/display.sh" ]] && cp "$CLIENT_DIR/common/scripts/display.sh" "$dest/scripts/"
+    [[ -f "$CLIENT_DIR/common/scripts/display-detect.sh" ]] && cp "$CLIENT_DIR/common/scripts/display-detect.sh" "$dest/scripts/"
+
+    # Systemd service files (display detection boot service)
+    if [[ -d "$CLIENT_DIR/common/systemd" ]]; then
+        cp -r "$CLIENT_DIR/common/systemd" "$dest/"
+    fi
 }
 
 # ── Main ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `prepare-sd.sh` only copied `setup.sh` and `ro-mode.sh` to the SD boot partition
- `setup.sh` sources `display.sh` at line 1108 for HDMI detection during first-boot install
- The file was never copied, causing setup to fail: `scripts/display.sh: No such file or directory`
- Root cause of snapvideo client install failure

### Changes
- Add `display.sh` and `display-detect.sh` to the scripts copied by `prepare-sd.sh`
- Add `systemd/` directory (contains `snapclient-display.service`) to boot partition
- Mirror the same fix in `prepare-sd.ps1` (Windows)

## Test plan
- [ ] Re-flash snapvideo SD card with `prepare-sd.sh`
- [ ] Verify first-boot install completes without error
- [ ] Verify `display.sh` exists at `/opt/snapclient/scripts/display.sh`
- [ ] Verify `snapclient-display.service` is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)