### PR TITLE
fix(prepare-sd): include boot-tune.sh in SD card copy chain

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -369,6 +369,7 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
         cp "$SNAP_BOOT/server/.env.example" "$SERVER_DIR/" 2>/dev/null || true
         cp -r "$SNAP_BOOT/server/config" "$SERVER_DIR/"
         cp "$SNAP_BOOT/server/deploy.sh" "$SERVER_DIR/scripts/"
+        cp "$SNAP_BOOT/server/boot-tune.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/status.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/.version" "$SERVER_DIR/" 2>/dev/null || true
     fi

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -238,6 +238,10 @@ function Copy-ServerFiles {
     New-Item -ItemType Directory -Path $serverDest -Force | Out-Null
 
     Copy-Item (Join-Path $ScriptDir 'deploy.sh') -Destination $serverDest
+    $bootTuneSh = Join-Path $ScriptDir 'boot-tune.sh'
+    if (Test-Path $bootTuneSh) {
+        Copy-Item $bootTuneSh -Destination $serverDest
+    }
     $statusSh = Join-Path $ScriptDir 'status.sh'
     if (Test-Path $statusSh) {
         Copy-Item $statusSh -Destination $serverDest

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -214,6 +214,7 @@ copy_server_files() {
     mkdir -p "$dest"
 
     cp "$SCRIPT_DIR/deploy.sh" "$dest/"
+    cp "$SCRIPT_DIR/boot-tune.sh" "$dest/" 2>/dev/null || true
     cp "$SCRIPT_DIR/status.sh" "$dest/" 2>/dev/null || true
     cp -r "$PROJECT_DIR/config" "$dest/"
     cp "$PROJECT_DIR/docker-compose.yml" "$dest/"


### PR DESCRIPTION
## Summary

`boot-tune.sh` was missing from the prepare-sd → firstboot → deploy copy chain. Fresh SD installs had `deploy.sh` trying to install a systemd service from a file that didn't exist.

- `prepare-sd.sh`: copy `boot-tune.sh` to `server/` on boot partition
- `prepare-sd.ps1`: same for Windows
- `firstboot.sh`: copy `boot-tune.sh` to `/opt/snapmulti/scripts/`

## Test plan

- [ ] Reflash SD → verify `/opt/snapmulti/scripts/boot-tune.sh` exists
- [ ] Verify `snapmulti-boot-tune.service` is enabled after firstboot
- [ ] Reboot → verify CPU governor=performance, USB autosuspend=-1, CAKE active

🤖 Generated with [Claude Code](https://claude.com/claude-code)