### PR TITLE
docs: council audit — fix port ref, update changelog, HAT threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Diagnostic log persistence** — saves dmesg audio errors, docker logs, ALSA state, and system health to boot partition every 30 minutes. Survives overlayroot reboots. Keeps last 3 snapshots at `/boot/firmware/diagnostics/`
 - **Pi Zero 2 W support** — documented in HARDWARE.md (64-bit required, 2.4 GHz only, headless audio)
 
+### Changed
+- **Modular firstboot** — rewritten as orchestrator with 4 extracted modules (unified-log, mount-music, install-docker, readonly-fs)
+
 ### Fixed
+- **IMAGE_TAG not persisted** — `deploy.sh` now writes `IMAGE_TAG` to `.env` (previously lost after reboot)
+- **LOG_SOURCE not reset** — module calls no longer leak source labels into subsequent log lines
+- **--no-readonly flag** — positioned before positional config file argument
+- **display.sh validation** — restored display-detect.sh validation checks
+- **apt lock race** — explicit `_wait_for_apt_lock` prevents concurrent apt failures
+- **install.conf parsing** — `_rc` helper no longer crashes on missing keys with `set -e`
 - **USB/I2S HAT conflict** — `prepare-sd.sh` and `setup.sh` now strip `otg_mode=1` and `dr_mode=host` from config.txt (Imager sets these, they block GPIO I2S/I2C communication with audio HATs)
 - **CAKE QoS on clients** — `boot-tune.sh` skips CAKE/DSCP on client-only systems (server-side only feature; `tc qdisc replace` hangs on Pi Zero when WiFi is DOWN)
 - **Stale boot-tune.sh on overlayroot** — `system-tune.sh` uses `install -m 755` to always overwrite `/usr/local/bin/` copy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Detection checks `/dev/fb0` and `/sys/class/drm/card*-HDMI-*/status`.
 
 When both are installed on the same Pi:
 - Server: `/opt/snapmulti/` — host networking (ports 1704, 1705, 1780, 6600, 8082, 8083, 8180)
-- Client: `/opt/snapclient/` — bridge networking (ports 8080, 8081)
+- Client: `/opt/snapclient/` — bridge networking (port 8081)
 - Client auto-connects to `127.0.0.1` (local server)
 
 ### Progress Display (`scripts/common/progress.sh`)

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -648,10 +648,10 @@ case "$INSTALL_TYPE" in
         done
         # Verify audio HAT configs exist
         hat_count=$(ls -1 "$DEST/client/audio-hats/"*.conf 2>/dev/null | wc -l)
-        if [[ "$hat_count" -ge 15 ]]; then
+        if [[ "$hat_count" -ge 17 ]]; then
             echo "  [OK] $hat_count audio HAT configs"
         else
-            echo "  [WARN] Only $hat_count HAT configs (expected 15+)"
+            echo "  [WARN] Only $hat_count HAT configs (expected 17+)"
         fi
         ;;
 esac


### PR DESCRIPTION
## Summary
Replaces #203 (was incorrectly branched from develop).

7-agent documentation council audit findings:

- **Fix CLAUDE.md**: remove stale port 8080 from client "both" mode (only 8081 exists)
- **Update CHANGELOG** with post-v0.3.26 commits (modular firstboot, IMAGE_TAG fixes, etc.)
- **Fix prepare-sd.sh**: HAT config threshold 15→17
- **Client submodule**: points to doc audit PR (lollonet/snapclient-pi#141)

## Test plan
- [ ] Verify CLAUDE.md port claims match docker-compose.yml
- [ ] Shellcheck passes (pre-push verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)