### PR TITLE
feat: FIFO health monitoring in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Dynamic tmpfs sizing** ([#221](https://github.com/lollonet/snapMULTI/pull/221)) — overlayroot tmpfs sized to 25% of RAM (floor 256MB, cap 2048MB) with monitoring at 70%/90% thresholds
+- **FIFO health monitoring** ([#224](https://github.com/lollonet/snapMULTI/pull/224)) — `save-diagnostics.sh` records pipe status (reader count via `fuser`) and container restart counts to `audio-health.log`
 
 ### Fixed
 - **Health check logic** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)

--- a/scripts/common/save-diagnostics.sh
+++ b/scripts/common/save-diagnostics.sh
@@ -92,7 +92,7 @@ cat /proc/asound/cards > "$SNAPSHOT/asound-cards.log" 2>/dev/null || true
         fi
     done
     echo "=== container restarts ==="
-    docker ps --format '{{.Names}}\t{{.Status}}' 2>/dev/null | while IFS=$'\t' read -r name status; do
+    docker ps --format '{{.Names}}|{{.Status}}' 2>/dev/null | while IFS='|' read -r name status; do
         restarts=$(docker inspect --format '{{.RestartCount}}' "$name" 2>/dev/null) || restarts=0
         [[ "$restarts" -gt 0 ]] && echo "WARNING: $name restarted $restarts times ($status)"
     done

--- a/scripts/common/save-diagnostics.sh
+++ b/scripts/common/save-diagnostics.sh
@@ -76,7 +76,12 @@ cat /proc/asound/cards > "$SNAPSHOT/asound-cards.log" 2>/dev/null || true
 # 8. Audio FIFO health
 {
     echo "=== FIFO status ==="
-    for fifo in /audio/*_fifo; do
+    # FIFOs are in the audio volume — find host path from common locations
+    audio_dir=""
+    for _d in /opt/snapmulti/audio /opt/snapclient/audio; do
+        [[ -d "$_d" ]] && audio_dir="$_d" && break
+    done
+    for fifo in "${audio_dir:-.}"/*_fifo; do
         [[ -e "$fifo" ]] || continue
         name=$(basename "$fifo")
         if [[ -p "$fifo" ]]; then

--- a/scripts/common/save-diagnostics.sh
+++ b/scripts/common/save-diagnostics.sh
@@ -73,7 +73,27 @@ if command -v aplay &>/dev/null; then
 fi
 cat /proc/asound/cards > "$SNAPSHOT/asound-cards.log" 2>/dev/null || true
 
-# 8. System state
+# 8. Audio FIFO health
+{
+    echo "=== FIFO status ==="
+    for fifo in /audio/*_fifo; do
+        [[ -e "$fifo" ]] || continue
+        name=$(basename "$fifo")
+        if [[ -p "$fifo" ]]; then
+            readers=$(fuser "$fifo" 2>/dev/null | wc -w) || readers=0
+            echo "$name: pipe exists, $readers process(es) attached"
+        else
+            echo "$name: NOT A PIPE (type: $(stat -c %F "$fifo" 2>/dev/null || echo unknown))"
+        fi
+    done
+    echo "=== container restarts ==="
+    docker ps --format '{{.Names}}\t{{.Status}}' 2>/dev/null | while IFS=$'\t' read -r name status; do
+        restarts=$(docker inspect --format '{{.RestartCount}}' "$name" 2>/dev/null) || restarts=0
+        [[ "$restarts" -gt 0 ]] && echo "WARNING: $name restarted $restarts times ($status)"
+    done
+} > "$SNAPSHOT/audio-health.log" 2>/dev/null || true
+
+# 9. System state
 {
     echo "=== uptime ==="
     uptime
@@ -92,7 +112,7 @@ cat /proc/asound/cards > "$SNAPSHOT/asound-cards.log" 2>/dev/null || true
     fi
 } > "$SNAPSHOT/system.log" 2>/dev/null || true
 
-# 9. Network state (brief)
+# 10. Network state (brief)
 {
     echo "=== interfaces ==="
     ip -brief addr 2>/dev/null


### PR DESCRIPTION
## Summary
Adds audio pipeline health checks to the periodic diagnostics (every 30min):

- **FIFO status**: checks each `/audio/*_fifo` exists as a pipe and has attached reader processes via `fuser`
- **Container restart detection**: flags containers with non-zero restart counts (catches restart loops)

Output goes to `/boot/firmware/diagnostics/<timestamp>/audio-health.log` — survives overlayroot reboots, accessible by pulling the SD card.

### Example output
```
=== FIFO status ===
mpd_fifo: pipe exists, 2 process(es) attached
spotify_fifo: pipe exists, 2 process(es) attached
airplay_fifo: pipe exists, 1 process(es) attached
tidal_fifo: pipe exists, 1 process(es) attached
=== container restarts ===
WARNING: metadata restarted 3 times (Up 2 hours (healthy))
```

## Test plan
- [x] shellcheck passes
- [ ] Verify on snapvideo: `sudo bash scripts/common/save-diagnostics.sh && cat /boot/firmware/diagnostics/*/audio-health.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)