### PR TITLE
fix: suppress Docker Compose layer progress flood in install log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **QUICKSTART.md** ([#226](https://github.com/lollonet/snapMULTI/pull/226)) — one-page quick start (60 lines); README slimmed from 245 to 72 lines
 
 ### Fixed
+- **Install log flood** ([#237](https://github.com/lollonet/snapMULTI/pull/237)) — suppress Docker Compose per-layer progress lines in install log (hundreds of "Pulling" lines that looked like an infinite loop)
 - **Health check logic** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)
 - **fuse-overlayfs broken binary** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — setup-docker.sh now returns error (was silently succeeding)
 - **Shell injection in _image_exists** ([#219](https://github.com/lollonet/snapMULTI/pull/219)) — pass service name via env var instead of string interpolation

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -421,8 +421,10 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
                     local_msg="${local_msg#==> }"
                     log_msg INFO deploy "$local_msg"
                     ;;
-                *"Pulling "*|*"pulling "*|*"Downloaded"*|*"Pull complete"*)
-                    log_msg INFO deploy "$line"
+                *"Pulling "*|*"Pull complete"*)
+                    # Skip Docker Compose layer progress (floods log with hundreds
+                    # of lines). Important pull messages from pull-images.sh already
+                    # have [INFO] prefix and are caught by the pattern above.
                     ;;
             esac
         fi

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -421,10 +421,12 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
                     local_msg="${local_msg#==> }"
                     log_msg INFO deploy "$local_msg"
                     ;;
-                *"Pulling "*|*"Pull complete"*)
-                    # Skip Docker Compose layer progress (floods log with hundreds
-                    # of lines). Important pull messages from pull-images.sh already
-                    # have [INFO] prefix and are caught by the pattern above.
+                *"Downloaded newer image"*)
+                    log_msg INFO deploy "$line"
+                    ;;
+                *"Pulling "*|*"Pull complete"*|*"pulling "*|*"Downloaded"*)
+                    # Skip Docker Compose per-layer progress (floods log).
+                    # Pull-images.sh messages have [INFO] prefix, caught above.
                     ;;
             esac
         fi


### PR DESCRIPTION
## Summary
firstboot.sh pattern-matched every line containing "Pulling" from docker compose output, flooding the install log with hundreds of layer download progress lines. This created the appearance of an infinite pull loop ("Pulling metadata (326/7)...").

### Root cause
Docker Compose v5 emits progress to stderr ("Pulling fs layer", "Pulling", "Pull complete" for each layer). firstboot.sh captures stderr via `2>&1` and pattern-matches `*"Pulling "*` — logging every single layer progress line.

The important pull messages from pull-images.sh already have `[INFO]` prefix (via `info()` function) and are caught by the `*"[INFO] "*` pattern on line 419. The `"Pulling"` pattern on line 424 was redundant and only caught Docker raw progress.

### Fix
Replace the "Pulling" pattern with a no-op comment. Pull-images.sh messages are already logged via the `[INFO]` pattern.

## Test plan
- [x] shellcheck passes
- [x] Syntax check passes
- [ ] Reflash and verify clean install log (no "Pulling" flood)

🤖 Generated with [Claude Code](https://claude.com/claude-code)