### PR TITLE
feat(deploy): add CAKE + DSCP network QoS for Snapcast

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -483,25 +483,30 @@ install_dependencies() {
     if [[ -n "$net_iface" ]]; then
         if modprobe sch_cake 2>/dev/null; then
             # Mark Snapcast streaming and control ports with DSCP EF
-            iptables -t mangle -C OUTPUT -p tcp --sport 1704 -j DSCP --set-dscp-class EF 2>/dev/null \
-                || iptables -t mangle -A OUTPUT -p tcp --sport 1704 -j DSCP --set-dscp-class EF 2>/dev/null
-            iptables -t mangle -C OUTPUT -p tcp --sport 1705 -j DSCP --set-dscp-class EF 2>/dev/null \
-                || iptables -t mangle -A OUTPUT -p tcp --sport 1705 -j DSCP --set-dscp-class EF 2>/dev/null
+            if command -v iptables &>/dev/null; then
+                iptables -t mangle -C OUTPUT -p tcp --sport 1704 -j DSCP --set-dscp-class EF 2>/dev/null \
+                    || iptables -t mangle -A OUTPUT -p tcp --sport 1704 -j DSCP --set-dscp-class EF
+                iptables -t mangle -C OUTPUT -p tcp --sport 1705 -j DSCP --set-dscp-class EF 2>/dev/null \
+                    || iptables -t mangle -A OUTPUT -p tcp --sport 1705 -j DSCP --set-dscp-class EF
+                if command -v iptables-save &>/dev/null; then
+                    mkdir -p /etc/iptables
+                    iptables-save > /etc/iptables/rules.v4 2>/dev/null || true
+                fi
+            else
+                warn "Network QoS: iptables not found, DSCP marking skipped (CAKE still active)"
+            fi
             # Replace default qdisc with CAKE
             tc qdisc replace dev "$net_iface" root cake diffserv4 2>/dev/null \
                 && ok "Network QoS: CAKE + DSCP EF on $net_iface (Snapcast prioritized)" \
                 || warn "Network QoS: CAKE setup failed on $net_iface"
-            # Persist iptables rules across reboots
-            if command -v iptables-save &>/dev/null; then
-                mkdir -p /etc/iptables
-                iptables-save > /etc/iptables/rules.v4 2>/dev/null || true
-            fi
-            # Persist CAKE via networkd or cron
+            # Persist CAKE via networkd-dispatcher (re-detect interface at boot)
             mkdir -p /etc/networkd-dispatcher/routable.d
-            cat > /etc/networkd-dispatcher/routable.d/50-cake-qos <<QEOF
+            cat > /etc/networkd-dispatcher/routable.d/50-cake-qos <<'QEOF'
 #!/bin/sh
+iface=$(ip route show default 2>/dev/null | awk '{print $5; exit}')
+[ -n "$iface" ] || exit 0
 modprobe sch_cake 2>/dev/null
-tc qdisc replace dev "$net_iface" root cake diffserv4 2>/dev/null
+tc qdisc replace dev "$iface" root cake diffserv4 2>/dev/null
 QEOF
             chmod +x /etc/networkd-dispatcher/routable.d/50-cake-qos
         else


### PR DESCRIPTION
## Summary
- Adds CAKE qdisc + DSCP EF marking on Snapcast ports 1704/1705 to `install_dependencies()`
- Prioritizes audio packets over bulk transfers (e.g. FLAC rsync) to prevent bufferbloat-induced glitches
- Persists rules across reboots via `iptables-save` and `networkd-dispatcher` hook

## Details
Snapcast uses ~1.4 Mbps (44100×16×2) but large file transfers saturate network buffers, adding latency to audio packets. CAKE with `diffserv4` automatically gives DSCP EF-marked packets the lowest-latency queue.

Tested on snapvideo with concurrent rsync of FLAC library — no audio glitches observed.

## Test plan
- [ ] Deploy to snapvideo, verify `tc qdisc show` shows CAKE on default interface
- [ ] Verify `iptables -t mangle -L OUTPUT` shows DSCP EF rules on ports 1704/1705
- [ ] Run bulk file transfer while streaming — confirm no audio dropouts
- [ ] Verify persistence: reboot and check CAKE qdisc is restored
- [ ] Test on x86_64 (raspy) — verify CAKE module loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)