### PR TITLE
fix: install hardening — logging, health, checkpoints, validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Diagnostic log persistence** — saves dmesg audio errors, docker logs, ALSA state, and system health to boot partition every 30 minutes. Survives overlayroot reboots. Keeps last 3 snapshots at `/boot/firmware/diagnostics/`
 - **Pi Zero 2 W support** — documented in HARDWARE.md (64-bit required, 2.4 GHz only, headless audio)
+- **Install checkpoints** — per-phase markers (deps, docker, deploy, setup) enable resume after power loss or crash without full reinstall
+- **Disk space pre-flight** — checks free space before Docker image pull (2 GB server, 1 GB client)
+- **Port availability check** — warns if key ports (1704, 1705, 1780, 6600, 8082, 8083, 8180) are in use before starting services
+- **Docker Compose v2+ enforcement** — validates version at startup with actionable error
+- **Diagnostic dump on failure** — trap collects memory, disk, docker status, and dmesg into install log
+- **Install duration logging** — total elapsed time shown at completion
 
 ### Changed
 - **Modular firstboot** — rewritten as orchestrator with 4 extracted modules (unified-log, mount-music, install-docker, readonly-fs)
+- **Silent Docker pulls** — progress output suppressed on success, surfaced on failure (fixes 500+ line log spam from Docker Compose v5)
+- **Unified logging for setup.sh** — output filtered through unified logger instead of raw dump to install log
 
 ### Fixed
 - **IMAGE_TAG not persisted** — `deploy.sh` now writes `IMAGE_TAG` to `.env` (previously lost after reboot)
 - **LOG_SOURCE not reset** — module calls no longer leak source labels into subsequent log lines
 - **--no-readonly flag** — positioned before positional config file argument
 - **display.sh validation** — restored display-detect.sh validation checks
-- **apt lock race** — explicit `_wait_for_apt_lock` prevents concurrent apt failures
+- **apt lock race** — explicit `_wait_for_apt_lock` with SECONDS-based 5-min deadline
+- **Health verification** — uses `docker compose ps --status healthy/running` instead of grep -c counting; client polls instead of fixed sleep
+- **Hostname sanitization** — enforces RFC 1123 max 253 chars
+- **prepare-sd.sh sed validation** — verifies boot script patches took effect, fails early if not
+- **prepare-sd.sh submodule error** — checks git exit code with clear network error message
 - **install.conf parsing** — `_rc` helper no longer crashes on missing keys with `set -e`
 - **USB/I2S HAT conflict** — `prepare-sd.sh` and `setup.sh` now strip `otg_mode=1` and `dr_mode=host` from config.txt (Imager sets these, they block GPIO I2S/I2C communication with audio HATs)
 - **CAKE QoS on clients** — `boot-tune.sh` skips CAKE/DSCP on client-only systems (server-side only feature; `tc qdisc replace` hangs on Pi Zero when WiFi is DOWN)

--- a/scripts/common/install-deps.sh
+++ b/scripts/common/install-deps.sh
@@ -28,12 +28,14 @@ fi
 
 # Wait for background apt (unattended-upgrades, cloud-init)
 _wait_for_apt_lock() {
-    local _apt_wait
-    for _apt_wait in $(seq 1 60); do
-        fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || return 0
+    local _apt_deadline=$(( SECONDS + 300 ))
+    while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+        if [[ $SECONDS -ge $_apt_deadline ]]; then
+            log_warn "apt lock still held after 5 minutes — proceeding anyway"
+            return 0
+        fi
         sleep 5
     done
-    log_warn "apt lock still held after 5 minutes — proceeding anyway"
 }
 
 # Install with automatic recovery on failure

