### PR TITLE
feat: persist diagnostic logs to boot partition across reboots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Diagnostic log persistence** — saves dmesg audio errors, docker logs, ALSA state, and system health to boot partition every 30 minutes. Survives overlayroot reboots. Keeps last 3 snapshots at `/boot/firmware/diagnostics/`
+
 ## [0.3.26] — 2026-04-07
 
 ### Added

--- a/scripts/common/save-diagnostics.sh
+++ b/scripts/common/save-diagnostics.sh
@@ -29,6 +29,7 @@ remount_ro() {
 }
 
 remount_rw
+trap 'remount_ro' EXIT
 mkdir -p "$DIAG_DIR"
 
 # Rotate: keep only the last MAX_SNAPSHOTS
@@ -99,6 +100,6 @@ cat /proc/asound/cards > "$SNAPSHOT/asound-cards.log" 2>/dev/null || true
     ip route show default 2>/dev/null
 } > "$SNAPSHOT/network.log" 2>/dev/null || true
 
-remount_ro
+# remount_ro handled by EXIT trap
 
 echo "Diagnostics saved to $SNAPSHOT"

--- a/scripts/common/save-diagnostics.sh
+++ b/scripts/common/save-diagnostics.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Save diagnostic logs to boot partition (FAT32) so they survive
+# overlayroot reboots. Runs periodically via systemd timer.
+#
+# Captures: dmesg (I2S/ALSA errors), docker container status,
+# snapclient logs, and system state. Keeps last 3 snapshots
+# to avoid filling the boot partition.
+set -euo pipefail
+
+# Detect boot partition
+if [[ -d /boot/firmware ]]; then
+    BOOT="/boot/firmware"
+else
+    BOOT="/boot"
+fi
+
+DIAG_DIR="$BOOT/diagnostics"
+MAX_SNAPSHOTS=3
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+SNAPSHOT="$DIAG_DIR/$TIMESTAMP"
+
+# Remount boot partition read-write
+remount_rw() {
+    mount -o remount,rw "$BOOT" 2>/dev/null || true
+}
+
+remount_ro() {
+    mount -o remount,ro "$BOOT" 2>/dev/null || true
+}
+
+remount_rw
+mkdir -p "$DIAG_DIR"
+
+# Rotate: keep only the last MAX_SNAPSHOTS
+# shellcheck disable=SC2012
+existing=$(ls -1d "$DIAG_DIR"/[0-9]* 2>/dev/null | sort | head -n -"$MAX_SNAPSHOTS")
+if [[ -n "$existing" ]]; then
+    echo "$existing" | while IFS= read -r old; do
+        rm -rf "$old"
+    done
+fi
+
+mkdir -p "$SNAPSHOT"
+
+# 1. Kernel audio/I2S errors
+dmesg 2>/dev/null | grep -iE 'i2s|alsa|snd|hifiberry|underrun|xrun|pcm|wm8804|error' \
+    > "$SNAPSHOT/dmesg-audio.log" 2>/dev/null || true
+
+# 2. Docker container status
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.RunningFor}}' \
+    > "$SNAPSHOT/docker-ps.log" 2>/dev/null || true
+
+# 3. Snapclient logs (last 100 lines)
+docker logs snapclient --tail 100 \
+    > "$SNAPSHOT/snapclient.log" 2>&1 || true
+
+# 4. fb-display logs (last 50 lines)
+docker logs fb-display --tail 50 \
+    > "$SNAPSHOT/fb-display.log" 2>&1 || true
+
+# 5. Audio visualizer logs (last 50 lines)
+docker logs audio-visualizer --tail 50 \
+    > "$SNAPSHOT/audio-visualizer.log" 2>&1 || true
+
+# 6. Server containers (if running — "both" mode)
+docker logs snapserver --tail 50 \
+    > "$SNAPSHOT/snapserver.log" 2>&1 || true
+
+# 7. ALSA state
+if command -v aplay &>/dev/null; then
+    aplay -l > "$SNAPSHOT/alsa-devices.log" 2>&1 || true
+fi
+cat /proc/asound/cards > "$SNAPSHOT/asound-cards.log" 2>/dev/null || true
+
+# 8. System state
+{
+    echo "=== uptime ==="
+    uptime
+    echo "=== memory ==="
+    free -h
+    echo "=== disk ==="
+    df -h / /boot/firmware 2>/dev/null || df -h / /boot
+    echo "=== temperature ==="
+    cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null \
+        | awk '{printf "%.1f°C\n", $1/1000}' || echo "N/A"
+    echo "=== overlayroot ==="
+    if mount | grep -q 'overlayroot'; then
+        echo "active"
+    else
+        echo "inactive"
+    fi
+} > "$SNAPSHOT/system.log" 2>/dev/null || true
+
+# 9. Network state (brief)
+{
+    echo "=== interfaces ==="
+    ip -brief addr 2>/dev/null
+    echo "=== route ==="
+    ip route show default 2>/dev/null
+} > "$SNAPSHOT/network.log" 2>/dev/null || true
+
+remount_ro
+
+echo "Diagnostics saved to $SNAPSHOT"

