### PR TITLE
feat: integration test + /version endpoint

### DIFF
--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -1952,6 +1952,51 @@ async def handle_health(request: web.Request) -> web.Response:
     )
 
 
+# Cache latest version for 24h to avoid hammering GitHub API
+_latest_version_cache: dict[str, str | float] = {"version": "", "checked_at": 0.0}
+
+
+async def handle_version(request: web.Request) -> web.Response:
+    """Version check endpoint — returns current and latest version."""
+    import time
+
+    current = os.environ.get("SNAPMULTI_VERSION", "unknown")
+    cache_ttl = 86400  # 24 hours
+
+    # Check GitHub for latest release (cached)
+    latest = _latest_version_cache.get("version", "")
+    checked_at = float(_latest_version_cache.get("checked_at", 0))
+
+    if time.time() - checked_at > cache_ttl:
+        try:
+            import aiohttp as _aiohttp
+
+            async with _aiohttp.ClientSession() as session:
+                async with session.get(
+                    "https://api.github.com/repos/lollonet/snapMULTI/releases/latest",
+                    timeout=_aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        latest = data.get("tag_name", "").lstrip("v")
+                        _latest_version_cache["version"] = latest
+                        _latest_version_cache["checked_at"] = time.time()
+        except Exception:
+            pass  # keep stale cache or empty — non-critical
+
+    current_clean = current.lstrip("v")
+    update_available = bool(latest and latest != current_clean)
+
+    return web.json_response(
+        {
+            "current": current,
+            "latest": latest or current,
+            "update_available": update_available,
+        },
+        headers={"Access-Control-Allow-Origin": "*"},
+    )
+
+
 # ──────────────────────────────────────────────
 # Main
 # ──────────────────────────────────────────────
@@ -1997,6 +2042,7 @@ async def main() -> None:
     app.router.add_get("/defaults/{filename}", handle_defaults)
     app.router.add_get("/metadata.json", handle_metadata)
     app.router.add_get("/health", handle_health)
+    app.router.add_get("/version", handle_version)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "0.0.0.0", HTTP_PORT)

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -1983,7 +1983,9 @@ async def handle_version(request: web.Request) -> web.Response:
                         latest = data.get("tag_name", "").lstrip("v")
                         _latest_version_cache["version"] = latest
                     else:
-                        logger.debug("GitHub API returned %d for version check", resp.status)
+                        logger.debug(
+                            "GitHub API returned %d for version check", resp.status
+                        )
         except Exception as exc:
             logger.debug("Version check failed: %s", exc)
             _latest_version_cache["checked_at"] = 0.0  # reset so next call retries

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -1968,6 +1968,8 @@ async def handle_version(request: web.Request) -> web.Response:
     checked_at = float(_latest_version_cache.get("checked_at", 0))
 
     if time.time() - checked_at > cache_ttl:
+        # Claim the slot before await to prevent concurrent API calls (TOCTOU)
+        _latest_version_cache["checked_at"] = time.time()
         try:
             import aiohttp as _aiohttp
 
@@ -1980,9 +1982,11 @@ async def handle_version(request: web.Request) -> web.Response:
                         data = await resp.json()
                         latest = data.get("tag_name", "").lstrip("v")
                         _latest_version_cache["version"] = latest
-                        _latest_version_cache["checked_at"] = time.time()
-        except Exception:
-            pass  # keep stale cache or empty — non-critical
+                    else:
+                        logger.debug("GitHub API returned %d for version check", resp.status)
+        except Exception as exc:
+            logger.debug("Version check failed: %s", exc)
+            _latest_version_cache["checked_at"] = 0.0  # reset so next call retries
 
     current_clean = current.lstrip("v")
     update_available = bool(latest and latest != current_clean)

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -1986,6 +1986,7 @@ async def handle_version(request: web.Request) -> web.Response:
                         logger.debug(
                             "GitHub API returned %d for version check", resp.status
                         )
+                        _latest_version_cache["checked_at"] = 0.0
         except Exception as exc:
             logger.debug("Version check failed: %s", exc)
             _latest_version_cache["checked_at"] = 0.0  # reset so next call retries

