### PR TITLE
feat: single-branch CI — santcasp via workflow_dispatch

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -64,9 +64,9 @@ jobs:
             REPO="https://github.com/badaix/snapcast.git"
             BRANCH="master"
           fi
-          SHA=$(git ls-remote "$REPO" HEAD | cut -f1)
+          SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH" | cut -f1)
           if [[ -z "$SHA" ]]; then
-            echo "ERROR: Failed to fetch snapcast HEAD from $REPO"
+            echo "ERROR: Failed to fetch $BRANCH from $REPO"
             exit 1
           fi
           echo "repo=$REPO" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -34,13 +34,15 @@ jobs:
 
       - name: Determine image label
         id: version
+        env:
+          USE_SANTCASP: ${{ inputs.use_santcasp }}
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             # Tagged release: push :latest + :version (badaix/snapcast)
             VERSION="${GITHUB_REF#refs/tags/v}"
             echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
             echo "label=latest" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
+          elif [[ "$USE_SANTCASP" == "true" ]]; then
             # Manual dispatch with santcasp: push :dev (santcasp fork)
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "label=dev" >> "$GITHUB_OUTPUT"
@@ -52,8 +54,10 @@ jobs:
 
       - name: Determine snapcast source
         id: snapcast
+        env:
+          USE_SANTCASP: ${{ inputs.use_santcasp }}
         run: |
-          if [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
+          if [[ "$USE_SANTCASP" == "true" ]]; then
             REPO="https://github.com/lollonet/santcasp.git"
             BRANCH="develop"
           else
@@ -163,12 +167,14 @@ jobs:
     steps:
       - name: Determine image label
         id: version
+        env:
+          USE_SANTCASP: ${{ inputs.use_santcasp }}
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
             echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
             echo "label=latest" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
+          elif [[ "$USE_SANTCASP" == "true" ]]; then
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "label=dev" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -3,8 +3,13 @@ name: Build and Push Images
 on:
   push:
     tags: ['v*']
-    branches: [develop]
   workflow_dispatch:
+    inputs:
+      use_santcasp:
+        description: 'Build :dev images from santcasp fork'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -31,19 +36,39 @@ jobs:
         id: version
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            # Tagged release: push :latest + :version
+            # Tagged release: push :latest + :version (badaix/snapcast)
             VERSION="${GITHUB_REF#refs/tags/v}"
             echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
             echo "label=latest" >> "$GITHUB_OUTPUT"
-          elif [[ "$GITHUB_REF" == refs/heads/develop ]]; then
-            # Develop branch: push :dev only
+          elif [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
+            # Manual dispatch with santcasp: push :dev (santcasp fork)
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "label=dev" >> "$GITHUB_OUTPUT"
           else
-            # Manual dispatch: push :manual (avoid empty tag)
+            # Manual dispatch without santcasp: push :manual (badaix)
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "label=manual" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Determine snapcast source
+        id: snapcast
+        run: |
+          if [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
+            REPO="https://github.com/lollonet/santcasp.git"
+            BRANCH="develop"
+          else
+            REPO="https://github.com/badaix/snapcast.git"
+            BRANCH="master"
+          fi
+          SHA=$(git ls-remote "$REPO" HEAD | cut -f1)
+          if [[ -z "$SHA" ]]; then
+            echo "ERROR: Failed to fetch snapcast HEAD from $REPO"
+            exit 1
+          fi
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "snapcast: $REPO ($BRANCH) SHA: $SHA"
 
       # docker driver on Mac: inherits host credentials, no isolated BuildKit container
       # docker-container on Linux: supports GHA cache export
@@ -58,17 +83,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Get latest snapcast commit SHA
-        id: snapcast
-        run: |
-          SHA=$(git ls-remote https://github.com/badaix/snapcast.git HEAD | cut -f1)
-          if [[ -z "$SHA" ]]; then
-            echo "ERROR: Failed to fetch snapcast HEAD commit"
-            exit 1
-          fi
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "snapcast HEAD: $SHA"
-
       - name: Build and push snapserver
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -77,6 +91,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           build-args: |
+            SNAPCAST_REPO=${{ steps.snapcast.outputs.repo }}
+            SNAPCAST_BRANCH=${{ steps.snapcast.outputs.branch }}
             SNAPCAST_SHA=${{ steps.snapcast.outputs.sha }}
           tags: |
             lollonet/snapmulti-server:${{ steps.version.outputs.label }}-${{ matrix.suffix }}
@@ -149,16 +165,13 @@ jobs:
         id: version
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            # Tagged release: push :latest + :version
             VERSION="${GITHUB_REF#refs/tags/v}"
             echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
             echo "label=latest" >> "$GITHUB_OUTPUT"
-          elif [[ "$GITHUB_REF" == refs/heads/develop ]]; then
-            # Develop branch: push :dev only
+          elif [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "label=dev" >> "$GITHUB_OUTPUT"
           else
-            # Manual dispatch: push :manual (avoid empty tag)
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "label=manual" >> "$GITHUB_OUTPUT"
           fi
@@ -194,4 +207,3 @@ jobs:
                 "lollonet/$image:$VERSION-arm64"
             done
           fi
-

--- a/Dockerfile.snapserver
+++ b/Dockerfile.snapserver
@@ -18,8 +18,8 @@ RUN --mount=type=cache,target=/var/cache/apk \
     soxr-dev
 
 WORKDIR /build
-# Build from upstream badaix/snapcast.
-# develop branch overrides SNAPCAST_REPO to lollonet/santcasp fork.
+# Build from upstream badaix/snapcast (default).
+# CI passes SNAPCAST_REPO=santcasp via workflow_dispatch for :dev builds.
 ARG SNAPCAST_REPO=https://github.com/badaix/snapcast.git
 ARG SNAPCAST_BRANCH=master
 ARG SNAPCAST_SHA=latest


### PR DESCRIPTION
## Summary
Eliminates the develop branch dependency for CI. `:dev` images (santcasp) are now built on-demand via `workflow_dispatch` with `use_santcasp` checkbox.

- `build-push.yml`: remove `branches: [develop]` trigger, add `workflow_dispatch` input
- Snapcast source (repo + branch + SHA) passed as build-args conditionally
- Tag push → `:latest` (badaix default). Manual dispatch + santcasp → `:dev`

Companion: lollonet/snapclient-pi#148

After both merge: delete develop branches, then merge client repo into server (monorepo).

## Test plan
- [ ] Tag push: verify `:latest` built from badaix
- [ ] workflow_dispatch with santcasp: verify `:dev` built from santcasp
- [ ] workflow_dispatch without santcasp: verify `:manual` built from badaix

🤖 Generated with [Claude Code](https://claude.com/claude-code)