### PR TITLE
fix: parallel Docker image pulls (2 at a time)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -869,12 +869,14 @@ pull_images() {
         count=$((count + 1))
         info "Pulling $svc1 ($count/$total)"
 
-        # Start svc2 in background if it exists
+        # Start svc2 in background if it exists (output to temp file to avoid interleaving)
+        local bg_pid="" bg_log=""
         if [[ -n "$svc2" ]]; then
             count=$((count + 1))
             info "Pulling $svc2 ($count/$total)"
-            _pull_one "$svc2" &
-            local bg_pid=$!
+            bg_log=$(mktemp)
+            _pull_one "$svc2" >"$bg_log" 2>&1 &
+            bg_pid=$!
         fi
 
         # Pull svc1 in foreground with retry
@@ -887,19 +889,18 @@ pull_images() {
             fi
         fi
 
-        # Wait for background svc2
-        if [[ -n "${svc2:-}" ]]; then
+        # Wait for background svc2 (already retried 3x in background)
+        if [[ -n "$bg_pid" ]]; then
             if ! wait "$bg_pid" 2>/dev/null; then
-                # Retry in foreground
-                if ! _pull_one "$svc2"; then
-                    if [[ "$svc2" == "metadata" ]]; then
-                        info "Building metadata locally (not yet on registry)"
-                        docker compose build metadata || { error "Failed to build metadata"; exit 1; }
-                    else
-                        pull_failed+=("$svc2")
-                    fi
+                cat "$bg_log"  # surface output on failure
+                if [[ "$svc2" == "metadata" ]]; then
+                    info "Building metadata locally (not yet on registry)"
+                    docker compose build metadata || { error "Failed to build metadata"; exit 1; }
+                else
+                    pull_failed+=("$svc2")
                 fi
             fi
+            rm -f "$bg_log"
         fi
     done
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -767,6 +767,16 @@ EOF
     if grep -q '^AUTO_UPDATE=true' "$ENV_FILE" 2>/dev/null || [[ "${AUTO_UPDATE:-}" == "true" ]]; then
         ensure_profile "auto-update"
     fi
+
+    # Persist IMAGE_TAG (covers both new and existing .env)
+    if [[ "${IMAGE_TAG:-latest}" != "latest" ]]; then
+        if grep -q '^IMAGE_TAG=' "$ENV_FILE" 2>/dev/null; then
+            sed -i "s|^IMAGE_TAG=.*|IMAGE_TAG=$IMAGE_TAG|" "$ENV_FILE"
+        else
+            printf '\n# Docker image tag (non-default, set by --dev or advanced options)\nIMAGE_TAG=%s\n' "$IMAGE_TAG" >> "$ENV_FILE"
+        fi
+        info "IMAGE_TAG=$IMAGE_TAG"
+    fi
 }
 
 #######################################

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -847,32 +847,66 @@ pull_images() {
     local total=${#services[@]}
     local count=0
 
-    for svc in "${services[@]}"; do
-        count=$((count + 1))
-        info "Pulling $svc ($count/$total)"
-        local pull_ok=false
-        local delays=(0 10 30)  # retry after 10s, 30s
+    # Pull a single service with 3-attempt retry. Returns 0 on success.
+    _pull_one() {
+        local svc="$1"
+        local delays=(0 10 30)
         for delay in "${delays[@]}"; do
             [[ $delay -gt 0 ]] && { info "Retrying $svc in ${delay}s..."; sleep "$delay"; }
             if docker compose pull "$svc" 2>&1 | tail -5; then
-                pull_ok=true
-                break
+                return 0
             fi
         done
-        if [[ "$pull_ok" != "true" ]]; then
-            # metadata has a build: directive — fall back to local build
-            if [[ "$svc" == "metadata" ]]; then
+        return 1
+    }
+
+    # Pull 2 services at a time — balances network throughput vs SD I/O
+    local pull_failed=()
+    for ((i=0; i<${#services[@]}; i+=2)); do
+        local svc1="${services[$i]}"
+        local svc2="${services[$i+1]:-}"
+
+        count=$((count + 1))
+        info "Pulling $svc1 ($count/$total)"
+
+        # Start svc2 in background if it exists
+        if [[ -n "$svc2" ]]; then
+            count=$((count + 1))
+            info "Pulling $svc2 ($count/$total)"
+            _pull_one "$svc2" &
+            local bg_pid=$!
+        fi
+
+        # Pull svc1 in foreground with retry
+        if ! _pull_one "$svc1"; then
+            if [[ "$svc1" == "metadata" ]]; then
                 info "Building metadata locally (not yet on registry)"
-                if ! docker compose build metadata; then
-                    error "Failed to build metadata image"
-                    exit 1
-                fi
+                docker compose build metadata || { error "Failed to build metadata"; exit 1; }
             else
-                error "Failed to pull $svc after 3 attempts"
-                exit 1
+                pull_failed+=("$svc1")
+            fi
+        fi
+
+        # Wait for background svc2
+        if [[ -n "${svc2:-}" ]]; then
+            if ! wait "$bg_pid" 2>/dev/null; then
+                # Retry in foreground
+                if ! _pull_one "$svc2"; then
+                    if [[ "$svc2" == "metadata" ]]; then
+                        info "Building metadata locally (not yet on registry)"
+                        docker compose build metadata || { error "Failed to build metadata"; exit 1; }
+                    else
+                        pull_failed+=("$svc2")
+                    fi
+                fi
             fi
         fi
     done
+
+    if [[ ${#pull_failed[@]} -gt 0 ]]; then
+        error "Failed to pull after 3 attempts: ${pull_failed[*]}"
+        exit 1
+    fi
 
     ok "All $total images ready"
 }


### PR DESCRIPTION
## Summary
Council audit optimization: `deploy.sh` pulled images sequentially (~5-8 min on Pi). Now pulls 2 services concurrently.

- 2-at-a-time parallel pulls (background + foreground)
- Retains 3-attempt retry with backoff
- Retains metadata local build fallback
- Client submodule updated with matching retry+parallel fix

## Test plan
- [ ] Shellcheck passes (pre-push verified)
- [ ] Deploy on Pi, verify all images pulled
- [ ] Verify metadata fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)