### PR TITLE
fix(metadata): address deep review findings

### DIFF
--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -1186,7 +1186,9 @@ class MetadataService:
         1. Embedded art (MPD) / Snapcast HTTP art URL
         2. MusicBrainz Cover Art Archive (album-specific, score >= 80)
         3. iTunes Search API (album-specific, validated)
-        4. artist_image (generic artist photo — last resort)
+        4. Radio-Browser logo (radio streams only)
+        5. artist_image (generic artist photo — last resort)
+        6. Default radio placeholder (radio streams only)
         """
         if not metadata.get("playing"):
             return
@@ -1254,6 +1256,7 @@ class MetadataService:
                     metadata["artist_image"] = artist_image_served
                     # Last resort: use artist_image as artwork if nothing else found
                     if not metadata.get("artwork"):
+                        logger.info("No album artwork for %s - %s, using artist image", metadata.get("artist"), metadata.get("album"))
                         metadata["artwork"] = artist_image_served
                         artwork_source = "artist_image"
 
@@ -1357,13 +1360,6 @@ class MetadataService:
                     )
 
                     if changed:
-                        new_title = metadata.get("title", "")
-                        new_artist = metadata.get("artist", "")
-                        old_title = sm.current.get("title", "")
-                        old_artist = sm.current.get("artist", "")
-                        if (new_title or new_artist) and (new_title, new_artist) != (old_title, old_artist):
-                            pass  # Let OrderedDict (capped at 500) handle eviction naturally
-
                         title = metadata.get("title", "N/A")
                         artist = metadata.get("artist", "N/A")
                         logger.info(f"[{stream_id}] Updated: {title} - {artist}")


### PR DESCRIPTION
## Summary

Three fixes from deep `/review` (6-agent audit):

- **Docstring**: `enrich_artwork` priority chain now documents all 6 steps (was missing radio-browser and default placeholder)
- **Dead code**: Removed empty `if/pass` block left over from `_failed_downloads.clear()` removal
- **Logging**: Added info-level log when falling back to artist_image as artwork (was silent)

## Test plan

- [ ] Verify artwork lookup still works (embedded, MusicBrainz, iTunes)
- [ ] Play track with no album art → check logs show "using artist image" message
- [ ] No functional changes — docstring, dead code removal, and logging only

🤖 Generated with [Claude Code](https://claude.com/claude-code)