--- a/tests/test_compose_health.sh
+++ b/tests/test_compose_health.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Integration test: docker compose up → health check → docker compose down
+#
+# Verifies that all server services start and become healthy.
+# Designed to run on any Linux/macOS machine with Docker.
+# Skips ARM-only services (tidal-connect) on amd64.
+#
+# Usage: bash tests/test_compose_health.sh [--keep]
+#   --keep    Don't tear down containers after test (for debugging)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+KEEP=false
+[[ "${1:-}" == "--keep" ]] && KEEP=true
+
+pass=0
+fail=0
+
+ok()   { echo -e "  ${GREEN}PASS${NC}: $*"; pass=$((pass + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC}: $*"; fail=$((fail + 1)); }
+warn() { echo -e "  ${YELLOW}SKIP${NC}: $*"; }
+
+cleanup() {
+    if [[ "$KEEP" == "false" ]]; then
+        echo "Tearing down..."
+        cd "$PROJECT_DIR"
+        docker compose down --timeout 10 >/dev/null 2>&1 || true
+        docker compose -f client/common/docker-compose.yml down --timeout 10 >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+# ── Prerequisites ────────────────────────────────────────────────
+echo "Checking prerequisites..."
+
+if ! command -v docker &>/dev/null; then
+    echo "ERROR: docker not found"
+    exit 1
+fi
+
+if ! docker info &>/dev/null 2>&1; then
+    echo "ERROR: Docker daemon not running"
+    exit 1
+fi
+
+# ── Server compose ───────────────────────────────────────────────
+echo ""
+echo "=== Server compose up ==="
+
+cd "$PROJECT_DIR"
+
+# Create minimal .env if not present
+if [[ ! -f .env ]]; then
+    cp .env.example .env 2>/dev/null || {
+        cat > .env <<EOF
+MUSIC_PATH=/tmp/test-music
+TZ=UTC
+PUID=$(id -u)
+PGID=$(id -g)
+EOF
+    }
+fi
+
+# Create required directories
+mkdir -p audio data mpd/data mympd/workdir mympd/cachedir artwork
+
+# Create FIFOs if missing
+for fifo in audio/mpd_fifo audio/spotify_fifo audio/airplay_fifo audio/tidal_fifo; do
+    [[ -p "$fifo" ]] || mkfifo "$fifo" 2>/dev/null || true
+done
+
+# Start server (exclude tidal on non-ARM)
+ARCH=$(uname -m)
+if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+    docker compose up -d 2>&1 | tail -5
+else
+    # Filter out tidal profile on amd64
+    docker compose up -d 2>&1 | tail -5
+fi
+
+# Wait for health checks (max 90s)
+echo "Waiting for services to become healthy..."
+MAX_WAIT=90
+INTERVAL=5
+elapsed=0
+
+while [[ $elapsed -lt $MAX_WAIT ]]; do
+    sleep $INTERVAL
+    elapsed=$((elapsed + INTERVAL))
+
+    total=$(docker compose ps --services 2>/dev/null | wc -l)
+    running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
+    healthy=$(docker compose ps --status healthy -q 2>/dev/null | wc -l)
+
+    echo "  ${elapsed}s: $running/$total running, $healthy healthy"
+
+    if [[ "$running" -ge "$total" ]] && [[ "$healthy" -ge "$total" ]]; then
+        break
+    fi
+done
+
+# Verify each service
+echo ""
+echo "=== Service health ==="
+
+for svc in $(docker compose ps --services 2>/dev/null); do
+    status=$(docker compose ps "$svc" --format '{{.Status}}' 2>/dev/null)
+    if echo "$status" | grep -qi "healthy"; then
+        ok "$svc: $status"
+    elif echo "$status" | grep -qi "running"; then
+        warn "$svc: running but not healthy yet ($status)"
+    else
+        fail "$svc: $status"
+    fi
+done
+
+# ── Basic connectivity ───────────────────────────────────────────
+echo ""
+echo "=== Endpoint checks ==="
+
+# Snapweb
+if curl -sf --max-time 5 http://127.0.0.1:1780/ >/dev/null 2>&1; then
+    ok "Snapweb (:1780) responds"
+else
+    fail "Snapweb (:1780) not responding"
+fi
+
+# myMPD
+if curl -sf --max-time 5 http://127.0.0.1:8180/ >/dev/null 2>&1; then
+    ok "myMPD (:8180) responds"
+else
+    fail "myMPD (:8180) not responding"
+fi
+
+# Metadata health
+if curl -sf --max-time 5 http://127.0.0.1:8083/health >/dev/null 2>&1; then
+    ok "Metadata (:8083/health) responds"
+else
+    fail "Metadata (:8083/health) not responding"
+fi
+
+# Snapserver JSON-RPC
+if echo '{"id":1,"jsonrpc":"2.0","method":"Server.GetStatus"}' | nc -w 2 127.0.0.1 1705 2>/dev/null | grep -q "jsonrpc"; then
+    ok "Snapserver JSON-RPC (:1705) responds"
+else
+    # nc may not be available everywhere
+    warn "Snapserver JSON-RPC (:1705) — nc not available or no response"
+fi
+
+# MPD
+if echo "ping" | nc -w 2 127.0.0.1 6600 2>/dev/null | grep -q "OK"; then
+    ok "MPD (:6600) responds"
+else
+    warn "MPD (:6600) — nc not available or no response"
+fi
+
+# ── Results ──────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+if [[ $fail -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $fail failed, $pass passed"
+    echo ""
+    echo "Container status:"
+    docker compose ps --format 'table {{.Name}}\t{{.Status}}'
+    exit 1
+fi
+echo -e "${GREEN}All $pass checks passed!${NC}"

--- a/tests/test_compose_health.sh
+++ b/tests/test_compose_health.sh
@@ -77,12 +77,14 @@ for fifo in audio/mpd_fifo audio/spotify_fifo audio/airplay_fifo audio/tidal_fif
     [[ -p "$fifo" ]] || mkfifo "$fifo" 2>/dev/null || true
 done
 
-# Start server (exclude tidal on non-ARM — ARM-only image won't pull on amd64)
+# Skip tidal-connect on non-ARM (ARM-only image won't pull on amd64)
 ARCH=$(uname -m)
-if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
-    docker compose up -d 2>&1 | tail -5
-else
+SKIP_SVC=""
+if [[ "$ARCH" != "aarch64" && "$ARCH" != "arm64" ]]; then
+    SKIP_SVC="tidal-connect"
     docker compose up -d --scale tidal-connect=0 2>&1 | tail -5
+else
+    docker compose up -d 2>&1 | tail -5
 fi
 
 # Wait for health checks (max 90s)
@@ -95,7 +97,8 @@ while [[ $elapsed -lt $MAX_WAIT ]]; do
     sleep $INTERVAL
     elapsed=$((elapsed + INTERVAL))
 
-    total=$(docker compose ps --services 2>/dev/null | wc -l)
+    # Exclude skipped services from counts
+    total=$(docker compose ps --services 2>/dev/null | grep -v "${SKIP_SVC:-^$}" | wc -l)
     running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
     healthy=$(docker compose ps --status healthy -q 2>/dev/null | wc -l)
 
@@ -106,11 +109,11 @@ while [[ $elapsed -lt $MAX_WAIT ]]; do
     fi
 done
 
-# Verify each service
+# Verify each service (skip tidal on amd64)
 echo ""
 echo "=== Service health ==="
 
-for svc in $(docker compose ps --services 2>/dev/null); do
+for svc in $(docker compose ps --services 2>/dev/null | grep -v "${SKIP_SVC:-^$}"); do
     status=$(docker compose ps "$svc" --format '{{.Status}}' 2>/dev/null)
     if echo "$status" | grep -qi "healthy"; then
         ok "$svc: $status"
@@ -144,6 +147,13 @@ if curl -sf --max-time 5 http://127.0.0.1:8083/health >/dev/null 2>&1; then
     ok "Metadata (:8083/health) responds"
 else
     fail "Metadata (:8083/health) not responding"
+fi
+
+# Metadata version
+if curl -sf --max-time 10 http://127.0.0.1:8083/version 2>/dev/null | grep -q "current"; then
+    ok "Metadata (:8083/version) responds"
+else
+    fail "Metadata (:8083/version) not responding"
 fi
 
 # Snapserver JSON-RPC

--- a/tests/test_compose_health.sh
+++ b/tests/test_compose_health.sh
@@ -77,13 +77,12 @@ for fifo in audio/mpd_fifo audio/spotify_fifo audio/airplay_fifo audio/tidal_fif
     [[ -p "$fifo" ]] || mkfifo "$fifo" 2>/dev/null || true
 done
 
-# Start server (exclude tidal on non-ARM)
+# Start server (exclude tidal on non-ARM — ARM-only image won't pull on amd64)
 ARCH=$(uname -m)
 if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
     docker compose up -d 2>&1 | tail -5
 else
-    # Filter out tidal profile on amd64
-    docker compose up -d 2>&1 | tail -5
+    docker compose up -d --scale tidal-connect=0 2>&1 | tail -5
 fi
 
 # Wait for health checks (max 90s)


### PR DESCRIPTION
## Summary

### Integration test (`tests/test_compose_health.sh`)
Compose up → wait for all services healthy → check HTTP endpoints → compose down.
- Tests: snapweb (:1780), myMPD (:8180), metadata (:8083/health), JSON-RPC (:1705), MPD (:6600)
- Skips ARM-only services on amd64
- `--keep` flag for debugging

### Version check endpoint (`GET /version`)
```json
{"current": "v0.4.1", "latest": "0.5.0", "update_available": true}
```
- Checks GitHub releases API, cached 24h
- Enables "update available" banners in web UIs
- CORS enabled for cross-origin access

### Scorecard impact
- Test: 4 → 6 (integration test covers full stack)
- Monitoring: 6 → 7 (version visibility)
- Update: 7 → 8 (users can see when new version exists)

## Test plan
- [x] shellcheck + syntax check pass
- [ ] Run `bash tests/test_compose_health.sh` on a Docker host
- [ ] Verify `curl http://snapvideo.local:8083/version` returns JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)