### PR TITLE
fix(prepare-sd): username verification matched hostname

### DIFF
--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -559,7 +559,7 @@ fi
 echo ""
 echo "--- User ---"
 if [[ -f "$BOOT/user-data" ]]; then
-    USERNAME=$(sed -n 's/^.*name: *\([a-z][a-z0-9_-]*\).*/\1/p' "$BOOT/user-data" 2>/dev/null | head -1)
+    USERNAME=$(sed -n 's/^.*- name: *\([a-z][a-z0-9_-]*\).*/\1/p' "$BOOT/user-data" 2>/dev/null | head -1)
     if [[ -n "$USERNAME" ]]; then
         echo "  [OK] User: $USERNAME"
     else


### PR DESCRIPTION
## Summary

`prepare-sd.sh` verification step showed hostname instead of username.

The regex `name:` matched `hostname: snapvideo` when it appeared before `users:` in cloud-init user-data. Changed to `- name:` which only matches YAML list items under the users block.

## Test plan

- [ ] Run `prepare-sd.sh` — verify "User: claudio" (not "User: snapvideo")

🤖 Generated with [Claude Code](https://claude.com/claude-code)