### PR TITLE
fix(tidal): add SIGTERM forwarding for clean container shutdown

### DIFF
--- a/scripts/tidal/entrypoint.sh
+++ b/scripts/tidal/entrypoint.sh
@@ -5,9 +5,11 @@ set -euo pipefail
 
 # Forward SIGTERM to all child processes for clean container shutdown
 cleanup() {
+    trap - TERM INT
     echo "tidal-connect: shutting down..."
     kill -TERM 0 2>/dev/null || true
     wait
+    exit 0
 }
 trap cleanup TERM INT
 


### PR DESCRIPTION
## Summary
- Add `trap cleanup TERM INT` that forwards signals to entire process group
- Run `tidal_connect_application` in background with tracked PID so `wait` is interruptible
- `docker stop` now cleanly terminates all child processes (tmux, metadata bridge, tidal app) instead of waiting for timeout + SIGKILL

Previously, SIGTERM was silently ignored by PID 1 (default bash behavior for non-waiting processes), causing Docker to wait the full 10s stop timeout before force-killing.

From deep council audit (batch 3).

## Test plan
- [ ] `docker stop tidal-connect` completes in <2s (was 10s+)
- [ ] `docker logs tidal-connect` shows "shutting down..." message
- [ ] Metadata bridge and speaker controller also exit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)