### PR TITLE
feat: MPD backup timer + reflash extraction script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Dynamic tmpfs sizing** ([#221](https://github.com/lollonet/snapMULTI/pull/221)) — overlayroot tmpfs sized to 25% of RAM (floor 256MB, cap 2048MB) with monitoring at 70%/90% thresholds
 - **FIFO health monitoring** ([#224](https://github.com/lollonet/snapMULTI/pull/224)) — `save-diagnostics.sh` records pipe status (reader count via `fuser`) and container restart counts to `audio-health.log`
+- **MPD backup timer** ([#225](https://github.com/lollonet/snapMULTI/pull/225)) — daily backup of `mpd.db` to boot partition; `backup-from-sd.sh` extracts it before reflashing so MPD does fast incremental scan instead of hours-long rescan
 
 ### Fixed
 - **Health check logic** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)

--- a/README.it.md
+++ b/README.it.md
@@ -202,23 +202,19 @@ Per la risoluzione dettagliata (mDNS, log, diagnostica), vedi [Guida all'Uso](do
 
 ## Aggiornamento
 
-Collegati via SSH al Pi (dal tuo computer: `ssh <username>@<hostname>.local`), poi esegui:
+Il metodo consigliato è il **reflash della scheda SD** — tutta la configurazione è auto-rilevata, quindi una nuova installazione equivale a un aggiornamento.
 
 ```bash
-# Server
-cd /opt/snapmulti
-git pull
-docker compose pull
-docker compose up -d
+# 1. Estrai il database MPD dalla vecchia SD (preserva l'indice della libreria musicale):
+./scripts/backup-from-sd.sh
 
-# Client (se installato — disabilita prima la modalità read-only: sudo ro-mode disable && sudo reboot)
-cd /opt/snapclient
-git pull
-docker compose pull
-docker compose up -d
+# 2. Flasha con Pi Imager, poi:
+./scripts/prepare-sd.sh          # include il database MPD automaticamente
+
+# 3. Inserisci la SD e accendi — pronto in ~10 minuti
 ```
 
-Per aggiornamenti di versioni maggiori, controlla [CHANGELOG.md](CHANGELOG.md) per le modifiche incompatibili. Per dettagli su Watchtower (aggiornamenti automatici) e update.sh (aggiornamenti config), vedi [Guida all'Uso — Aggiornamento](docs/USAGE.it.md#aggiornamento).
+> **Utenti avanzati:** Watchtower (opt-in) e `update.sh` sono disponibili per aggiornamenti in-place via SSH. Vedi [Guida all'Uso — Aggiornamento](docs/USAGE.it.md#aggiornamento).
 
 ## Documentazione
 

--- a/README.md
+++ b/README.md
@@ -202,23 +202,19 @@ For detailed troubleshooting (mDNS, logs, diagnostics), see [Usage Guide](docs/U
 
 ## Upgrading
 
-SSH into your Pi (from your computer: `ssh <username>@<hostname>.local`), then run:
+The recommended update method is **reflashing the SD card** — all configuration is auto-detected, so a fresh install is equivalent to an upgrade.
 
 ```bash
-# Server
-cd /opt/snapmulti
-git pull
-docker compose pull
-docker compose up -d
+# 1. Extract MPD database from old SD card (preserves music library index):
+./scripts/backup-from-sd.sh
 
-# Client (if installed — disable read-only mode first: sudo ro-mode disable && sudo reboot)
-cd /opt/snapclient
-git pull
-docker compose pull
-docker compose up -d
+# 2. Flash with Pi Imager, then:
+./scripts/prepare-sd.sh          # includes MPD database automatically
+
+# 3. Insert SD card and boot — ready in ~10 minutes
 ```
 
-For major version upgrades, check [CHANGELOG.md](CHANGELOG.md) for breaking changes. For details on Watchtower (automatic updates) and update.sh (config updates), see [Usage Guide — Updating](docs/USAGE.md#updating).
+> **Advanced users:** Watchtower (opt-in) and `update.sh` are available for in-place updates via SSH. See [Usage Guide — Updating](docs/USAGE.md#updating).
 
 ## Documentation
 

--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -742,30 +742,43 @@ sudo bash /boot/firmware/snapmulti/firstboot.sh
 
 ## Aggiornamento
 
-snapMULTI ha due meccanismi di aggiornamento: **Watchtower** per aggiornamenti automatici delle immagini Docker e **update.sh** per aggiornamenti di configurazione e script.
+Il metodo consigliato è il **reflash della scheda SD**. snapMULTI è progettato come un elettrodomestico — tutta la configurazione è auto-rilevata, quindi una nuova installazione equivale a un aggiornamento senza rischi di bug da upgrade.
 
-> **Filesystem read-only (installazioni da SD):** Se il tuo Pi usa la modalità read-only (abilitata di default sulle installazioni client), devi disabilitarla prima di aggiornare:
-> ```bash
-> sudo ro-mode disable && sudo reboot
-> ```
-> Dopo l'aggiornamento, riabilita con `sudo ro-mode enable && sudo reboot`.
+### Reflash (Consigliato)
 
-### Aggiornamenti Automatici delle Immagini (Watchtower)
+L'unico dato da preservare tra un reflash e l'altro è il **database musicale MPD** (`mpd.db`). Senza di esso, MPD riscansiona l'intera libreria al primo avvio — operazione che può richiedere ore via NFS.
 
-Aggiornamenti automatici opt-in delle immagini Docker. Watchtower monitora i container in esecuzione e scarica nuove immagini `:latest` secondo una pianificazione.
+Un timer systemd sul Pi esegue automaticamente il backup di `mpd.db` sulla partizione di boot ogni giorno. Prima del reflash:
 
-**Abilitare:**
 ```bash
-# Aggiungi a /opt/snapmulti/.env:
+# 1. Rimuovi la SD dal Pi, inseriscila nel computer
+# 2. Estrai il backup del database MPD:
+./scripts/backup-from-sd.sh
+
+# 3. Flasha con Pi Imager (cancella la SD)
+# 4. Esegui prepare-sd.sh — include mpd.db automaticamente:
+./scripts/prepare-sd.sh
+
+# 5. Inserisci la SD, accendi → MPD scansiona in modo incrementale (secondi, non ore)
+```
+
+`backup-from-sd.sh` rileva automaticamente il punto di mount della SD e salva `mpd.db` nella cartella del progetto dove `prepare-sd.sh` lo trova.
+
+> **Nessun database MPD?** Se è una installazione nuova o usi solo sorgenti streaming (Spotify, AirPlay, Tidal), salta il passo 2 — non c'è nulla da salvare.
+
+### Aggiornamenti Automatici Immagini (Watchtower) — opt-in
+
+Per utenti avanzati che preferiscono aggiornamenti in-place delle immagini Docker senza reflash. Disabilitato di default.
+
+> **Non consigliato per installazioni read-only o client.** Watchtower scarica nuove immagini nello storage Docker. Sui sistemi overlayroot (client, Pi Zero), le immagini sono in tmpfs RAM e si perdono al riavvio. Usa il reflash.
+
+```bash
+# Abilitare: aggiungi a /opt/snapmulti/.env:
 AUTO_UPDATE=true
 
 # Riavvia con il profilo auto-update:
 COMPOSE_PROFILES=auto-update docker compose up -d
 ```
-
-Oppure riesegui `deploy.sh` — rileva `AUTO_UPDATE=true` e aggiunge `auto-update` a `COMPOSE_PROFILES` automaticamente.
-
-**Configurazione** (in `.env`):
 
 | Variabile | Default | Descrizione |
 |-----------|---------|-------------|
@@ -773,55 +786,22 @@ Oppure riesegui `deploy.sh` — rileva `AUTO_UPDATE=true` e aggiunge `auto-updat
 | `UPDATE_SCHEDULE` | `0 0 3 * * *` | Pianificazione cron (default: ogni giorno alle 3:00) |
 | `UPDATE_NOTIFY_URL` | (nessuno) | URL notifiche ([formato shoutrrr](https://containrrr.dev/shoutrrr/)) |
 
-**Cosa viene aggiornato:**
-- `lollonet/snapmulti-server`, `-airplay`, `-mpd`, `-metadata`, `-tidal` (immagini `:latest`)
+**Cosa aggiorna Watchtower:** immagini `lollonet/snapmulti-*` (solo tag `:latest`)
 
-**Cosa NON viene aggiornato:**
-- `go-librespot` (fissato a `v0.7.0`)
-- `mympd` (immagine di terze parti, fissata)
-- File di configurazione, script, docker-compose.yml (usa `update.sh` per quelli)
+**Cosa NON aggiorna:** immagini fissate (go-librespot, mympd), file di configurazione, script
 
-### Aggiornamenti Config e Script (update.sh)
+### Aggiornamenti Config e Script (update.sh) — avanzato
 
-Per aggiornare file di configurazione, script e docker-compose.yml dalle release GitHub. Funziona senza git — progettato per installazioni da SD card.
+Per aggiornare file di configurazione, script e docker-compose.yml dalle release GitHub via SSH. Funziona senza git.
 
 ```bash
 # Controlla aggiornamenti disponibili
 sudo /opt/snapmulti/scripts/update.sh --check
 
-# Applica aggiornamento (interattivo)
+# Applica aggiornamento
 sudo /opt/snapmulti/scripts/update.sh
-
-# Applica aggiornamento (non interattivo, es. da cron)
-sudo /opt/snapmulti/scripts/update.sh --force
 ```
 
 **Cosa viene aggiornato:** `config/`, `scripts/`, `docker-compose.yml`, `Dockerfile.*`, `.env.example`
 
 **Cosa NON viene MAI toccato:** `.env`, `audio/`, `artwork/`, `mpd/`, `mympd/`, `data/`
-
-**Sicurezza:** Rifiuta di attraversare i confini di versione maggiore (es. v0.x → v1.x). Gli aggiornamenti maggiori richiedono intervento manuale.
-
-### Aggiornamento Standard (con git)
-
-Se hai clonato il repo con git:
-
-```bash
-cd /opt/snapmulti
-git pull
-docker compose pull
-docker compose up -d
-```
-
-### Rollback
-
-Se un aggiornamento causa problemi:
-```bash
-# Usa una versione specifica dell'immagine
-docker pull lollonet/snapmulti-server:v0.3.5
-docker compose up -d
-
-# Oppure ripristina la configurazione dal backup
-cp -r config.backup/* config/
-docker compose up -d
-```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -720,30 +720,43 @@ sudo bash /boot/firmware/snapmulti/firstboot.sh
 
 ## Updating
 
-snapMULTI has two update mechanisms: **Watchtower** for automatic Docker image updates and **update.sh** for config/script updates.
+The recommended update method is **reflashing the SD card**. snapMULTI is designed as an appliance — all configuration is auto-detected, so a fresh install is equivalent to an update with zero risk of upgrade-path bugs.
 
-> **Read-only filesystem (SD card installs):** If your Pi uses read-only mode (enabled by default on client installs), you must disable it before updating:
-> ```bash
-> sudo ro-mode disable && sudo reboot
-> ```
-> After updating, re-enable with `sudo ro-mode enable && sudo reboot`.
+### Reflash (Recommended)
 
-### Automatic Image Updates (Watchtower)
+The only data worth preserving across reflashes is the **MPD music database** (`mpd.db`). Without it, MPD rescans your entire music library on first boot — which can take hours over NFS.
 
-Opt-in automatic Docker image updates. Watchtower monitors running containers and pulls new `:latest` images on a schedule.
+A systemd timer on the Pi automatically backs up `mpd.db` to the boot partition daily. Before reflashing:
 
-**Enable:**
 ```bash
-# Add to /opt/snapmulti/.env:
+# 1. Remove SD card from Pi, insert in your computer
+# 2. Extract the MPD database backup:
+./scripts/backup-from-sd.sh
+
+# 3. Flash with Pi Imager (this erases the SD card)
+# 4. Run prepare-sd.sh — it includes mpd.db automatically:
+./scripts/prepare-sd.sh
+
+# 5. Insert SD, boot → MPD scans incrementally (seconds, not hours)
+```
+
+`backup-from-sd.sh` auto-detects the SD card mount point and saves `mpd.db` to the project directory where `prepare-sd.sh` picks it up.
+
+> **No MPD database?** If this is a fresh install or you only use streaming sources (Spotify, AirPlay, Tidal), skip step 2 — there's nothing to back up.
+
+### Automatic Image Updates (Watchtower) — opt-in
+
+For advanced users who prefer in-place Docker image updates without reflashing. Disabled by default.
+
+> **Not recommended for read-only or client installs.** Watchtower pulls new images into Docker storage. On overlayroot systems (clients, Pi Zero), images are stored in RAM tmpfs and lost on reboot. Use reflash instead.
+
+```bash
+# Enable: add to /opt/snapmulti/.env:
 AUTO_UPDATE=true
 
 # Restart with the auto-update profile:
 COMPOSE_PROFILES=auto-update docker compose up -d
 ```
-
-Or re-run `deploy.sh` — it detects `AUTO_UPDATE=true` and adds `auto-update` to `COMPOSE_PROFILES` automatically.
-
-**Configuration** (in `.env`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -751,55 +764,22 @@ Or re-run `deploy.sh` — it detects `AUTO_UPDATE=true` and adds `auto-update` t
 | `UPDATE_SCHEDULE` | `0 0 3 * * *` | Cron schedule (default: daily 3 AM) |
 | `UPDATE_NOTIFY_URL` | (none) | Notification URL ([shoutrrr format](https://containrrr.dev/shoutrrr/)) |
 
-**What gets updated:**
-- `lollonet/snapmulti-server`, `-airplay`, `-mpd`, `-metadata`, `-tidal` (`:latest` images)
+**What Watchtower updates:** `lollonet/snapmulti-*` images (`:latest` tag only)
 
-**What does NOT get updated:**
-- `go-librespot` (pinned to `v0.7.0`)
-- `mympd` (third-party image, pinned)
-- Config files, scripts, docker-compose.yml (use `update.sh` for those)
+**What it does NOT update:** pinned images (go-librespot, mympd), config files, scripts
 
-### Config & Script Updates (update.sh)
+### Config & Script Updates (update.sh) — advanced
 
-For updating config files, scripts, and docker-compose.yml from GitHub releases. Works without git — designed for SD-card installs.
+For updating config files, scripts, and docker-compose.yml from GitHub releases via SSH. Works without git.
 
 ```bash
 # Check for updates
 sudo /opt/snapmulti/scripts/update.sh --check
 
-# Apply update (interactive)
+# Apply update
 sudo /opt/snapmulti/scripts/update.sh
-
-# Apply update (non-interactive, e.g. from cron)
-sudo /opt/snapmulti/scripts/update.sh --force
 ```
 
 **What gets updated:** `config/`, `scripts/`, `docker-compose.yml`, `Dockerfile.*`, `.env.example`
 
 **What is NEVER touched:** `.env`, `audio/`, `artwork/`, `mpd/`, `mympd/`, `data/`
-
-**Safety:** Refuses to cross major version boundaries (e.g., v0.x to v1.x). Major upgrades require manual intervention.
-
-### Standard Update (with git)
-
-If you cloned the repo with git:
-
-```bash
-cd /opt/snapmulti
-git pull
-docker compose pull
-docker compose up -d
-```
-
-### Rollback
-
-If an update breaks things:
-```bash
-# Use a specific image version
-docker pull lollonet/snapmulti-server:v0.3.5
-docker compose up -d
-
-# Or restore config from backup
-cp -r config.backup/* config/
-docker compose up -d
-```

--- a/scripts/backup-from-sd.sh
+++ b/scripts/backup-from-sd.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Extract MPD database backup from an SD card before reflashing.
+#
+# Usage: ./scripts/backup-from-sd.sh [boot-partition-path]
+#
+# The Pi's backup timer copies mpd.db to /boot/firmware/snapmulti-backup/
+# every day. This script reads it from the SD card (mounted on your Mac/PC)
+# and saves it to mpd/data/mpd.db in the project directory, where
+# prepare-sd.sh will pick it up automatically.
+#
+# If no path is given, the script auto-detects common mount points.
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+info()  { echo -e "\033[34m[INFO]\033[0m  $*"; }
+ok()    { echo -e "\033[32m[OK]\033[0m    $*"; }
+warn()  { echo -e "\033[33m[WARN]\033[0m  $*"; }
+error() { echo -e "\033[31m[ERROR]\033[0m $*" >&2; }
+
+# Find boot partition
+find_boot() {
+    local given="$1"
+
+    # User provided a path
+    if [[ -n "$given" ]]; then
+        if [[ -d "$given/snapmulti-backup" ]]; then
+            echo "$given"
+            return 0
+        fi
+        error "No snapmulti-backup/ found on $given"
+        return 1
+    fi
+
+    # Auto-detect common mount points
+    local candidates=(
+        # macOS
+        /Volumes/bootfs
+        /Volumes/boot
+        # Linux
+        /media/*/bootfs
+        /media/*/boot
+        /mnt/bootfs
+        /mnt/boot
+    )
+
+    for pattern in "${candidates[@]}"; do
+        # shellcheck disable=SC2086
+        for candidate in $pattern; do
+            if [[ -d "$candidate/snapmulti-backup" ]]; then
+                echo "$candidate"
+                return 0
+            fi
+        done
+    done
+
+    return 1
+}
+
+main() {
+    local boot_path
+    boot_path=$(find_boot "${1:-}") || {
+        error "Could not find SD card with snapMULTI backup."
+        echo ""
+        echo "Insert the SD card and try again, or specify the boot partition path:"
+        echo "  $0 /Volumes/bootfs"
+        echo ""
+        echo "The Pi backs up mpd.db to the boot partition daily."
+        echo "If this is a fresh SD card, there's nothing to extract."
+        exit 1
+    }
+
+    info "Found backup on: $boot_path"
+
+    local backup_dir="$boot_path/snapmulti-backup"
+    local restored=0
+
+    # MPD database
+    if [[ -f "$backup_dir/mpd/data/mpd.db" ]]; then
+        mkdir -p "$PROJECT_DIR/mpd/data"
+        cp "$backup_dir/mpd/data/mpd.db" "$PROJECT_DIR/mpd/data/mpd.db"
+        local size
+        size=$(du -h "$PROJECT_DIR/mpd/data/mpd.db" | cut -f1)
+        ok "MPD database restored ($size) → mpd/data/mpd.db"
+        restored=$((restored + 1))
+    fi
+
+    # myMPD state
+    if [[ -d "$backup_dir/mympd/state" ]]; then
+        mkdir -p "$PROJECT_DIR/mympd/workdir"
+        cp -r "$backup_dir/mympd/state" "$PROJECT_DIR/mympd/workdir/"
+        ok "myMPD playlists restored → mympd/workdir/state/"
+        restored=$((restored + 1))
+    fi
+
+    if [[ $restored -eq 0 ]]; then
+        warn "Backup directory found but empty — nothing to restore"
+        exit 0
+    fi
+
+    echo ""
+    ok "Backup extracted. Now flash the SD card with Pi Imager, then run:"
+    echo "  ./scripts/prepare-sd.sh"
+    echo ""
+    echo "prepare-sd.sh will include the MPD database automatically."
+}
+
+main "$@"

--- a/scripts/common/backup-mpd.sh
+++ b/scripts/common/backup-mpd.sh
@@ -52,13 +52,8 @@ trap '[[ "${MPD_DB:-}" == /tmp/* ]] && rm -f "$MPD_DB"; mount -o remount,ro "$BO
 
 mkdir -p "$BACKUP_DIR/mpd/data"
 
-# Copy MPD database
+# Copy MPD database (temp file cleaned up by EXIT trap)
 cp "$MPD_DB" "$BACKUP_DIR/mpd/data/mpd.db"
-
-# Clean up temp file if we used docker cp
-if [[ "$MPD_DB" == /tmp/* ]]; then
-    rm -f "$MPD_DB"
-fi
 
 # Optional: myMPD playlists
 if [[ -d "$INSTALL_DIR/mympd/workdir/state" ]]; then

--- a/scripts/common/backup-mpd.sh
+++ b/scripts/common/backup-mpd.sh
@@ -48,7 +48,7 @@ fi
 
 # Remount boot partition read-write
 mount -o remount,rw "$BOOT" 2>/dev/null || true
-trap 'mount -o remount,ro "$BOOT" 2>/dev/null || true' EXIT
+trap '[[ "${MPD_DB:-}" == /tmp/* ]] && rm -f "$MPD_DB"; mount -o remount,ro "$BOOT" 2>/dev/null || true' EXIT
 
 mkdir -p "$BACKUP_DIR/mpd/data"
 

--- a/scripts/common/backup-mpd.sh
+++ b/scripts/common/backup-mpd.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Backup MPD database to boot partition (FAT32).
+# Runs periodically via systemd timer. The backup survives on the SD card
+# so that backup-from-sd.sh can extract it before reflashing.
+#
+# Also backs up myMPD playlists if present.
+set -euo pipefail
+
+# Detect install directory
+if [[ -d /opt/snapmulti ]]; then
+    INSTALL_DIR="/opt/snapmulti"
+elif [[ -d /opt/snapclient ]]; then
+    # Client-only — no MPD, nothing to back up
+    exit 0
+else
+    exit 0
+fi
+
+# Detect boot partition
+if [[ -d /boot/firmware ]]; then
+    BOOT="/boot/firmware"
+else
+    BOOT="/boot"
+fi
+
+BACKUP_DIR="$BOOT/snapmulti-backup"
+
+# Get MPD database path from container
+MPD_DB=""
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^mpd$'; then
+    # Copy from running container (most up-to-date)
+    MPD_DB=$(mktemp)
+    if ! docker cp mpd:/data/mpd.db "$MPD_DB" 2>/dev/null; then
+        rm -f "$MPD_DB"
+        MPD_DB=""
+    fi
+fi
+
+# Fallback: check host path
+if [[ -z "$MPD_DB" ]] && [[ -f "$INSTALL_DIR/mpd/data/mpd.db" ]]; then
+    MPD_DB="$INSTALL_DIR/mpd/data/mpd.db"
+fi
+
+# Nothing to back up
+if [[ -z "$MPD_DB" ]]; then
+    exit 0
+fi
+
+# Remount boot partition read-write
+mount -o remount,rw "$BOOT" 2>/dev/null || true
+trap 'mount -o remount,ro "$BOOT" 2>/dev/null || true' EXIT
+
+mkdir -p "$BACKUP_DIR/mpd/data"
+
+# Copy MPD database
+cp "$MPD_DB" "$BACKUP_DIR/mpd/data/mpd.db"
+
+# Clean up temp file if we used docker cp
+if [[ "$MPD_DB" == /tmp/* ]]; then
+    rm -f "$MPD_DB"
+fi
+
+# Optional: myMPD playlists
+if [[ -d "$INSTALL_DIR/mympd/workdir/state" ]]; then
+    mkdir -p "$BACKUP_DIR/mympd"
+    cp -r "$INSTALL_DIR/mympd/workdir/state" "$BACKUP_DIR/mympd/" 2>/dev/null || true
+fi
+
+logger -t backup-mpd "MPD database backed up to $BACKUP_DIR"

--- a/scripts/common/snapmulti-backup.service
+++ b/scripts/common/snapmulti-backup.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Backup MPD database to boot partition
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/backup-mpd

--- a/scripts/common/snapmulti-backup.timer
+++ b/scripts/common/snapmulti-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodic MPD database backup to boot partition
+
+[Timer]
+# Backup daily at 4 AM and on boot (after containers are up)
+OnBootSec=5min
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -640,6 +640,28 @@ if [[ -n "$DIAG_SCRIPT" ]]; then
     log_info "Diagnostic log persistence installed"
 fi
 
+# MPD database backup to boot partition (server installs only)
+if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
+    BACKUP_SCRIPT=""
+    for _bk_candidate in \
+        "$COMMON/backup-mpd.sh" \
+        "$SERVER_DIR/scripts/common/backup-mpd.sh"; do
+        [[ -f "$_bk_candidate" ]] && BACKUP_SCRIPT="$_bk_candidate" && break
+    done
+    if [[ -n "$BACKUP_SCRIPT" ]]; then
+        install -m 755 "$BACKUP_SCRIPT" /usr/local/bin/backup-mpd
+        bk_dir="$(dirname "$BACKUP_SCRIPT")"
+        if [[ -f "$bk_dir/snapmulti-backup.service" && \
+              -f "$bk_dir/snapmulti-backup.timer" ]]; then
+            cp "$bk_dir/snapmulti-backup.service" /etc/systemd/system/
+            cp "$bk_dir/snapmulti-backup.timer" /etc/systemd/system/
+            systemctl daemon-reload
+            systemctl enable snapmulti-backup.timer
+        fi
+        log_info "MPD backup timer installed (daily to boot partition)"
+    fi
+fi
+
 # Read-only filesystem
 if [[ "${ENABLE_READONLY}" == "true" ]]; then
     log_info "Configuring read-only filesystem..."


### PR DESCRIPTION
## Summary
Reflash-friendly update strategy. The Pi automatically backs up the MPD database to the boot partition daily. Before reflashing, the user extracts it from the SD card with a simple script. No SSH required.

### Flow
```
[Pi runs normally, timer backs up mpd.db to boot partition daily]

1. User removes SD card
2. ./scripts/backup-from-sd.sh           # extracts mpd.db from SD
3. Flash SD with Pi Imager                # erases everything
4. ./scripts/prepare-sd.sh               # includes mpd.db automatically
5. Insert SD, boot → MPD scans in seconds (not hours)
```

### New files
| File | Runs on | Purpose |
|------|---------|---------|
| `scripts/common/backup-mpd.sh` | Pi (timer) | Copies mpd.db + myMPD playlists to `/boot/firmware/snapmulti-backup/` |
| `scripts/common/snapmulti-backup.{service,timer}` | Pi (systemd) | Daily 4AM + on boot |
| `scripts/backup-from-sd.sh` | Mac/PC | Extracts backup from SD card, auto-detects mount points |

### Why reflash > OTA
- Config is minimal and auto-generated (hostname, WiFi, HAT — all auto-detected)
- Only mpd.db needs preserving (NFS library scan takes hours without it)
- 10 min reflash guarantees clean state — no upgrade path bugs
- OTA impossible on Pi Zero (128MB tmpfs < 227MB Docker images)

## Test plan
- [x] shellcheck passes on all new files
- [x] bash syntax check passes
- [ ] Verify on snapvideo: `sudo bash scripts/common/backup-mpd.sh && ls -la /boot/firmware/snapmulti-backup/`
- [ ] Verify backup-from-sd.sh finds backup on mounted SD card

🤖 Generated with [Claude Code](https://claude.com/claude-code)