### PR TITLE
fix: Trivy scan for ARM images (tidal + client)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,18 +17,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - lollonet/snapmulti-server
-          - lollonet/snapmulti-airplay
-          - lollonet/snapmulti-mpd
-          - lollonet/snapmulti-metadata
+        include:
+          - image: lollonet/snapmulti-server
+          - image: lollonet/snapmulti-airplay
+          - image: lollonet/snapmulti-mpd
+          - image: lollonet/snapmulti-metadata
+          - image: lollonet/snapmulti-tidal
+            platform: linux/arm64
+          - image: lollonet/snapclient-pi
+            platform: linux/arm64
+          - image: lollonet/snapclient-pi-visualizer
+            platform: linux/arm64
+          - image: lollonet/snapclient-pi-fb-display
+            platform: linux/arm64
           # go-librespot: upstream image scanned separately below
-          # tidal: ARM-only image, cannot pull on amd64 runner
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Pull image (cross-platform if needed)
+        env:
+          IMAGE: ${{ matrix.image }}
+          PLATFORM: ${{ matrix.platform || 'linux/amd64' }}
+        run: docker pull --platform "$PLATFORM" "$IMAGE:latest"
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 # v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: '${{ matrix.image }}:latest'
           format: 'sarif'


### PR DESCRIPTION
## Summary
Add 4 ARM-only images to Trivy security scan. Previously only 4 server images (amd64) were scanned — tidal and all client images were skipped.

### Before
- 4 images scanned: snapmulti-server, -airplay, -mpd, -metadata (amd64)
- 4 images skipped: tidal, snapclient-pi, -visualizer, -fb-display (ARM)

### After
- 8 images scanned: all 4 server + all 4 ARM
- ARM images pulled with `docker pull --platform linux/arm64` on the amd64 runner

## Test plan
- [x] Workflow syntax valid
- [ ] Trigger manual run to verify ARM pull + Trivy scan works

🤖 Generated with [Claude Code](https://claude.com/claude-code)