### PR TITLE
fix: pull-images temp dir race + retry on readonly pull failure

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1448,9 +1448,16 @@ cd "$INSTALL_DIR"
 if ! pull_compose_images log_progress 1024; then
     stop_progress_animation
     echo ""
-    echo "ERROR: Failed to pull container images"
-    echo "  Check network connectivity and try: docker compose pull"
-    exit 1
+    echo "WARNING: Failed to pull some container images"
+    echo "  firstboot will retry on next boot, or run manually:"
+    echo "  cd $INSTALL_DIR && docker compose pull"
+    # Don't exit 1 — let firstboot retry. After a Docker storage driver
+    # switch (readonly mode), images were wiped and the pull may fail
+    # due to rate limits or network issues. On next boot, fuse-overlayfs
+    # is already configured so no wipe happens, and the pull retries.
+    PULL_FAILED=true
+else
+    PULL_FAILED=false
 fi
 echo ""
 
@@ -1459,7 +1466,9 @@ echo ""
 # First-boot: overlayroot not active yet -> harmless no-op.
 # Re-runs on overlayroot: persists images so tmpfs doesn't fill on next boot.
 # ============================================
-if mountpoint -q /media/root-ro 2>/dev/null; then
+if [[ "$PULL_FAILED" == "true" ]]; then
+    echo "Skipping bake — images incomplete (will retry on next boot)"
+elif mountpoint -q /media/root-ro 2>/dev/null; then
     log_progress "Baking Docker images to SD card..."
     BAKE_DIR=$(mktemp -d /tmp/snapclient-bake-XXXXX)
     bake_cleanup() {
@@ -1556,5 +1565,12 @@ if [[ "$NEEDS_REBOOT" == "true" ]]; then
 echo ""
 echo "NOTE: Boot configuration was modified."
 echo "  A reboot is required for changes to take effect."
+fi
+
+# Exit with error if pull failed — firstboot won't mark .done-setup,
+# so it retries on next boot (fuse-overlayfs already configured, no wipe)
+if [[ "${PULL_FAILED:-false}" == "true" ]]; then
+    echo "WARNING: Setup completed but image pull failed — will retry on next boot"
+    exit 1
 fi
 echo ""

--- a/scripts/common/pull-images.sh
+++ b/scripts/common/pull-images.sh
@@ -100,10 +100,10 @@ pull_compose_images() {
     local total=${#to_pull[@]}
     local count=0
 
-    # Temp directory for pull output (cleaned up on function return).
-    # RETURN only — EXIT would clobber the caller's global EXIT trap.
+    # Temp directory for pull output.
+    # Cleaned up explicitly at the end — NOT via RETURN trap, because
+    # background jobs still reference files in this directory.
     _pi_tmp=$(mktemp -d)
-    trap 'rm -rf "$_pi_tmp"' RETURN
 
     local pull_failed=()
     local rate_limited=false
@@ -142,9 +142,11 @@ pull_compose_images() {
             fi
         fi
 
-        # Wait for background svc2
+        # Always wait for background svc2 before next pair
         if [[ -n "$bg_pid" ]]; then
-            if ! wait "$bg_pid" 2>/dev/null; then
+            local bg_rc=0
+            wait "$bg_pid" 2>/dev/null || bg_rc=$?
+            if [[ $bg_rc -ne 0 ]]; then
                 cat "$bg_log" 2>/dev/null
                 if grep -qi "too many requests\|rate limit\|429" "$bg_log" 2>/dev/null; then
                     rate_limited=true
@@ -158,6 +160,9 @@ pull_compose_images() {
             rm -f "$bg_log"
         fi
     done
+
+    # Clean up temp directory (safe — all background jobs have been waited on)
+    rm -rf "$_pi_tmp"
 
     # Prune dangling images
     docker image prune -f >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
Fixes two bugs found on snapdigi (Pi 4 2GB, ENABLE_READONLY=true) where install hung for 40 minutes then failed:

### Bug 1: Temp directory race condition
`pull-images.sh` used a RETURN trap to clean up the temp dir, but background pull jobs were still writing to it. The background job got "No such file or directory" when trying to log output.

**Fix**: Remove RETURN trap, clean up explicitly after all background jobs are waited on.

### Bug 2: Fatal exit after Docker storage wipe
With `ENABLE_READONLY=true`, setup.sh switches Docker to fuse-overlayfs by wiping `/var/lib/docker/*`. If the subsequent pull fails (rate limit, network), `exit 1` kills everything. On reboot, firstboot WOULD retry — but setup.sh never completed, so configs/systemd/readonly weren't set up either.

**Fix**: Don't exit on pull failure. Complete all setup steps (config, systemd, readonly), skip bake, then exit 1 at the end. On retry, fuse-overlayfs is already configured (no wipe), pull succeeds.

### The retry flow (after fix)
```
Boot 1: setup.sh → readonly config → Docker wipe → pull FAILS → exit 1
         (firstboot: .done-setup NOT marked)
Boot 2: setup.sh → readonly already configured, NO wipe → pull SUCCEEDS → exit 0
         (firstboot: .done-setup marked, containers start)
```

## Test plan
- [x] shellcheck passes
- [x] `bash client/tests/test_pull_hardening.sh` — 13/13 pass
- [x] Syntax check passes
- [ ] Verify on device with ENABLE_READONLY=true + simulated pull failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)