### PR TITLE
fix: persist IMAGE_TAG to .env after reboot

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -771,7 +771,7 @@ EOF
     # Persist IMAGE_TAG (covers both new and existing .env)
     if [[ "${IMAGE_TAG:-latest}" != "latest" ]]; then
         if grep -q '^IMAGE_TAG=' "$ENV_FILE" 2>/dev/null; then
-            sed -i "s|^IMAGE_TAG=.*|IMAGE_TAG=$IMAGE_TAG|" "$ENV_FILE"
+            sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" "$ENV_FILE"
         else
             printf '\n# Docker image tag (non-default, set by --dev or advanced options)\nIMAGE_TAG=%s\n' "$IMAGE_TAG" >> "$ENV_FILE"
         fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -767,6 +767,16 @@ EOF
     if grep -q '^AUTO_UPDATE=true' "$ENV_FILE" 2>/dev/null || [[ "${AUTO_UPDATE:-}" == "true" ]]; then
         ensure_profile "auto-update"
     fi
+
+    # Persist IMAGE_TAG (covers both new and existing .env)
+    if [[ "${IMAGE_TAG:-latest}" != "latest" ]]; then
+        if grep -q '^IMAGE_TAG=' "$ENV_FILE" 2>/dev/null; then
+            sed -i "s|^IMAGE_TAG=.*|IMAGE_TAG=$IMAGE_TAG|" "$ENV_FILE"
+        else
+            printf '\n# Docker image tag (non-default, set by --dev or advanced options)\nIMAGE_TAG=%s\n' "$IMAGE_TAG" >> "$ENV_FILE"
+        fi
+        info "IMAGE_TAG=$IMAGE_TAG"
+    fi
 }
 
 #######################################


### PR DESCRIPTION
## Summary
- **Server**: `deploy.sh` now writes `IMAGE_TAG` to `.env` (was only exported, lost after reboot)
- **Client**: submodule updated with 5 bugfixes from lollonet/snapclient-pi#140:
  - gpu_mem=16 headless + audio fallback
  - systemctl not-found suppression
  - I2C false positive detection
  - discover-server.sh IPv4 fix
  - Persist IMAGE_TAG + ENABLE_READONLY to client .env

## Test plan
- [ ] Flash SD with `--dev` flag → verify .env has `IMAGE_TAG=dev` after reboot
- [ ] Flash SD without `--dev` → verify .env has `IMAGE_TAG=latest` (or absent)
- [ ] Verify containers pull correct image tag after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)