### PR TITLE
fix: restore badaix/snapcast on main (santcasp leaked via merge)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Get latest snapcast commit SHA
         id: snapcast
         run: |
-          SHA=$(git ls-remote https://github.com/lollonet/santcasp.git refs/heads/develop | cut -f1)
+          SHA=$(git ls-remote https://github.com/badaix/snapcast.git HEAD | cut -f1)
           if [[ -z "$SHA" ]]; then
             echo "ERROR: Failed to fetch snapcast HEAD commit"
             exit 1

--- a/Dockerfile.snapserver
+++ b/Dockerfile.snapserver
@@ -18,11 +18,10 @@ RUN --mount=type=cache,target=/var/cache/apk \
     soxr-dev
 
 WORKDIR /build
-# Build from santcasp fork (snapcast + IPDV jitter measurement)
-# Pin to develop branch — tracks lollonet/santcasp which is
-# upstream v0.35.0 + IPDV patches
-ARG SNAPCAST_REPO=https://github.com/lollonet/santcasp.git
-ARG SNAPCAST_BRANCH=develop
+# Build from upstream badaix/snapcast.
+# develop branch overrides SNAPCAST_REPO to lollonet/santcasp fork.
+ARG SNAPCAST_REPO=https://github.com/badaix/snapcast.git
+ARG SNAPCAST_BRANCH=master
 ARG SNAPCAST_SHA=latest
 RUN git clone --branch "$SNAPCAST_BRANCH" "$SNAPCAST_REPO" . && \
     mkdir build && cd build && \


### PR DESCRIPTION
## Summary
santcasp fork was accidentally brought to main during the modular firstboot merge. This restores:

- **main** → `badaix/snapcast` (upstream vanilla)
- **develop** → `lollonet/santcasp` (fork with IPDV jitter)

Changes:
- `Dockerfile.snapserver`: `SNAPCAST_REPO` → `badaix/snapcast.git`, branch → `master`
- `build-push.yml`: cache buster fetches `badaix/snapcast` SHA

Companion: lollonet/snapclient-pi#147

After both merge: reset develop onto main + santcasp commit → develop is 1 commit ahead.

## Test plan
- [ ] CI builds snapserver with badaix/snapcast
- [ ] `:latest` images use upstream snapcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)