### PR TITLE
docs: sync all docs with current code (council v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Dynamic tmpfs sizing** ([#221](https://github.com/lollonet/snapMULTI/pull/221)) — overlayroot tmpfs sized to 25% of RAM (floor 256MB, cap 2048MB) with monitoring at 70%/90% thresholds
+
+### Fixed
+- **Health check logic** ([#220](https://github.com/lollonet/snapMULTY/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)
+- **fuse-overlayfs broken binary** ([#220](https://github.com/lollonet/snapMULTY/pull/220)) — setup-docker.sh now returns error (was silently succeeding)
+- **Shell injection in _image_exists** ([#219](https://github.com/lollonet/snapMULTY/pull/219)) — pass service name via env var instead of string interpolation
+
+## [0.4.1] — 2026-04-13
+
+### Fixed
+- **EXIT trap clobber** — pull-images.sh uses RETURN trap only (not EXIT) to avoid clobbering caller's _setup_failure_dump trap. Fixed unbound variable crash on v0.4.0
+
+## [0.4.0] — 2026-04-13
+
+### Added
 - **Diagnostic log persistence** — saves dmesg audio errors, docker logs, ALSA state, and system health to boot partition every 30 minutes. Survives overlayroot reboots. Keeps last 3 snapshots at `/boot/firmware/diagnostics/`
 - **Pi Zero 2 W support** — documented in HARDWARE.md (64-bit required, 2.4 GHz only, headless audio)
 - **Install checkpoints** — per-phase markers (deps, docker, deploy, setup) enable resume after power loss or crash without full reinstall
@@ -16,15 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docker Compose v2+ enforcement** — validates version at startup with actionable error
 - **Diagnostic dump on failure** — trap collects memory, disk, docker status, and dmesg into install log
 - **Install duration logging** — total elapsed time shown at completion
+- **Shared modules** ([#217](https://github.com/lollonet/snapMULTI/pull/217)) — extracted `pull-images.sh` and `resource-detect.sh` from setup.sh/deploy.sh
+- **Skip existing images** ([#218](https://github.com/lollonet/snapMULTI/pull/218)) — pull-images.sh skips already-pulled images, detects Docker Hub rate limit (429)
 
 ### Changed
-- **Monorepo** — merged `snapclient-pi` into `snapMULTI` as `client/` directory (was git submodule). One repo, one branch, one CI pipeline
-- **Single-branch CI** — develop branch eliminated; `:dev` images (santcasp fork) built on-demand via `workflow_dispatch` checkbox
+- **Monorepo** ([#212](https://github.com/lollonet/snapMULTI/pull/212)) — merged `snapclient-pi` into `snapMULTI` as `client/` directory (was git submodule). One repo, one branch, one CI pipeline
+- **Single-branch CI** ([#211](https://github.com/lollonet/snapMULTI/pull/211)) — develop branch eliminated; `:dev` images (santcasp fork) built on-demand via `workflow_dispatch` checkbox
+- **Snapcast pinned to v0.35.0** — stable release, no longer tracking develop branch
 - **Modular firstboot** — rewritten as orchestrator with 4 extracted modules (unified-log, mount-music, install-docker, readonly-fs)
 - **Silent Docker pulls** — progress output suppressed on success, surfaced on failure (fixes 500+ line log spam from Docker Compose v5)
 - **Unified logging for setup.sh** — output filtered through unified logger instead of raw dump to install log
+- **Unified version format** — always `v0.x.x` (no more stripping `v` prefix)
 
 ### Fixed
+- **badaix/snapcast restored on main** ([#210](https://github.com/lollonet/snapMULTI/pull/210)) — santcasp fork accidentally leaked via merge; reverted
 - **IMAGE_TAG not persisted** — `deploy.sh` now writes `IMAGE_TAG` to `.env` (previously lost after reboot)
 - **LOG_SOURCE not reset** — module calls no longer leak source labels into subsequent log lines
 - **--no-readonly flag** — positioned before positional config file argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dynamic tmpfs sizing** ([#221](https://github.com/lollonet/snapMULTI/pull/221)) — overlayroot tmpfs sized to 25% of RAM (floor 256MB, cap 2048MB) with monitoring at 70%/90% thresholds
 
 ### Fixed
-- **Health check logic** ([#220](https://github.com/lollonet/snapMULTY/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)
-- **fuse-overlayfs broken binary** ([#220](https://github.com/lollonet/snapMULTY/pull/220)) — setup-docker.sh now returns error (was silently succeeding)
-- **Shell injection in _image_exists** ([#219](https://github.com/lollonet/snapMULTY/pull/219)) — pass service name via env var instead of string interpolation
+- **Health check logic** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)
+- **fuse-overlayfs broken binary** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — setup-docker.sh now returns error (was silently succeeding)
+- **Shell injection in _image_exists** ([#219](https://github.com/lollonet/snapMULTI/pull/219)) — pass service name via env var instead of string interpolation
 
 ## [0.4.1] — 2026-04-13
 
@@ -159,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Shared system-tune.sh** ([#147](https://github.com/lollonet/snapMULTI/pull/147)) — shared system tuning module eliminates configuration drift between server and client (CPU governor, USB autosuspend, WiFi power save, Docker daemon.json)
 - **apt upgrade on first boot** ([#147](https://github.com/lollonet/snapMULTI/pull/147)) — security patches applied during first boot, before overlayroot freezes the filesystem
-- **USB drive auto-mount** ([#147](https://github.com/lollonet/snapMULTY/pull/147)) — headless Debian doesn't auto-mount USB; firstboot.sh now mounts and adds fstab entry
+- **USB drive auto-mount** ([#147](https://github.com/lollonet/snapMULTI/pull/147)) — headless Debian doesn't auto-mount USB; firstboot.sh now mounts and adds fstab entry
 - **INSTALL.it.md** — Italian translation of installation guide
 
 ### Fixed
@@ -379,7 +379,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Source numbering in snapserver.conf** — Commented-out example sources were numbered 6–9 instead of 5–8, mismatching `docs/SOURCES.md`
 - **Shell option restoration in deploy.sh** — `$old_nullglob` changed to `eval "$old_nullglob"` for proper `shopt` state restoration in `detect_music_library()`
 - **Metadata-service socket leak** ([#87](https://github.com/lollonet/snapMULTI/pull/87)) — Fixed file descriptor leak in `_create_socket()` when `connect()` fails; socket is now closed in the error path
-- **Metadata-service poll loop resilience** ([#87](https://github.com/lollonet/snapMULTY/pull/87)) — Added consecutive error counter (30 threshold) to `poll_loop()` so the service exits instead of spinning forever on persistent failures; Docker's restart policy then recovers it
+- **Metadata-service poll loop resilience** ([#87](https://github.com/lollonet/snapMULTI/pull/87)) — Added consecutive error counter (30 threshold) to `poll_loop()` so the service exits instead of spinning forever on persistent failures; Docker's restart policy then recovers it
 
 ### Security
 - **Container vulnerability scanning** ([#36](https://github.com/lollonet/snapMULTI/issues/36)) — [Trivy](https://trivy.dev/) scans all Docker images for CRITICAL and HIGH CVEs. Results uploaded to GitHub Security tab (SARIF). Runs after every image build, weekly on Monday, and on manual dispatch
@@ -388,8 +388,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Maintenance
 - **CI: all workflows on self-hosted runner** — Claude Code Review and Claude Code helper workflows moved from `ubuntu-latest` to `snapcast-runner` for consistent CI environment
-- **CI: actions/setup-python 5.6.0 → 6.2.0** ([#81](https://github.com/lollonet/snapMULTY/pull/81)) — Node.js 22 runtime, improved caching
-- **Snapweb builder: Node 22 → Node 24 LTS** ([#85](https://github.com/lollonet/snapMULTY/pull/85)) — Active LTS (Oct 2025–Apr 2028), same Alpine base
+- **CI: actions/setup-python 5.6.0 → 6.2.0** ([#81](https://github.com/lollonet/snapMULTI/pull/81)) — Node.js 22 runtime, improved caching
+- **Snapweb builder: Node 22 → Node 24 LTS** ([#85](https://github.com/lollonet/snapMULTI/pull/85)) — Active LTS (Oct 2025–Apr 2028), same Alpine base
 
 ## [0.2.0] — 2026-02-19
 

--- a/README.it.md
+++ b/README.it.md
@@ -67,6 +67,8 @@ git clone https://github.com/lollonet/snapMULTI.git
 
 **Su Windows (PowerShell):**
 ```powershell
+# Richiede Git per Windows: https://git-scm.com/download/win
+Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
 git clone https://github.com/lollonet/snapMULTI.git
 .\snapMULTI\scripts\prepare-sd.ps1
 ```

--- a/client/CONTRIBUTING.md
+++ b/client/CONTRIBUTING.md
@@ -1,20 +1,21 @@
-# Contributing to snapclient-pi
+# Contributing to snapMULTI Client
+
+> The client lives at `client/` in the [snapMULTI](https://github.com/lollonet/snapMULTI) monorepo.
 
 ## Quick Start
 
-1. Fork and clone the repo
+1. Fork and clone the monorepo: `git clone git@github.com:lollonet/snapMULTI.git`
 2. Create a feature branch: `git checkout -b feature/my-change`
 3. Make changes, commit with [Conventional Commits](https://www.conventionalcommits.org/)
-4. Push and open a PR
+4. Push and open a PR against `main`
 
 ## Development
 
 ```bash
-# Run pre-push checks locally
-./dev/git-hooks/pre-push
-
 # Run tests
-pytest tests/ -v
+bash client/tests/test_resource_profiles.sh
+bash client/tests/test_pull_hardening.sh
+bash client/tests/test_hat_configs.sh
 ```
 
 ## Code Style
@@ -26,7 +27,7 @@ pytest tests/ -v
 
 ## Architecture
 
-snapclient-pi is part of the [snapMULTI](https://github.com/lollonet/snapMULTI) project. See `CLAUDE.md` for detailed conventions.
+The client is part of the [snapMULTI](https://github.com/lollonet/snapMULTI) monorepo. See `CLAUDE.md` for detailed conventions.
 
 ## Reporting Issues
 

--- a/client/QUICKSTART.md
+++ b/client/QUICKSTART.md
@@ -40,11 +40,11 @@ See the [Supported Audio HATs](README.md#supported-audio-hats) table in the READ
 
 ## Step 3: Copy Project Files
 
-From your computer, clone the repo and copy files to the Pi:
+From your computer, clone the monorepo and copy client files to the Pi:
 
 ```bash
 git clone https://github.com/lollonet/snapMULTI.git
-scp -r snapMULTI/client <username>@<hostname>.local:/home/<username>/snapclient-pi
+scp -r snapMULTI/client <username>@<hostname>.local:/home/<username>/snapclient
 ```
 
 Then SSH into the Pi:
@@ -58,7 +58,7 @@ ssh <username>@<hostname>.local
 On the Raspberry Pi:
 
 ```bash
-cd ~/snapclient-pi
+cd ~/snapclient
 sudo bash common/scripts/setup.sh
 ```
 

--- a/client/README.md
+++ b/client/README.md
@@ -132,7 +132,7 @@ The setup script installs Docker CE, automatically configures your audio HAT and
 ## Project Structure
 
 ```
-snapclient-pi/
+client/                           # Part of the snapMULTI monorepo
 ├── install/
 │   └── snapclient.conf         # Config defaults (AUDIO_HAT=auto)
 │
@@ -145,18 +145,13 @@ snapclient-pi/
 │   │   └── ro-mode.sh          # Read-only filesystem management
 │   ├── docker-compose.yml      # Docker services (snapclient, visualizer, fb-display)
 │   ├── .env.example            # Environment template
-│   ├── audio-hats/             # Audio HAT configurations (16 files)
+│   ├── audio-hats/             # Audio HAT configurations (17 files)
 │   └── docker/
 │       ├── snapclient/         # Snapclient Docker image
 │       ├── audio-visualizer/   # Spectrum analyzer (dBFS)
 │       └── fb-display/         # Framebuffer display renderer
 │
-├── dev/                        # Development tooling
-│   └── install-hooks.sh        # Git hooks installer
-│
-├── tests/                      # Test and validation scripts
-│
-└── .github/workflows/          # CI/CD pipelines
+└── tests/                      # Test and validation scripts
 ```
 
 > **Note**: This is the `client/` directory of the [snapMULTI](https://github.com/lollonet/snapMULTI) monorepo. The server's `prepare-sd.sh` copies the necessary files to the SD card; the server's `firstboot.sh` runs `setup.sh --auto` during first boot.

--- a/client/SECURITY.md
+++ b/client/SECURITY.md
@@ -9,7 +9,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in snapclient-pi, please report it responsibly:
+If you discover a security vulnerability in the snapMULTI client, please report it responsibly:
 
 1. **Do NOT open a public GitHub issue**
 2. Use [GitHub Security Advisories](https://github.com/lollonet/snapMULTI/security/advisories/new)
@@ -20,15 +20,13 @@ We will acknowledge receipt within 48 hours and aim to release a fix within 7 da
 ## Scope
 
 This policy covers:
-- The snapclient-pi project (`lollonet/snapclient-pi`)
+- The snapMULTI client (lives at `client/` in the [snapMULTI](https://github.com/lollonet/snapMULTI) monorepo)
 - Docker images published under `lollonet/snapclient-pi*`
 - Install scripts (`setup.sh`, `discover-server.sh`, `display-detect.sh`)
 
-For server-side issues, report to [snapMULTI](https://github.com/lollonet/snapMULTI/security/advisories/new).
-
 ## Security Model
 
-snapclient-pi runs on home networks behind a firewall:
+The snapMULTI client runs on home networks behind a firewall:
 
 - **Containers**: `cap_drop: ALL`, `read_only: true`, `no-new-privileges`
 - **Network**: Host networking for low-latency audio; not designed for public-facing deployment

--- a/client/SECURITY.md
+++ b/client/SECURITY.md
@@ -21,7 +21,7 @@ We will acknowledge receipt within 48 hours and aim to release a fix within 7 da
 
 This policy covers:
 - The snapMULTI client (lives at `client/` in the [snapMULTI](https://github.com/lollonet/snapMULTI) monorepo)
-- Docker images published under `lollonet/snapclient-pi*`
+- Docker images published under `lollonet/snapclient-pi-*`
 - Install scripts (`setup.sh`, `discover-server.sh`, `display-detect.sh`)
 
 ## Security Model

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -331,7 +331,8 @@ Queste combinazioni hardware sono state verificate in installazioni reali:
 | Pi 4 | HiFiBerry Digi+ | Server + Client | NFS, USB | Funzionante |
 | Pi 4 | InnoMaker DAC | Client | — | Funzionante |
 | Pi 4 | Nessuno (HDMI/3.5mm) | Server | NFS, USB | Funzionante |
-| Pi 3 | InnoMaker DAC | Client | — | Funzionante |
+| Pi 4 | Nessuno (HDMI) | Client (headless) | — | Funzionante |
+| Pi 3 | InnoMaker DAC | Client (headless) | — | Funzionante |
 | Pi Zero 2 W | InnoMaker DAC | Client (headless) | — | Funzionante |
 
 ## Limitazioni Note

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -69,6 +69,16 @@ I client Snapcast sono leggeri — ricevono audio e lo riproducono attraverso gl
 | **Vecchio telefono Android** | Gratis | Altoparlante integrato | Batteria | Tramite [app Snapcast Android](https://github.com/badaix/snapdroid) |
 | **Qualsiasi PC Linux** | Varia | Audio integrato | Varia | `apt install snapclient` |
 
+### Note Pi Zero 2 W
+
+Il Pi Zero 2 W è l'opzione client più economica ma ha requisiti specifici:
+
+- **OS 64-bit obbligatorio** — Imager propone 32-bit come predefinito per questo modello. Seleziona esplicitamente "Raspberry Pi OS Lite (64-bit)"
+- **Solo WiFi 2,4 GHz** — niente 5 GHz. Usa il tuo SSID 2,4 GHz quando configuri il WiFi in Imager
+- **512 MB RAM** — solo audio headless (senza display). Non può eseguire fb-display o server
+- **Compatibilità HAT I2S** — funziona con HAT basati su PCM5122 (HiFiBerry DAC+, InnoMaker Mini). L'impostazione USB `otg_mode=1` di Imager interferisce con I2S — `prepare-sd.sh` e `setup.sh` lo correggono automaticamente
+- **Modalità gadget USB** — per debug senza WiFi, collegare la porta USB dati al computer. Richiede `dtoverlay=dwc2` sotto `[all]` in config.txt (non sotto `[cm5]`)
+
 ### Qualità dell'Uscita Audio
 
 | Metodo di Uscita | Qualità | Costo | Note |
@@ -310,6 +320,19 @@ Se un nodo è collegato a un ricevitore AV o sistema home theatre via cavo ottic
 | Server | Intel NUC o mini PC (x86_64) | ~€150+ |
 | Client × 3 | Pi Zero 2 W + HiFiBerry DAC+ Zero + accessori ciascuno | ~€65 × 3 = €195 |
 | Rete | Switch gestito ([TP-Link TL-SG105E](https://www.amazon.it/s?k=tp-link+tl-sg105e)) | ~€25 |
+
+## Combinazioni Testate
+
+Queste combinazioni hardware sono state verificate in installazioni reali:
+
+| Modello Pi | HAT Audio | Modalità | Sorgente Musica | Stato |
+|------------|-----------|----------|----------------|-------|
+| Pi 4 | HiFiBerry DAC+ | Server + Client | NFS, USB | Funzionante |
+| Pi 4 | HiFiBerry Digi+ | Server + Client | NFS, USB | Funzionante |
+| Pi 4 | InnoMaker DAC | Client | — | Funzionante |
+| Pi 4 | Nessuno (HDMI/3.5mm) | Server | NFS, USB | Funzionante |
+| Pi 3 | InnoMaker DAC | Client | — | Funzionante |
+| Pi Zero 2 W | InnoMaker DAC | Client (headless) | — | Funzionante |
 
 ## Limitazioni Note
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -360,7 +360,8 @@ These hardware combinations have been verified in real deployments:
 | Pi 4 | HiFiBerry Digi+ | Server + Client | NFS, USB | Working |
 | Pi 4 | InnoMaker DAC | Client | — | Working |
 | Pi 4 | None (HDMI/3.5mm) | Server | NFS, USB | Working |
-| Pi 3 | InnoMaker DAC | Client | — | Working |
+| Pi 4 | None (HDMI) | Client (headless) | — | Working |
+| Pi 3 | InnoMaker DAC | Client (headless) | — | Working |
 | Pi Zero 2 W | InnoMaker DAC | Client (headless) | — | Working |
 
 ## Known Limitations

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -350,6 +350,19 @@ If a node connects to an AV receiver or home theatre system via optical cable, u
 | Client × 3 | Pi Zero 2 W + HiFiBerry DAC+ Zero + accessories each | ~$67 × 3 = $201 |
 | Network | 5-port managed switch ([TP-Link TL-SG105E](https://www.amazon.com/TP-LINK-TL-SG105E-5-Port-Gigabit-Version/dp/B00N0OHEMA)) | ~$25 |
 
+## Tested Combinations
+
+These hardware combinations have been verified in real deployments:
+
+| Pi Model | Audio HAT | Mode | Music Source | Status |
+|----------|-----------|------|-------------|--------|
+| Pi 4 | HiFiBerry DAC+ | Server + Client | NFS, USB | Working |
+| Pi 4 | HiFiBerry Digi+ | Server + Client | NFS, USB | Working |
+| Pi 4 | InnoMaker DAC | Client | — | Working |
+| Pi 4 | None (HDMI/3.5mm) | Server | NFS, USB | Working |
+| Pi 3 | InnoMaker DAC | Client | — | Working |
+| Pi Zero 2 W | InnoMaker DAC | Client (headless) | — | Working |
+
 ## Known Limitations
 
 | Limitation | Details |

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -359,6 +359,9 @@ Il nuovo speaker appare nell'interfaccia web Snapcast a `http://snapvideo.local:
 | `prepare-sd.sh`: partizione boot non trovata | SD non reinserita dopo Imager | Rimuovi SD, reinserisci, esegui di nuovo lo script |
 | Windows: script non si avvia | Execution policy | Esegui prima `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` |
 | HAT audio non rilevato (client) | Scheda senza EEPROM | Collegati via SSH ed esegui `sudo bash /opt/snapclient/common/scripts/setup.sh` per selezionare il tuo HAT manualmente |
+| `no matching manifest for linux/arm/v7` | OS 32-bit flashato invece del 64-bit | Riflasha con **Raspberry Pi OS Lite (64-bit)** — tutti i modelli Pi incluso Zero 2 W lo supportano |
+| Pi Zero 2 W: WiFi non si connette | SSID 5 GHz configurato ma Pi Zero ha solo 2,4 GHz | Riflasha con il tuo SSID 2,4 GHz nelle impostazioni WiFi di Imager |
+| Pi Zero 2 W: HAT audio non rilevato | `otg_mode=1` o `dr_mode=host` in config.txt | `prepare-sd.sh` lo corregge automaticamente. Per installazioni manuali: commenta `otg_mode=1` e rimuovi `dr_mode=host` dall'overlay dwc2 |
 
 Per problemi post-installazione vedi [Risoluzione problemi in USAGE.it.md](USAGE.it.md#risoluzione-problemi).
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,7 +10,7 @@ This guide takes you from a blank SD card to a working multiroom audio system, s
 
 | Item | Notes |
 |------|-------|
-| Raspberry Pi 4 (2 GB+ RAM) | Pi 5 should work; Pi 3B+ tested (minimal profile) |
+| Raspberry Pi 4 or 5 (2 GB+ RAM) | Pi 5 fully supported; Pi 3B+ tested (minimal profile) |
 | microSD card (16 GB+) | Class 10 / A1 or better. 32 GB recommended |
 | Power supply | Official 15W USB-C for Pi 4 |
 | A second computer | macOS, Linux, or Windows — to prepare the SD card |

--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -163,7 +163,7 @@ Metadati: `tidal-meta-bridge.sh` estrae i metadati dalla TUI tmux di `speaker_co
 | 8000 | HTTP | Stream audio (accesso diretto) |
 
 **Configurazione**: `config/mpd.conf`
-- Output: FIFO verso `/audio/snapcast_fifo`
+- Output: FIFO verso `/audio/mpd_fifo`
 - Directory musicale: `/music` (mappata a `MUSIC_PATH` sull'host)
 - Database: `/data/mpd.db`
 

--- a/docs/standards/WBS.md
+++ b/docs/standards/WBS.md
@@ -142,5 +142,7 @@ source_of_truth: true
 | v0.3.1 | MPD connection resilience | Done |
 | v0.3.2 | First-boot reliability, per-image pull progress | Done |
 | v0.3.3 | Performance optimizations (CPU -73% tidal, -79% metadata) | Done |
-| v0.4.0 | Monitoring & observability (Prometheus, notifications) | Planned |
+| v0.4.0 | Monorepo, single-branch CI, install hardening, shared modules | Done |
+| v0.4.1 | EXIT trap fix, pull-images.sh rate limit detection | Done |
+| v0.5.0 | Monitoring & observability (Prometheus, notifications) | Planned |
 | v1.0.0 | Production ready, community launch | Planned |

--- a/docs/technology/TECH-002.audio.md
+++ b/docs/technology/TECH-002.audio.md
@@ -23,7 +23,7 @@ All audio streams use a consistent format:
 
 | Component | Version | Source |
 |-----------|---------|--------|
-| Snapcast | develop branch | badaix/snapcast upstream (Dockerfile.snapserver builds from latest HEAD) |
+| Snapcast | v0.35.0 (pinned) | badaix/snapcast upstream (Dockerfile.snapserver builds from pinned tag; santcasp fork available via workflow_dispatch) |
 | MPD | 0.24.x | Alpine packages (Dockerfile.mpd) |
 | go-librespot | v0.7.0 | Upstream image (ghcr.io/devgianlu/go-librespot) |
 | Shairport-sync | 4.x | Built from source (Dockerfile.shairport-sync) |

--- a/docs/technology/TECH-003.cicd.md
+++ b/docs/technology/TECH-003.cicd.md
@@ -81,11 +81,9 @@ Native builds on self-hosted runners using Docker buildx with platform emulation
 |--------|------------------|------|------------------|
 | snapmulti-runner | amd64 | raspy (amd64 machine) | `myoung34/github-runner:ubuntu-jammy` |
 | snapmulti-runner-2 | amd64 | raspy (amd64 machine) | `myoung34/github-runner:ubuntu-jammy` |
-| rpi-runner-1 | amd64 | raspy (amd64 machine) | `myoung34/github-runner:ubuntu-jammy` |
-| rpi-runner-2 | amd64 | raspy (amd64 machine) | `myoung34/github-runner:ubuntu-jammy` |
-| snapctrl-runner | amd64 | raspy (amd64 machine) | `myoung34/github-runner:ubuntu-jammy` |
+| mac-arm64-runner | arm64 | Mac (Apple Silicon) | Native (GitHub runner app) |
 
-**Total: 5 runners** running as Docker containers on a single amd64 host. Multi-arch builds use Docker buildx with QEMU platform emulation on the amd64 host.
+**Total: 3 runners** — 2 Docker containers on amd64 host (raspy) + 1 native macOS arm64 runner. Server images build on amd64 runners, client images build natively on Mac arm64 runner.
 
 ## Quality Gates
 


### PR DESCRIPTION
## Summary
14 files updated based on 7-agent council deep audit of documentation accuracy.

### HIGH fixes
- **CHANGELOG.md** — add v0.4.0 and v0.4.1 release entries, PRs #217-220
- **client/ docs** — replace stale snapclient-pi references with monorepo context (SECURITY, CONTRIBUTING, QUICKSTART, README)
- **Italian translations** — sync FIFO path (USAGE.it), Pi Zero 2W notes (HARDWARE.it), troubleshooting rows (INSTALL.it), PowerShell section (README.it)
- **TECH-002** — Snapcast "develop branch" → "v0.35.0 (pinned)"
- **WBS.md** — v0.4.0 status "Planned" → "Done"

### MEDIUM fixes
- **TECH-003** — runner architecture updated (was 5 amd64, now 2 amd64 + 1 mac-arm64)
- **INSTALL.md** — Pi 5 "should work" → "fully supported"
- **HARDWARE.md** + **HARDWARE.it.md** — add tested hardware combinations table

## Test plan
- [x] Pre-push hooks pass (shellcheck, hadolint)
- [x] All changes are documentation only — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)