--- a/scripts/common/snapmulti-diagnostics.service
+++ b/scripts/common/snapmulti-diagnostics.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Save snapMULTI diagnostic logs to boot partition
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/save-diagnostics

--- a/scripts/common/snapmulti-diagnostics.timer
+++ b/scripts/common/snapmulti-diagnostics.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodic snapMULTI diagnostic log capture
+
+[Timer]
+# Save diagnostics every 30 minutes and on boot
+OnBootSec=2min
+OnUnitActiveSec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -911,7 +911,8 @@ if [[ -n "$DIAG_SCRIPT" ]]; then
     install -m 755 "$DIAG_SCRIPT" /usr/local/bin/save-diagnostics
     # Install systemd service + timer
     DIAG_DIR="$(dirname "$DIAG_SCRIPT")"
-    if [[ -f "$DIAG_DIR/snapmulti-diagnostics.service" ]]; then
+    if [[ -f "$DIAG_DIR/snapmulti-diagnostics.service" && \
+          -f "$DIAG_DIR/snapmulti-diagnostics.timer" ]]; then
         cp "$DIAG_DIR/snapmulti-diagnostics.service" /etc/systemd/system/
         cp "$DIAG_DIR/snapmulti-diagnostics.timer" /etc/systemd/system/
         systemctl daemon-reload

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -894,6 +894,35 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════
+# Diagnostic log persistence (all modes)
+# ══════════════════════════════════════════════════════════════════
+# Saves dmesg, docker logs, and system state to the boot partition
+# (FAT32, survives overlayroot reboots) every 30 minutes.
+DIAG_SCRIPT=""
+for _diag_candidate in \
+    "$SNAP_BOOT/common/save-diagnostics.sh" \
+    "$SCRIPT_DIR/common/save-diagnostics.sh" \
+    "$SERVER_DIR/scripts/common/save-diagnostics.sh" \
+    "$CLIENT_DIR/scripts/common/save-diagnostics.sh"; do
+    [[ -f "$_diag_candidate" ]] && DIAG_SCRIPT="$_diag_candidate" && break
+done
+
+if [[ -n "$DIAG_SCRIPT" ]]; then
+    install -m 755 "$DIAG_SCRIPT" /usr/local/bin/save-diagnostics
+    # Install systemd service + timer
+    DIAG_DIR="$(dirname "$DIAG_SCRIPT")"
+    if [[ -f "$DIAG_DIR/snapmulti-diagnostics.service" ]]; then
+        cp "$DIAG_DIR/snapmulti-diagnostics.service" /etc/systemd/system/
+        cp "$DIAG_DIR/snapmulti-diagnostics.timer" /etc/systemd/system/
+        systemctl daemon-reload
+        systemctl enable snapmulti-diagnostics.timer
+    fi
+    log_progress "Diagnostic log persistence installed" 2>/dev/null || true
+else
+    log_progress "save-diagnostics.sh not found — skipping" 2>/dev/null || true
+fi
+
+# ══════════════════════════════════════════════════════════════════
 # Read-only filesystem (all modes, if enabled)
 # ══════════════════════════════════════════════════════════════════
 if [[ "${ENABLE_READONLY}" == "true" ]]; then


### PR DESCRIPTION
## Summary
On overlayroot systems, all logs are lost on reboot — makes it impossible to diagnose intermittent issues (like the silent-audio problem on snapdigi where I2S sync errors or ALSA multi plugin stalls kill audio but metadata/display keep working).

### New files
- `scripts/common/save-diagnostics.sh` — captures dmesg audio errors, docker logs, ALSA state, system health
- `scripts/common/snapmulti-diagnostics.{service,timer}` — systemd timer runs every 30min + 2min after boot

### How it works
- Remounts `/boot/firmware` rw briefly, writes snapshot, remounts ro
- Saves to `/boot/firmware/diagnostics/<timestamp>/` (FAT32, survives reboots)
- Keeps last 3 snapshots (~50KB each, 444MB free on boot partition)
- Installed by firstboot.sh (all modes: client, server, both)
- Automatically lands on SD card via prepare-sd.sh's existing `cp -r scripts/common/`

### What gets captured
| File | Contents |
|------|----------|
| `dmesg-audio.log` | I2S, ALSA, HiFiBerry, xrun, PCM errors |
| `docker-ps.log` | Container status table |
| `snapclient.log` | Last 100 lines |
| `fb-display.log` | Last 50 lines |
| `audio-visualizer.log` | Last 50 lines |
| `snapserver.log` | Last 50 lines (both mode) |
| `alsa-devices.log` | `aplay -l` output |
| `system.log` | uptime, memory, disk, temp, overlayroot |
| `network.log` | interfaces, default route |

## Test plan
- [ ] Shellcheck passes (verified)
- [ ] Deploy on Pi, verify `/boot/firmware/diagnostics/` populated after 2min
- [ ] Reboot, verify previous snapshot survives
- [ ] Verify rotation (only 3 snapshots kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)