### PR TITLE
fix: shairport 10MB buffer + metadata cache eviction

### DIFF
--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -1362,7 +1362,7 @@ class MetadataService:
                         old_title = sm.current.get("title", "")
                         old_artist = sm.current.get("artist", "")
                         if (new_title or new_artist) and (new_title, new_artist) != (old_title, old_artist):
-                            self._failed_downloads.clear()
+                            pass  # Let OrderedDict (capped at 500) handle eviction naturally
 
                         title = metadata.get("title", "N/A")
                         artist = metadata.get("artist", "N/A")

--- a/scripts/meta_shairport.py
+++ b/scripts/meta_shairport.py
@@ -250,7 +250,7 @@ def main() -> None:
     stdin_buffer = ""
     pipe_buffer = b""
     MAX_STDIN_BUFFER = 65536    # 64 KB — snapserver sends small JSON-RPC messages
-    MAX_PIPE_BUFFER = 1048576   # 1 MB — cover art PICT items can be large
+    MAX_PIPE_BUFFER = 10485760  # 10 MB — high-res ALAC embedded art can exceed 1 MB
     pipe_fd: int | None = None
     last_pipe_check = 0.0
 


### PR DESCRIPTION
Fixes #151, #152

## Summary

Two targeted fixes from external code review:

1. **meta_shairport.py**: `MAX_PIPE_BUFFER` 1MB → 10MB. High-res embedded art in ALAC files can exceed 1MB, causing truncated XML and silent artwork loss. Buffer is only allocated during metadata burst — no idle memory impact.

2. **metadata-service.py**: Remove `_failed_downloads.clear()` on track change. The bounded `OrderedDict` (500 entries) handles eviction naturally. Prevents redundant API retries for known-missing artwork on every track skip.

## Test plan

- [ ] AirPlay with high-res cover art (>1MB) — verify artwork displays
- [ ] Radio station with missing logo — verify no repeated 404 retries on track change
- [ ] Verify failed downloads still expire when cache reaches 500 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)