### PR TITLE
feat: operational hardening — watchdog, log rotation, healthchecks

### DIFF
--- a/config/mpd.conf
+++ b/config/mpd.conf
@@ -4,6 +4,7 @@
 music_directory         "/music"
 playlist_directory      "/playlists"
 log_file                "/data/mpd.log"
+log_file_max_size       "1048576"
 pid_file                "/data/mpd.pid"
 state_file              "/data/mpd.state"
 sticker_file            "/data/sticker.sql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "pidof snapserver || exit 1"]
-      interval: 60s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 15s
@@ -81,7 +81,7 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "pgrep -x shairport-sync && test -p /audio/airplay_fifo || exit 1"]
-      interval: 60s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 10s
@@ -134,7 +134,7 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "pgrep go-librespot && wget -q --spider http://127.0.0.1:24879/ || exit 1"]
-      interval: 60s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 15s
@@ -179,7 +179,7 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8180/ || exit 1"]
-      interval: 60s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: ${MPD_START_PERIOD:-300s}
@@ -219,7 +219,7 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "echo 'ping' | nc -w 2 127.0.0.1 6600 | grep -q OK || exit 1"]
-      interval: 60s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: ${MPD_START_PERIOD:-300s}
@@ -257,7 +257,7 @@ services:
       - ./artwork:/app/artwork
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8083/health', timeout=3)"]
-      interval: 60s
+      interval: 30s
       timeout: 5s
       start_period: 10s
       retries: 3
@@ -311,7 +311,7 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "pgrep -f tidal || exit 1"]
-      interval: 60s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 10s

--- a/scripts/boot-tune.sh
+++ b/scripts/boot-tune.sh
@@ -6,7 +6,7 @@
 # - udev rules don't re-trigger for already-present USB devices at boot
 # - networkd-dispatcher is not installed (CAKE/DSCP hook never runs)
 #
-# Installed as systemd oneshot by deploy.sh. Idempotent and safe on
+# Installed as systemd oneshot by deploy.sh/setup.sh. Idempotent and safe on
 # both writable and overlayroot filesystems.
 
 set -euo pipefail
@@ -24,6 +24,17 @@ done
 for ctrl in /sys/bus/usb/devices/*/power/autosuspend; do
     [ -f "$ctrl" ] && echo -1 > "$ctrl" 2>/dev/null || true
 done
+
+# ── Memory tuning: reduce swappiness for audio workloads ──────────
+# Default 60 is too aggressive — audio buffers should stay in RAM
+echo 10 > /proc/sys/vm/swappiness 2>/dev/null || true
+
+# ── Hardware watchdog: auto-reboot on system hang ─────────────────
+# Pi's bcm2835_wdt triggers reboot if systemd stops petting it
+modprobe bcm2835_wdt 2>/dev/null || true
+
+# ── Artwork cache cleanup: remove files older than 30 days ────────
+find /opt/snapmulti/artwork -type f -mtime +30 -delete 2>/dev/null || true
 
 # ── CAKE QoS + DSCP EF on Snapcast ports ─────────────────────────
 modprobe sch_cake 2>/dev/null || true

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -285,6 +285,13 @@ install_boot_tune_service() {
 
     cp "$boot_tune_script" /usr/local/bin/snapmulti-boot-tune.sh
     chmod +x /usr/local/bin/snapmulti-boot-tune.sh
+
+    # Enable hardware watchdog — auto-reboot on system hang (60s timeout)
+    mkdir -p /etc/systemd/system.conf.d
+    cat > /etc/systemd/system.conf.d/watchdog.conf <<'WEOF'
+[Manager]
+RuntimeWatchdogSec=60
+WEOF
     cat > /etc/systemd/system/snapmulti-boot-tune.service <<'SEOF'
 [Unit]
 Description=snapMULTI boot-time system tuning


### PR DESCRIPTION
## Summary

Council audit (7 agents) identified 6 operational improvements for production readiness.

### Changes
1. **MPD log rotation**: `log_file_max_size 1048576` (1MB) — was unbounded
2. **Hardware watchdog**: `bcm2835_wdt` + `RuntimeWatchdogSec=60` — auto-reboot on hang
3. **vm.swappiness=10**: keep audio buffers in RAM — was default 60
4. **Healthcheck interval 30s**: faster failure detection — was 60s (up to 3 min)
5. **Artwork cache cleanup**: delete files >30 days at boot — was unbounded
6. **Restart limits**: dismissed — `unless-stopped` correct for appliance; healthchecks catch loops

### No Docker image rebuild needed
All changes are config files and scripts — `docker compose pull` is NOT required. Just restart containers with `docker compose up -d`.

## Test plan
- [ ] MPD: verify log file stops growing past 1MB
- [ ] Watchdog: `dmesg | grep watchdog` shows bcm2835_wdt loaded
- [ ] Swappiness: `cat /proc/sys/vm/swappiness` = 10
- [ ] Healthchecks: `docker compose ps` shows faster health transitions
- [ ] Artwork: verify old files cleaned on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)