### PR TITLE
fix: bug hunt — WiFi IP, meta_mpd crash, cover art, MPD exit, Bash 3.2

### DIFF
--- a/patches/meta_mpd.py
+++ b/patches/meta_mpd.py
@@ -470,8 +470,9 @@ class MPDWrapper(object):
                                                          "message": "Method not found"}, "id": id})
             send({"jsonrpc": "2.0", "result": "ok", "id": id})
         except Exception as e:
+            req_id = locals().get('id')
             send({"jsonrpc": "2.0", "error": {
-                 "code": -32700, "message": "Parse error", "data": str(e)}, "id": id})
+                 "code": -32700, "message": "Parse error", "data": str(e)}, "id": req_id})
 
     def io_callback(self, fd, event):
         try:

--- a/scripts/boot-tune.sh
+++ b/scripts/boot-tune.sh
@@ -30,14 +30,18 @@ done
 
 # ── WiFi auto-disable when Ethernet is connected ─────────────────
 # Avoids dual mDNS announcements (clients might connect to the wrong IP).
-# If Ethernet is unplugged, WiFi stays active as fallback.
-if command -v nmcli &>/dev/null && ip link show eth0 2>/dev/null | grep -q 'state UP'; then
-    nmcli radio wifi off 2>/dev/null \
-        && logger -t boot-tune "Ethernet UP — WiFi disabled (single mDNS announcement)" \
-        || logger -t boot-tune -p warning "Failed to disable WiFi"
-elif command -v nmcli &>/dev/null && ! ip link show eth0 2>/dev/null | grep -q 'state UP'; then
-    # Ensure WiFi is on if Ethernet is not connected (recovery after cable removal)
-    nmcli radio wifi on 2>/dev/null || true
+# If Ethernet is unplugged or has no IP, WiFi stays active as fallback.
+if command -v nmcli &>/dev/null; then
+    eth_ip=$(ip -4 addr show eth0 2>/dev/null | awk '/inet /{print $2; exit}')
+    if [[ -n "$eth_ip" ]]; then
+        # Ethernet has an IP — safe to disable WiFi
+        nmcli radio wifi off 2>/dev/null \
+            && logger -t boot-tune "Ethernet $eth_ip — WiFi disabled (single mDNS)" \
+            || logger -t boot-tune -p warning "Failed to disable WiFi"
+    else
+        # No Ethernet IP — ensure WiFi is on (recovery after cable removal)
+        nmcli radio wifi on 2>/dev/null || true
+    fi
 fi
 
 # ── Memory tuning: reduce swappiness for audio workloads ──────────

--- a/scripts/meta_shairport.py
+++ b/scripts/meta_shairport.py
@@ -171,9 +171,7 @@ def parse_item(item_data: bytes) -> None:
                 f.write(data)
             os.replace(tmp_path, cover_art_path)
             # Cache host IP on first use
-            if _host_ip is None:
-                _host_ip = get_host_ip()
-            metadata["artUrl"] = f"http://{_host_ip}:{COVER_ART_PORT}/cover.jpg"
+            metadata["artUrl"] = f"http://{get_host_ip()}:{COVER_ART_PORT}/cover.jpg"
         except Exception as e:
             log("warning", f"Cover art error: {e}")
     elif code == "astm" and isinstance(data, bytes) and len(data) >= 4:

--- a/scripts/meta_shairport.py
+++ b/scripts/meta_shairport.py
@@ -119,14 +119,8 @@ def get_host_ip() -> str:
     return "localhost"
 
 
-# Cache the host IP at startup
-_host_ip: str | None = None
-
-
 def parse_item(item_data: bytes) -> None:
     """Parse a single metadata item from shairport-sync XML."""
-    global _host_ip
-
     try:
         item_xml = item_data.decode("utf-8", errors="replace")
     except Exception:

--- a/scripts/mpd-entrypoint.sh
+++ b/scripts/mpd-entrypoint.sh
@@ -45,4 +45,9 @@ else
     echo "Database has $song_count songs — auto_update handles incremental scan"
 fi
 wait $MPD_PID
-exit $?
+rc=$?
+# Signal termination (128+N) is normal during Docker stop — exit 0
+if [ "$rc" -gt 128 ]; then
+    exit 0
+fi
+exit $rc

--- a/scripts/mpd-entrypoint.sh
+++ b/scripts/mpd-entrypoint.sh
@@ -46,8 +46,9 @@ else
 fi
 wait $MPD_PID
 rc=$?
-# Signal termination (128+N) is normal during Docker stop — exit 0
-if [ "$rc" -gt 128 ]; then
+# SIGTERM (143) and SIGKILL (137) are normal during Docker stop — exit clean.
+# Other signals (SIGSEGV=139, etc.) should propagate as failure.
+if [ "$rc" -eq 143 ] || [ "$rc" -eq 137 ]; then
     exit 0
 fi
 exit $rc

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -672,22 +672,21 @@ echo "  install.conf -> AUTO_UPDATE=$(grep '^AUTO_UPDATE=' "$DEST/install.conf" 
 echo "  install.conf -> VERBOSE_INSTALL=$(grep '^VERBOSE_INSTALL=' "$DEST/install.conf" | cut -d= -f2)"
 
 # Version files
-case "$INSTALL_TYPE" in
-    server|both)
-        if [[ -f "$DEST/server/.version" ]]; then
-            echo "  [OK] Server version: $(cat "$DEST/server/.version")"
-        else
-            echo "  [WARN] server/.version missing (version will show as 'unknown')"
-        fi
-        ;;&
-    client|both)
-        if [[ -f "$DEST/client/VERSION" ]]; then
-            echo "  [OK] Client version: $(cat "$DEST/client/VERSION")"
-        else
-            echo "  [WARN] client/VERSION missing"
-        fi
-        ;;
-esac
+# Check version files (avoid ;;& which requires Bash 4+, macOS has 3.2)
+if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
+    if [[ -f "$DEST/server/.version" ]]; then
+        echo "  [OK] Server version: $(cat "$DEST/server/.version")"
+    else
+        echo "  [WARN] server/.version missing (version will show as 'unknown')"
+    fi
+fi
+if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
+    if [[ -f "$DEST/client/VERSION" ]]; then
+        echo "  [OK] Client version: $(cat "$DEST/client/VERSION")"
+    else
+        echo "  [WARN] client/VERSION missing"
+    fi
+fi
 
 # -- OS configuration --
 echo ""


### PR DESCRIPTION
## Summary
5 bugs from deep 5-agent bug hunt + SOTA review:

### Fixes
1. **boot-tune.sh**: Check eth0 has IP address (not just link UP) before disabling WiFi. Cable without DHCP = no network.
2. **meta_mpd.py**: Catch NameError in JSON-RPC error handler when request has no 'id' field.
3. **meta_shairport.py**: Don't cache host IP forever — call get_host_ip() each time. Fixes stale cover art URLs after DHCP renewal.
4. **mpd-entrypoint.sh**: Exit 0 on signal termination (128+N) so Docker stop doesn't mark container as failed.
5. **prepare-sd.sh**: Replace `;;&` (Bash 4+) with if/fi for macOS Bash 3.2 compatibility.

### Requires rebuild
- snapserver image (meta_mpd.py, meta_shairport.py)
- mpd image (mpd-entrypoint.sh)

## Test plan
- [x] shellcheck passes
- [x] python3 compile check passes
- [x] bash -n syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)