### PR TITLE
fix: SSH key cleanup trap and grep-c progress bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
           DEPLOY_USER: ${{ secrets.USER }}
         run: |
           KEY_FILE=$(mktemp)
+          trap 'rm -f "$KEY_FILE"' EXIT
           echo "$SSH_KEY" > "$KEY_FILE"
           chmod 600 "$KEY_FILE"
           ssh -i "$KEY_FILE" -o StrictHostKeyChecking=no "${DEPLOY_USER}@${HOST}" "mkdir -p /tmp/snapmulti-deploy"

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -103,7 +103,7 @@ render_progress() {
             done <<< "$log_lines"
         fi
         local line_count
-        line_count=$(printf '%s' "$log_lines" | grep -c '^') || line_count=0
+        line_count=$(printf '%s' "$log_lines" | grep -c '^' || true)
         for ((i=line_count; i<8; i++)); do
             printf '  | %-68s |\n' ""
         done


### PR DESCRIPTION
## Summary
- `deploy.yml`: add `trap 'rm -f "$KEY_FILE"' EXIT` to clean SSH key on cancellation (client already had this)
- `progress.sh`: fix `grep -c` on empty input producing double output — move `|| true` inside subshell

From deep council audit (batch 1 quick fixes).

## Test plan
- [ ] deploy workflow runs without regression
- [ ] firstboot TUI progress display correct on empty log

🤖 Generated with [Claude Code](https://claude.com/claude-code)