### PR TITLE
fix(deploy): set CPU governor to performance and disable USB autosuspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CPU governor and USB autosuspend tuning** ([#139](https://github.com/lollonet/snapMULTI/pull/139)) — `deploy.sh` sets CPU governor to `performance` and disables USB autosuspend to prevent audio glitches; settings persist via `/etc/default/cpufrequtils` and udev rule. Success messages now reflect actual write outcome
+
+### Changed
+- **Client submodule updated** ([#140](https://github.com/lollonet/snapMULTI/pull/140)) — HAT mixer auto-detection: `setup.sh` auto-configures `MIXER` based on detected audio HAT (hardware mixer for DACs, software for S/PDIF/USB), preserving full 16-bit audio resolution
+
 ## [0.3.13] — 2026-03-23
 
 ### Changed

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -450,22 +450,30 @@ install_dependencies() {
     # Audio performance tuning
     # CPU governor: 'performance' avoids ramp-up latency during audio playback
     if [[ -f /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ]]; then
+        local set_count=0
         for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
-            echo performance > "$gov" 2>/dev/null || true
+            echo performance > "$gov" 2>/dev/null && (( set_count++ )) || true
         done
         if [[ -d /etc/default ]]; then
             echo 'GOVERNOR="performance"' > /etc/default/cpufrequtils 2>/dev/null || true
         fi
-        ok "CPU governor set to performance"
+        if (( set_count > 0 )); then
+            ok "CPU governor set to performance ($set_count CPUs)"
+        else
+            warn "CPU governor: no cpufreq paths writable, skipped"
+        fi
     fi
 
     # USB autosuspend: disable to prevent audio device sleep
     if [[ -f /sys/module/usbcore/parameters/autosuspend ]]; then
-        echo -1 > /sys/module/usbcore/parameters/autosuspend 2>/dev/null || true
-        mkdir -p /etc/udev/rules.d
-        echo 'ACTION=="add", SUBSYSTEM=="usb", ATTR{power/autosuspend}="-1"' \
-            > /etc/udev/rules.d/50-usb-no-autosuspend.rules 2>/dev/null || true
-        ok "USB autosuspend disabled"
+        if echo -1 > /sys/module/usbcore/parameters/autosuspend 2>/dev/null; then
+            mkdir -p /etc/udev/rules.d
+            echo 'ACTION=="add", SUBSYSTEM=="usb", ATTR{power/autosuspend}="-1"' \
+                > /etc/udev/rules.d/50-usb-no-autosuspend.rules 2>/dev/null || true
+            ok "USB autosuspend disabled"
+        else
+            warn "USB autosuspend: not writable, skipped"
+        fi
     fi
 
     ok "System dependencies ready"


### PR DESCRIPTION
## Summary
- Set CPU governor to `performance` to avoid micro-latency during frequency ramp-up that causes audio glitches
- Disable USB autosuspend (`-1`) to prevent USB audio devices from being suspended after 2s idle
- Both settings persist across reboots via `/etc/default/cpufrequtils` and udev rule

Mirror of client PR #104 (already merged), applied to server `deploy.sh`.

## Test plan
- [x] Deployed to snapvideo — governor confirmed `performance`, autosuspend `-1`
- [x] Deployed to moniaclient — same
- [ ] shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)