### PR TITLE
feat: post-install summary screen + RAM validation

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -306,6 +306,20 @@ EOF
             ;;
     esac
 
+    # Warn if memory reserves exceed available RAM
+    local total_reserve_mb=0
+    while IFS='=' read -r key val; do
+        if [[ "$key" == *_MEM_RESERVE ]]; then
+            total_reserve_mb=$(( total_reserve_mb + ${val%M} ))
+        fi
+    done < <(grep '_MEM_RESERVE=' "$ENV_FILE")
+    local avail_mb
+    avail_mb=$(awk '/MemTotal/{print int($2/1024)}' /proc/meminfo 2>/dev/null) || true
+    if [[ -n "$avail_mb" && "$total_reserve_mb" -gt "$avail_mb" ]]; then
+        warn "Memory reserves (${total_reserve_mb}M) exceed available RAM (${avail_mb}M)"
+        warn "Containers may be OOM-killed. Consider 'minimal' profile."
+    fi
+
     ok "Resource profile '$profile' applied"
 }
 

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -869,9 +869,26 @@ touch "$MARKER"
 
 progress_complete 2>/dev/null || true
 
+# Show completion summary with access info
+HOSTNAME=$(hostname 2>/dev/null || echo "snapmulti")
+IP_ADDR=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}') || true
 log_and_tty ""
-log_and_tty "  --- Installation complete! ($INSTALL_TYPE) ---"
+log_and_tty "  +--------------------------------------------+"
+log_and_tty "  |       Installation complete!               |"
+log_and_tty "  +--------------------------------------------+"
 log_and_tty ""
+case "$INSTALL_TYPE" in
+    server|both)
+        log_and_tty "  Speakers:  http://${IP_ADDR:-$HOSTNAME}:1780"
+        log_and_tty "  Library:   http://${IP_ADDR:-$HOSTNAME}:8180"
+        ;;
+    client)
+        log_and_tty "  Player will auto-discover your server"
+        ;;
+esac
+log_and_tty ""
+log_and_tty "  Rebooting in 10 seconds..."
+sleep 5
 for i in 5 4 3 2 1; do
     log_and_tty "  Rebooting in $i..."
     sleep 1


### PR DESCRIPTION
## Summary
Phase 4 of council audit findings:

- **Post-install confirmation**: Shows Snapweb/myMPD URLs with detected IP on HDMI before reboot (10s reading time). Beginners now know the install succeeded and where to connect.
- **RAM validation**: Warns during deploy if memory reserves exceed available RAM (prevents silent OOM kills on small Pis using wrong profile).
- **|| true audit**: Reviewed all 65+ patterns in firstboot.sh — only 3 are operational, all legitimate. Rest are display/progress code (correct to suppress).

## Council findings addressed
| # | Finding | Status |
|---|---------|--------|
| 15 | No post-install confirmation | Fixed — summary screen with URLs |
| 18 | Resource profiles may exceed 2GB | Fixed — runtime warning |
| 12 | || true masking errors | Audited — all operational uses are correct |

## Test plan
- [ ] Install with HDMI — verify summary screen shows correct IP and URLs
- [ ] Install on Pi Zero 2W with performance profile — verify RAM warning
- [ ] Client-only install — verify "auto-discover" message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)