### PR TITLE
fix(firstboot): validate critical client files and fail loudly on copy errors

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -354,16 +354,25 @@ fi
 if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     mkdir -p "$CLIENT_DIR"
     if [[ -d "$SNAP_BOOT/client" ]]; then
-        # Copy all client files
-        cp -r "$SNAP_BOOT/client/"* "$CLIENT_DIR/" 2>/dev/null || true
+        # Copy all client files — fail loudly on errors
+        cp -r "$SNAP_BOOT/client/"* "$CLIENT_DIR/" || {
+            log_and_tty "ERROR: Failed to copy client files from $SNAP_BOOT/client/"
+            exit 1
+        }
         # Copy dotfiles (.env.example) — glob may match nothing, which is OK
         if ! cp -r "$SNAP_BOOT/client/".??* "$CLIENT_DIR/" 2>/dev/null; then
             echo "Note: no dotfiles found in client source (non-fatal)" >> "$LOG"
         fi
     fi
     # Verify critical client files were copied
-    if [[ ! -f "$CLIENT_DIR/docker-compose.yml" ]]; then
-        log_and_tty "ERROR: Client docker-compose.yml missing after copy."
+    missing=()
+    [[ -f "$CLIENT_DIR/docker-compose.yml" ]] || missing+=("docker-compose.yml")
+    [[ -f "$CLIENT_DIR/scripts/setup.sh" ]] || missing+=("scripts/setup.sh")
+    [[ -d "$CLIENT_DIR/audio-hats" ]] || missing+=("audio-hats/")
+    [[ -f "$CLIENT_DIR/scripts/display.sh" ]] || missing+=("scripts/display.sh")
+    [[ -f "$CLIENT_DIR/scripts/display-detect.sh" ]] || missing+=("scripts/display-detect.sh")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_and_tty "ERROR: Critical client files missing after copy: ${missing[*]}"
         exit 1
     fi
     log_progress "Client files copied to $CLIENT_DIR" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Expand post-copy validation to check all files setup.sh needs: `docker-compose.yml`, `scripts/setup.sh`, `audio-hats/`, `scripts/display.sh`, `scripts/display-detect.sh`
- Remove `|| true` from main client file copy — errors now surface instead of silently proceeding with missing files
- Dotfile copy remains non-fatal (glob may legitimately match nothing)

Previously, only `docker-compose.yml` was validated. If `setup.sh` or HAT configs failed to copy, firstboot would proceed and crash later with a cryptic error.

## Test plan
- [ ] shellcheck passes
- [ ] firstboot with all files present succeeds
- [ ] firstboot with missing setup.sh fails with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)