### PR TITLE
fix: council audit batch 4 — 8 cross-cutting fixes

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -47,6 +47,10 @@ jobs:
         id: snapcast
         run: |
           SHA=$(git ls-remote https://github.com/badaix/snapcast.git HEAD | cut -f1)
+          if [[ -z "$SHA" ]]; then
+            echo "ERROR: Failed to fetch snapcast HEAD commit"
+            exit 1
+          fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "snapcast HEAD: $SHA"
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,6 +50,10 @@ jobs:
         id: snapcast
         run: |
           SHA=$(git ls-remote https://github.com/badaix/snapcast.git HEAD | cut -f1)
+          if [[ -z "$SHA" ]]; then
+            echo "ERROR: Failed to fetch snapcast HEAD commit"
+            exit 1
+          fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
       - name: Check architecture

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,8 +45,8 @@ jobs:
           trap 'rm -f "$KEY_FILE"' EXIT
           echo "$SSH_KEY" > "$KEY_FILE"
           chmod 600 "$KEY_FILE"
-          ssh -i "$KEY_FILE" -o StrictHostKeyChecking=no "${DEPLOY_USER}@${HOST}" "mkdir -p /tmp/snapmulti-deploy"
-          scp -i "$KEY_FILE" -o StrictHostKeyChecking=no docker-compose.yml "${DEPLOY_USER}@${HOST}:/tmp/snapmulti-deploy/docker-compose.yml"
+          ssh -i "$KEY_FILE" -o StrictHostKeyChecking=accept-new "${DEPLOY_USER}@${HOST}" "mkdir -p /tmp/snapmulti-deploy"
+          scp -i "$KEY_FILE" -o StrictHostKeyChecking=accept-new docker-compose.yml "${DEPLOY_USER}@${HOST}:/tmp/snapmulti-deploy/docker-compose.yml"
           rm -f "$KEY_FILE"
 
       - name: Deploy via SSH

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -888,7 +888,7 @@ pull_images() {
         info "Pulling $svc ($count/$total)"
         # metadata has a build: directive — pull from Hub if available,
         # fall back to local build on first bootstrap.
-        if ! docker compose pull "$svc" > /dev/null 2>&1; then
+        if ! docker compose pull "$svc" 2>&1 | tail -5; then
             if [[ "$svc" == "metadata" ]]; then
                 info "Building metadata locally (not yet on registry)"
                 if ! docker compose build metadata; then

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -168,8 +168,8 @@ has_display() {
     done
     # DRM status files exist but none say "connected" → headless
     $found_status && return 1
-    # No DRM status files at all (very old firmware) → assume display if fb0 exists
-    return 0
+    # No DRM status files at all (very old firmware / virtual fb) → assume headless
+    return 1
 }
 
 # Initialize progress display
@@ -600,7 +600,8 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
                 || scrub_failed=true
         done
         if [[ "$scrub_failed" == "true" ]]; then
-            log_and_tty "WARNING: Could not scrub some fields from boot partition — remove manually"
+            log_and_tty "WARNING: Could not scrub credentials via sed — removing install.conf"
+            rm -f "$SNAP_BOOT/install.conf" 2>/dev/null || true
         fi
     fi
 

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -251,7 +251,7 @@ function Copy-ServerFiles {
     }
 
     # Dockerfiles
-    foreach ($df in @('Dockerfile.snapserver', 'Dockerfile.shairport-sync', 'Dockerfile.mpd', 'Dockerfile.tidal')) {
+    foreach ($df in @('Dockerfile.snapserver', 'Dockerfile.shairport-sync', 'Dockerfile.mpd', 'Dockerfile.metadata', 'Dockerfile.tidal')) {
         $dfPath = Join-Path $ProjectDir $df
         if (Test-Path $dfPath) {
             Copy-Item $dfPath -Destination $serverDest

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -34,18 +34,25 @@ check_client_submodule() {
 
 # ── Auto-detect boot partition ────────────────────────────────────
 detect_boot() {
+    local candidates=()
     # macOS
-    if [[ -d "/Volumes/bootfs" ]]; then
-        echo "/Volumes/bootfs"
-        return
-    fi
+    [[ -d "/Volumes/bootfs" ]] && candidates+=("/Volumes/bootfs")
     # Linux: common mount points
     for base in "/media/$USER" "/media" "/mnt"; do
-        if [[ -d "$base/bootfs" ]]; then
-            echo "$base/bootfs"
+        [[ -d "$base/bootfs" ]] && candidates+=("$base/bootfs")
+    done
+    # Prefer partitions that look like a Pi boot (has cmdline.txt or config.txt)
+    for candidate in "${candidates[@]}"; do
+        if [[ -f "$candidate/cmdline.txt" ]] || [[ -f "$candidate/config.txt" ]]; then
+            echo "$candidate"
             return
         fi
     done
+    # Fall back to first candidate if none have Pi boot files
+    if [[ ${#candidates[@]} -gt 0 ]]; then
+        echo "${candidates[0]}"
+        return
+    fi
     return 1
 }
 

--- a/scripts/tidal/entrypoint.sh
+++ b/scripts/tidal/entrypoint.sh
@@ -41,7 +41,10 @@ if [ -f /usr/bin/tmux ] && [ -f /app/ifi-tidal-release/bin/speaker_controller_ap
     # Start metadata bridge with auto-restart (scrapes speaker controller TUI → JSON file)
     if [ -f /tidal-meta-bridge.sh ]; then
         echo "Starting metadata bridge..."
-        (while true; do /tidal-meta-bridge.sh; echo "tidal-meta-bridge: restarting in 5s" >&2; sleep 5; done) &
+        (failures=0; while [ "$failures" -lt 10 ]; do
+            if /tidal-meta-bridge.sh; then failures=0; else failures=$((failures + 1)); fi
+            echo "tidal-meta-bridge: restarting in 5s (failures: $failures/10)" >&2; sleep 5
+        done; echo "tidal-meta-bridge: too many failures, giving up" >&2) &
     fi
 fi
 


### PR DESCRIPTION
## Summary
- **prepare-sd.ps1**: add missing `Dockerfile.metadata` to server file copy list (parity with bash version)
- **firstboot.sh**: fix `has_display()` returning true on headless Pi with virtual framebuffer but no DRM status files
- **deploy.sh**: show last 5 lines of docker pull output instead of silencing all errors
- **deploy.yml**: SSH `StrictHostKeyChecking=accept-new` instead of `=no` (prevents MITM while still accepting first-time connections)
- **prepare-sd.sh**: validate boot partition has Pi boot files before auto-selecting (prevents wrong-partition on multi-SD setups)
- **build-push.yml + build-test.yml**: fail fast if `git ls-remote` returns empty SHA for snapcast HEAD
- **tidal/entrypoint.sh**: circuit breaker on metadata bridge — gives up after 10 consecutive failures instead of infinite loop
- **firstboot.sh**: delete `install.conf` entirely if credential scrub fails (FAT32 has no permissions)

## Test plan
- [ ] Validate CI passes (shellcheck, docker-compose syntax)
- [ ] Verify `prepare-sd.ps1` copies `Dockerfile.metadata` to SD
- [ ] Test headless Pi detection on device without HDMI
- [ ] Verify docker pull errors are visible in deploy output
- [ ] Test boot partition detection with cmdline.txt present vs absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)