### PR TITLE
feat: music menu guidance + prepare-sd parity CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -90,6 +90,34 @@ jobs:
           fi
           echo "✓ All Dockerfiles pass hadolint"
 
+      - name: Verify prepare-sd.sh / prepare-sd.ps1 parity
+        run: |
+          echo "Checking file copy parity between bash and PowerShell scripts..."
+          # Extract copied filenames from both scripts
+          grep -oP "cp.*\"\$\w+/\K[^\"]+|Copy-Item.*'[^']*\\\\(\K[^']+)" \
+            scripts/prepare-sd.sh scripts/prepare-sd.ps1 2>/dev/null | sort -u > /dev/null
+
+          # Check install.conf fields match
+          SH_FIELDS=$(grep -oP '^\w+=' scripts/prepare-sd.sh | grep -v '^#' | sort -u)
+          PS_FIELDS=$(grep -oP '^\w+=' scripts/prepare-sd.ps1 | grep -v '^#' | sort -u)
+
+          # Check key files are in both copy functions
+          MISSING=0
+          for file in deploy.sh boot-tune.sh ro-mode.sh discover-server.sh setup.sh display.sh display-detect.sh; do
+            if grep -q "$file" scripts/prepare-sd.sh && ! grep -q "$file" scripts/prepare-sd.ps1; then
+              echo "ERROR: $file in prepare-sd.sh but missing from prepare-sd.ps1"
+              MISSING=1
+            fi
+            if grep -q "$file" scripts/prepare-sd.ps1 && ! grep -q "$file" scripts/prepare-sd.sh; then
+              echo "ERROR: $file in prepare-sd.ps1 but missing from prepare-sd.sh"
+              MISSING=1
+            fi
+          done
+          if [ "$MISSING" -eq 1 ]; then
+            exit 1
+          fi
+          echo "✓ prepare-sd scripts in sync"
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -116,6 +116,9 @@ function Show-MusicMenu {
     Write-Host '  |                                              |'
     Write-Host '  +---------------------------------------------+'
     Write-Host ''
+    Write-Host '  Most users choose 1 (streaming). Pick 3 if you'
+    Write-Host '  have a music collection on a NAS or server.'
+    Write-Host ''
 }
 
 function Get-MusicSource {

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -110,6 +110,9 @@ show_music_menu() {
     echo "  |                                              |"
     echo "  +---------------------------------------------+"
     echo ""
+    echo "  Most users choose 1 (streaming). Pick 3 if you"
+    echo "  have a music collection on a NAS or server."
+    echo ""
 }
 
 get_music_source() {


### PR DESCRIPTION
## Summary
- **Music source menu**: Adds guidance text ("Most users choose 1, pick 3 for NAS") to both bash and PS1 scripts
- **CI parity check**: New validate.yml step verifies both prepare-sd scripts copy the same key files. Catches drift like the discover-server.sh miss from earlier today.

## Council findings addressed
| # | Finding | Status |
|---|---------|--------|
| 20 | Music source menu has no guidance | Fixed |
| 21 | prepare-sd.sh / ps1 sync — no CI test | Fixed |

## Test plan
- [ ] CI passes parity check
- [ ] Intentionally remove a file from ps1 — CI fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)