### PR TITLE
feat(metadata): server-side album art lookup with priority chain

### DIFF
--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -822,8 +822,9 @@ class MetadataService:
         if cache_key in self.artwork_cache:
             cached = self.artwork_cache[cache_key]
             if "|" in cached:
-                return tuple(cached.split("|", 1))  # type: ignore[return-value]
-            return cached, ""
+                url, source = cached.split("|", 1)
+                return url, source
+            return cached, ""  # old-format entry — source unknown
 
         # Priority: MusicBrainz (album-specific, scored) then iTunes
         artwork_url = self.fetch_musicbrainz_artwork(artist, album)


### PR DESCRIPTION
Closes #149

## Summary

Move album art resolution logic server-side so clients always get the best available artwork without implementing their own fallback chains.

### Changes

- **MusicBrainz scoring**: Filter results by `score >= 80` (was: accept first result blindly)
- **Priority reorder**: MusicBrainz first (album-specific, high quality), iTunes fallback (was: iTunes first)
- **artist_image as last resort**: When no album art found, `artwork` field now falls back to `artist_image` (was: separate field only — clients showed generic artist photos instead of album covers)
- **New `artwork_source` field**: Tells clients where the art came from (`embedded`, `musicbrainz`, `itunes`, `artist_image`, `radio-browser`, `snapcast`, `default`)

### API response change

Before:
```json
{"artwork": "", "artist_image": "http://.../artist.jpg"}
```

After:
```json
{"artwork": "http://.../artist.jpg", "artist_image": "http://.../artist.jpg", "artwork_source": "artist_image"}
```

The `artwork` field now always contains the best available image. `artwork_source` is optional — clients that don't care can ignore it.

## Test plan

- [ ] MPD file with embedded art → `artwork_source: "embedded"`
- [ ] MPD file without art, known album → `artwork_source: "musicbrainz"` or `"itunes"`
- [ ] MPD file without art, unknown album → `artwork_source: "artist_image"`
- [ ] Spotify/AirPlay → `artwork_source: "snapcast"` (Snapcast provides URL)
- [ ] Radio stream → `artwork_source: "radio-browser"` or `"default"`
- [ ] Verify MusicBrainz results with score < 80 are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)