--- a/scripts/common/sanitize.sh
+++ b/scripts/common/sanitize.sh
@@ -17,9 +17,13 @@ sanitize_airplay_name() {
 
 # Sanitize hostname/IP: alphanumeric, dots, hyphens only
 # Used for NFS servers, SMB servers, and any network hostname
+# Truncates to RFC 1123 max (253 chars total)
 # Usage: sanitize_hostname "nas.local"
 sanitize_hostname() {
-    printf '%s' "$1" | tr -cd 'A-Za-z0-9.-' | sed 's/^[.-]*//;s/[.-]*$//'
+    local cleaned
+    cleaned=$(printf '%s' "$1" | tr -cd 'A-Za-z0-9.-' | sed 's/^[.-]*//;s/[.-]*$//')
+    cleaned="${cleaned:0:253}"
+    printf '%s' "$cleaned"
 }
 
 # Semantic alias for NFS server validation

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -873,7 +873,7 @@ pull_images() {
     local count=0
     local pull_tmp
     pull_tmp=$(mktemp -d)
-    trap 'rm -rf "$pull_tmp"' RETURN
+    trap 'rm -rf "$pull_tmp"' RETURN EXIT
 
     # Pull a single service with 3-attempt retry.
     # Output is suppressed on success and surfaced on failure.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -157,6 +157,10 @@ detect_hardware_profile() {
 
     info "Hardware: ${total_ram_mb}MB RAM, ${cpu_cores} CPU cores"
 
+    if [[ $total_ram_mb -lt 512 ]]; then
+        warn "Only ${total_ram_mb}MB RAM — server needs at least 512MB, expect OOM issues"
+    fi
+
     # Determine profile based on hardware
     if [[ -n "$pi_model" ]]; then
         case "$pi_model" in
@@ -761,6 +765,8 @@ EOF
     # Tidal Connect is ARM-only
     if [[ "$IS_ARM" == "true" ]]; then
         ensure_profile "tidal"
+    else
+        info "Tidal Connect skipped (ARM-only, current arch: $(uname -m))"
     fi
 
     # Watchtower auto-update (opt-in)
@@ -836,6 +842,15 @@ pull_images() {
     step "Pulling Docker images"
     cd "$PROJECT_ROOT"
 
+    # Pre-flight: ensure enough disk space for images (~2 GB needed for server)
+    local avail_mb
+    avail_mb=$(df -BM --output=avail "$PROJECT_ROOT" 2>/dev/null | tail -1 | tr -d ' M')
+    if [[ -n "$avail_mb" ]] && [[ "$avail_mb" -lt 2048 ]]; then
+        error "Only ${avail_mb}MB free — need at least 2 GB for container images"
+        error "Free up space and re-run: docker compose pull"
+        exit 1
+    fi
+
     # COMPOSE_PROFILES in .env controls which services are active (e.g. tidal
     # profile on ARM). docker compose pull respects profiles automatically.
     local services
@@ -846,17 +861,26 @@ pull_images() {
     fi
     local total=${#services[@]}
     local count=0
+    local pull_tmp
+    pull_tmp=$(mktemp -d)
+    trap 'rm -rf "$pull_tmp"' RETURN
 
-    # Pull a single service with 3-attempt retry. Returns 0 on success.
+    # Pull a single service with 3-attempt retry.
+    # Output is suppressed on success and surfaced on failure.
     _pull_one() {
         local svc="$1"
+        local log="$pull_tmp/pull-$svc"
         local delays=(0 10 30)
         for delay in "${delays[@]}"; do
             [[ $delay -gt 0 ]] && { info "Retrying $svc in ${delay}s..."; sleep "$delay"; }
-            if docker compose pull "$svc" 2>&1 | tail -5; then
+            if docker compose pull "$svc" >"$log" 2>&1; then
+                rm -f "$log"
                 return 0
             fi
         done
+        # Surface last attempt's output on failure
+        tail -5 "$log"
+        rm -f "$log"
         return 1
     }
 
@@ -874,7 +898,7 @@ pull_images() {
         if [[ -n "$svc2" ]]; then
             count=$((count + 1))
             info "Pulling $svc2 ($count/$total)"
-            bg_log=$(mktemp)
+            bg_log="$pull_tmp/bg-$svc2"
             _pull_one "$svc2" >"$bg_log" 2>&1 &
             bg_pid=$!
         fi
@@ -909,6 +933,7 @@ pull_images() {
         exit 1
     fi
 
+    docker image prune -f >/dev/null 2>&1 || true
     ok "All $total images ready"
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -426,14 +426,14 @@ install_dependencies() {
     if [[ ${#mon_pkgs[@]} -gt 0 ]]; then
         info "Installing monitoring tools: ${mon_pkgs[*]}..."
         # Wait for apt lock — firstboot may still be upgrading packages
-        local _apt_wait
-        for _apt_wait in $(seq 1 60); do
-            fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || break
+        local _apt_deadline=$(( SECONDS + 300 ))
+        while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+            if [[ $SECONDS -ge $_apt_deadline ]]; then
+                warn "apt lock still held after 5 minutes — proceeding anyway"
+                break
+            fi
             sleep 5
         done
-        if fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; then
-            warn "apt lock still held after 5 minutes — proceeding anyway"
-        fi
         apt-get install -y -qq "${mon_pkgs[@]}" >/dev/null
         # Enable sysstat data collection (sar)
         if [[ -f /etc/default/sysstat ]]; then
@@ -516,9 +516,19 @@ install_docker() {
         ok "Docker installed: $(docker --version)"
     fi
 
-    # Check Docker Compose
+    # Check Docker Compose (v2+ required for profiles, --status, config --services)
     if docker compose version >/dev/null 2>&1; then
-        info "Docker Compose: $(docker compose version --short)"
+        local _compose_ver
+        _compose_ver=$(docker compose version --short 2>/dev/null)
+        info "Docker Compose: $_compose_ver"
+        # Strip leading 'v' and compare major version
+        local _compose_major="${_compose_ver#v}"
+        _compose_major="${_compose_major%%.*}"
+        if [[ "$_compose_major" -lt 2 ]]; then
+            error "Docker Compose v2+ required (found $_compose_ver)"
+            error "Update: sudo apt-get install docker-compose-plugin"
+            exit 1
+        fi
     else
         error "Docker Compose not found. Install Docker Compose v2."
         exit 1
@@ -940,6 +950,20 @@ pull_images() {
 start_services() {
     step "Starting services"
     cd "$PROJECT_ROOT"
+
+    # Pre-flight: check key ports are available (host networking)
+    local _port_conflict=false
+    for port in 1704 1705 1780 6600 8082 8083 8180; do
+        if ss -tlnp 2>/dev/null | grep -q ":${port} "; then
+            local _holder
+            _holder=$(ss -tlnp 2>/dev/null | grep ":${port} " | awk '{print $NF}' | head -1)
+            warn "Port $port already in use by $_holder"
+            _port_conflict=true
+        fi
+    done
+    if [[ "$_port_conflict" == "true" ]]; then
+        warn "Port conflicts detected — services may fail to start"
+    fi
 
     # COMPOSE_PROFILES in .env controls which services are active.
     # docker compose up -d starts all services matching active profiles.

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -28,10 +28,15 @@ if [[ -f "$MARKER" ]]; then
     exit 0
 fi
 if [[ -f "$FAILED_MARKER" ]]; then
-    echo "Previous install failed. Check /var/log/snapmulti-install.log"
-    echo "Remove $FAILED_MARKER to retry."
-    exit 1
+    # Allow retry: remove failed marker and resume from last checkpoint
+    rm -f "$FAILED_MARKER"
+    echo "Retrying install from last checkpoint..."
 fi
+
+# Checkpoint helpers: skip completed phases on retry after power loss / crash.
+# Each checkpoint is a file in INSTALLER_STATE named after the phase.
+checkpoint_done()    { touch "$INSTALLER_STATE/.done-$1"; }
+checkpoint_reached() { [[ -f "$INSTALLER_STATE/.done-$1" ]]; }
 
 # Detect boot partition
 if [[ -d /boot/firmware ]]; then
@@ -341,9 +346,14 @@ fi
 set_module "deps"
 next_step "Installing git and dependencies..."
 start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
-# shellcheck source=common/install-deps.sh
-source "$COMMON/install-deps.sh"
-install_dependencies
+if checkpoint_reached "deps"; then
+    log_info "Dependencies already installed (checkpoint), skipping"
+else
+    # shellcheck source=common/install-deps.sh
+    source "$COMMON/install-deps.sh"
+    install_dependencies
+    checkpoint_done "deps"
+fi
 milestone "$CURRENT_STEP" "System dependencies installed" 2 2>/dev/null || true
 
 # ══════════════════════════════════════════════════════════════════
@@ -352,15 +362,27 @@ milestone "$CURRENT_STEP" "System dependencies installed" 2 2>/dev/null || true
 set_module "docker"
 next_step "Installing Docker..."
 start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
-# shellcheck source=common/setup-docker.sh
-source "$COMMON/setup-docker.sh"
-setup_docker
+if checkpoint_reached "docker"; then
+    log_info "Docker already installed (checkpoint), skipping"
+else
+    # shellcheck source=common/setup-docker.sh
+    source "$COMMON/setup-docker.sh"
+    setup_docker
+    checkpoint_done "docker"
+fi
 milestone "$CURRENT_STEP" "Docker installed" 2 2>/dev/null || true
 
 # ══════════════════════════════════════════════════════════════════
 # SERVER INSTALL
 # ══════════════════════════════════════════════════════════════════
 if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
+  if checkpoint_reached "deploy"; then
+    set_module "deploy"
+    log_info "Server deploy already complete (checkpoint), skipping"
+    next_step "Deploy server (cached)..."
+    set_module "verify-server"
+    next_step "Verifying server (cached)..."
+  else
     set_module "deploy"
     next_step "Deploy server..."
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
@@ -441,12 +463,21 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
             log_warn "  $line"
         done
     fi
+    checkpoint_done "deploy"
+  fi  # checkpoint guard
 fi
 
 # ══════════════════════════════════════════════════════════════════
 # CLIENT INSTALL
 # ══════════════════════════════════════════════════════════════════
 if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
+  if checkpoint_reached "setup"; then
+    set_module "setup"
+    log_info "Client setup already complete (checkpoint), skipping"
+    next_step "Setup client (cached)..."
+    set_module "verify-client"
+    next_step "Verifying client (cached)..."
+  else
     set_module "setup"
 
     DISPLAY_MODE="framebuffer"
@@ -555,6 +586,8 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
             log_warn "  $line"
         done
     fi
+    checkpoint_done "setup"
+  fi  # checkpoint guard
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -188,6 +188,27 @@ cleanup_on_failure() {
         stop_progress_animation 2>/dev/null || true
         log_error "Installation FAILED in module: $CURRENT_MODULE (exit code: $exit_code)"
         log_error "Check log: $UNIFIED_LOG"
+
+        # Diagnostic snapshot — appended to install log for remote troubleshooting
+        {
+            echo ""
+            echo "=== DIAGNOSTIC DUMP (module: $CURRENT_MODULE, exit: $exit_code) ==="
+            echo "--- Memory ---"
+            free -m 2>/dev/null || true
+            echo "--- Disk ---"
+            df -h / /opt 2>/dev/null || true
+            echo "--- Docker ---"
+            docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' 2>/dev/null || true
+            echo "--- Docker logs (last 10 lines per container) ---"
+            for ctr in $(docker ps -aq 2>/dev/null); do
+                echo ">> $(docker inspect --format '{{.Name}}' "$ctr" 2>/dev/null)"
+                docker logs --tail 10 "$ctr" 2>&1 || true
+            done
+            echo "--- dmesg (last 20 lines) ---"
+            dmesg | tail -20 2>/dev/null || true
+            echo "=== END DIAGNOSTIC DUMP ==="
+        } >> "$UNIFIED_LOG" 2>/dev/null || true
+
         echo "" > /dev/tty1 2>/dev/null || true
         echo "  --- Installation FAILED (module: $CURRENT_MODULE) ---" > /dev/tty1 2>/dev/null || true
         echo "  Check log: $UNIFIED_LOG" > /dev/tty1 2>/dev/null || true
@@ -400,24 +421,23 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
 
     local_healthy=false
-    for attempt in $(seq 1 12); do
-        local_total=$(docker compose -f "$SERVER_DIR/docker-compose.yml" ps -q 2>/dev/null | wc -l)
-        local_running=$(docker compose -f "$SERVER_DIR/docker-compose.yml" ps --format '{{.State}}' 2>/dev/null | grep -c '^running' || true)
-        if [[ "$local_running" -eq 0 ]] && [[ "$local_total" -gt 0 ]]; then
-            local_running=$(docker compose -f "$SERVER_DIR/docker-compose.yml" ps 2>/dev/null | grep -c ' Up ' || true)
-        fi
-        if [[ "$local_total" -ge 6 ]] && [[ "$local_running" -eq "$local_total" ]]; then
-            log_info "All $local_total server containers running"
+    local_compose=(-f "$SERVER_DIR/docker-compose.yml")
+    local_total=$(docker compose "${local_compose[@]}" config --services 2>/dev/null | wc -l)
+    for attempt in $(seq 1 18); do
+        local_up=$(docker compose "${local_compose[@]}" ps --status running -q 2>/dev/null | wc -l)
+        local_health=$(docker compose "${local_compose[@]}" ps --status healthy -q 2>/dev/null | wc -l)
+        if [[ "$local_up" -ge "$local_total" ]] || [[ "$local_health" -ge "$local_total" ]]; then
+            log_info "All $local_total server containers healthy"
             local_healthy=true
             break
         fi
-        log_info "Attempt $attempt/12: $local_running/$local_total running..."
+        log_info "Attempt $attempt/18: $local_up running, $local_health healthy (need $local_total)..."
         sleep 10
     done
 
     if [[ "$local_healthy" == "false" ]]; then
-        log_warn "Not all server containers healthy after 2 minutes"
-        docker ps --format '{{.Names}}\t{{.Status}}' | while read -r line; do
+        log_warn "Not all server containers healthy after 3 minutes"
+        docker compose "${local_compose[@]}" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
             log_warn "  $line"
         done
     fi
@@ -481,7 +501,32 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     [[ "$ENABLE_READONLY" != "true" ]] && setup_args+=(--no-readonly)
     [[ -n "$CONFIG_FILE" ]] && setup_args+=("$CONFIG_FILE")
 
-    if ! bash scripts/setup.sh "${setup_args[@]}" >> "$UNIFIED_LOG" 2>&1; then
+    # Run setup.sh — parse output through unified logger (same as deploy.sh)
+    set +eo pipefail
+    bash scripts/setup.sh "${setup_args[@]}" 2>&1 | while IFS= read -r line; do
+        if [[ "$VERBOSE_INSTALL" == "true" ]]; then
+            log_msg INFO setup "${line:0:200}"
+        else
+            case "$line" in
+                *"[INFO] "*|*"[OK] "*|*"==> "*)
+                    local_msg="${line#*] }"
+                    local_msg="${local_msg#==> }"
+                    log_msg INFO setup "$local_msg"
+                    ;;
+                *ERROR*|*FAIL*|*WARNING*)
+                    log_msg WARN setup "$line"
+                    ;;
+                "Hardware profile:"*|"Detected:"*|"Setup Complete"*|\
+                "Audio HAT:"*|"Configuration Summary:"*|"  - "*)
+                    log_msg INFO setup "$line"
+                    ;;
+            esac
+        fi
+    done
+    setup_rc=${PIPESTATUS[0]}
+    set -eo pipefail
+
+    if [[ "$setup_rc" -ne 0 ]]; then
         log_error "Client setup failed"
         log_error "Troubleshoot: sudo cat $UNIFIED_LOG | tail -50"
         exit 1
@@ -492,12 +537,23 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     set_module "verify-client"
     next_step "Verifying client..."
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
-    sleep 5
-    local_client_count=$(docker ps --format '{{.Names}}' | grep -c "snapclient" || true)
-    if [[ "$local_client_count" -ge 1 ]]; then
-        log_info "Client container running"
-    else
-        log_warn "snapclient container not running"
+    local_client_healthy=false
+    local_client_compose=(-f "$CLIENT_DIR/docker-compose.yml")
+    for attempt in $(seq 1 12); do
+        local_running=$(docker compose "${local_client_compose[@]}" ps --status running -q 2>/dev/null | wc -l)
+        local_healthy=$(docker compose "${local_client_compose[@]}" ps --status healthy -q 2>/dev/null | wc -l)
+        if [[ "$local_running" -ge 1 ]] || [[ "$local_healthy" -ge 1 ]]; then
+            log_info "Client container running"
+            local_client_healthy=true
+            break
+        fi
+        sleep 5
+    done
+    if [[ "$local_client_healthy" == "false" ]]; then
+        log_warn "snapclient not running after 60s"
+        docker compose -f "$CLIENT_DIR/docker-compose.yml" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
+            log_warn "  $line"
+        done
     fi
 fi
 
@@ -515,9 +571,9 @@ else
     if declare -F _wait_for_apt_lock &>/dev/null; then
         _wait_for_apt_lock
     fi
-    if ! apt-get update >> "$UNIFIED_LOG" 2>&1; then
+    if ! apt-get update >>"$UNIFIED_LOG" 2>&1; then
         log_warn "Final apt-get update failed (non-fatal)"
-    elif ! apt-get upgrade -y >> "$UNIFIED_LOG" 2>&1; then
+    elif ! apt-get upgrade -y >>"$UNIFIED_LOG" 2>&1; then
         log_warn "Final apt upgrade failed (non-fatal)"
     else
         log_info "Final package refresh complete"
@@ -577,6 +633,8 @@ IP_ADDR=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '/src/{for(i=1;i<=NF;i++) if
 # (log_info only writes to log + PROGRESS_LOG, not tty1 — use direct echo)
 _tty() { echo "$*" > /dev/tty1 2>/dev/null || true; log_info "$*"; }
 
+_elapsed="$((SECONDS / 60))m$((SECONDS % 60))s"
+log_info "Installation completed in $_elapsed"
 _tty ""
 _tty "  +--------------------------------------------+"
 _tty "  |       Installation complete!               |"

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -25,9 +25,13 @@ check_client_submodule() {
     # .git is a file (gitlink) in submodules, a directory in standalone clones
     if [[ ! -d "$CLIENT_DIR/.git" ]] && [[ ! -f "$CLIENT_DIR/.git" ]]; then
         echo "Client submodule not initialized. Fetching..."
-        git -C "$PROJECT_DIR" submodule update --init --recursive
+        if ! git -C "$PROJECT_DIR" submodule update --init --recursive; then
+            echo "ERROR: Failed to fetch client submodule (check network connection)"
+            echo "  Run manually: git submodule update --init --recursive"
+            exit 1
+        fi
         if [[ ! -d "$CLIENT_DIR/.git" ]] && [[ ! -f "$CLIENT_DIR/.git" ]]; then
-            echo "ERROR: client/ submodule is missing."
+            echo "ERROR: client/ submodule still missing after fetch"
             echo "  Run: git submodule update --init --recursive"
             exit 1
         fi
@@ -532,7 +536,11 @@ SETUP_VIDEO="video=HDMI-A-1:800x600@60"
 if [[ -f "$CMDLINE" ]] && ! grep -qF "video=HDMI-A-1:" "$CMDLINE"; then
     sed -i.bak "1s/$/ $SETUP_VIDEO/" "$CMDLINE"
     rm -f "${CMDLINE}.bak"
-    echo "  Set temporary setup resolution (800x600) in cmdline.txt"
+    if grep -qF "$SETUP_VIDEO" "$CMDLINE"; then
+        echo "  Set temporary setup resolution (800x600) in cmdline.txt"
+    else
+        echo "  WARNING: Failed to patch cmdline.txt — display may not work during install"
+    fi
 fi
 
 # ── Patch boot scripts ────────────────────────────────────────────
@@ -562,7 +570,12 @@ if [[ -f "$FIRSTRUN" ]]; then
 ' "$FIRSTRUN"
             rm -f "${FIRSTRUN}.bak"
         fi
-        echo "  firstrun.sh patched."
+        if grep -qF "snapmulti/firstboot.sh" "$FIRSTRUN"; then
+            echo "  firstrun.sh patched."
+        else
+            echo "  ERROR: firstrun.sh patch failed — auto-install will NOT run on first boot"
+            exit 1
+        fi
     fi
 elif [[ -f "$USERDATA" ]]; then
     # Modern Pi Imager (Bookworm+): boot partition is /boot/firmware
@@ -583,7 +596,12 @@ $RUNCMD_ENTRY" "$USERDATA"
             # Add runcmd section
             printf '\nruncmd:\n%s\n' "$RUNCMD_ENTRY" >> "$USERDATA"
         fi
-        echo "  user-data patched."
+        if grep -qF "snapmulti/firstboot.sh" "$USERDATA"; then
+            echo "  user-data patched."
+        else
+            echo "  ERROR: user-data patch failed — auto-install will NOT run on first boot"
+            exit 1
+        fi
     fi
 else
     echo ""


### PR DESCRIPTION
## Summary
Cherry-pick of install hardening from develop (#206, #207, #208) to main.

**PR #206** — Logging, health checks, disk pre-flight:
- setup.sh output filtered through unified logger
- Health checks use `--status healthy/running` instead of grep -c
- Disk space pre-flight, image prune, temp file cleanup
- Diagnostic dump on failure, sed validation in prepare-sd.sh

**PR #207** — Validation:
- Apt lock: SECONDS-based 5-min deadline
- Port availability check before docker compose up
- Docker Compose v2+ version check
- Hostname sanitization (RFC 1123 max 253 chars)

**PR #208** — Resilience:
- Install checkpoints (deps, docker, deploy, setup) for resume on retry
- Apt lock timeout in install-deps.sh

Companion: lollonet/snapclient-pi#146

After both merge: merge main → develop to maintain superset.

## Test plan
- [ ] Fresh install from main: verify all hardening active
- [ ] Kill mid-install, retry: verify checkpoint resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)