### PR TITLE
security: scope DAC_OVERRIDE to FIFO containers only (#146)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,18 @@ x-logging: &default-logging
 
 x-security: &default-security
   security_opt:
-    - apparmor:unconfined  # Required for D-Bus access
     - no-new-privileges:true
   cap_drop:
     - ALL
+
+# Services that read/write FIFOs and use D-Bus (Avahi/zeroconf)
+x-fifo-security: &fifo-security
+  <<: *default-security
+  security_opt:
+    - apparmor:unconfined  # Required for D-Bus access (Avahi zeroconf)
+    - no-new-privileges:true
   cap_add:
-    - DAC_OVERRIDE      # File access as non-root (FIFOs in /audio may be root-owned)
+    - DAC_OVERRIDE
 
 services:
   snapserver:
@@ -25,7 +31,7 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     network_mode: host
-    <<: *default-security
+    <<: *fifo-security
     read_only: true
     tmpfs:
       - /tmp:size=64M
@@ -62,7 +68,7 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     network_mode: host
-    <<: *default-security
+    <<: *fifo-security
     read_only: true
     tmpfs:
       - /tmp:size=32M
@@ -103,7 +109,7 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=false"
     network_mode: host
-    <<: *default-security
+    <<: *fifo-security
     read_only: true
     tmpfs:
       - /tmp:size=32M


### PR DESCRIPTION
## Summary
Closes #146. DAC_OVERRIDE was applied to ALL containers via the shared `x-security` anchor. Now scoped:

| Anchor | Capabilities | Services |
|--------|-------------|----------|
| `x-security` | cap_drop ALL, no-new-privileges | mympd, mpd, metadata |
| `x-fifo-security` | + DAC_OVERRIDE, apparmor:unconfined | snapserver, shairport-sync, librespot, tidal-connect |

Also removed `apparmor:unconfined` from services that don't use D-Bus.

## Council findings addressed
| # | Finding | Status |
|---|---------|--------|
| 3 | DAC_OVERRIDE on all containers | Fixed — scoped to FIFO services |
| 16 | apparmor:unconfined everywhere | Fixed — only on D-Bus services |
| 2 | SMB plaintext credentials | Already implemented (scrub in firstboot.sh) |

## Test plan
- [ ] `docker compose config` validates
- [ ] Server containers start — snapserver, shairport, librespot access FIFOs
- [ ] mympd, mpd, metadata work without DAC_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)