### PR TITLE
fix: install sequence — client verify, idempotent setup, safe DNS

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -594,18 +594,25 @@ echo ""
 INSTALL_DIR="/opt/snapclient"
 
 progress 1 "Installing system dependencies..."
-log_progress "apt-get update"
 start_progress_animation 1 0 12  # Animate during apt-get
 
 # Base packages (always needed)
 BASE_PACKAGES="ca-certificates curl alsa-utils avahi-daemon avahi-utils"
 
-apt-get update
-log_progress "apt-get install: ca-certificates curl..."
-log_progress "apt-get install: alsa-utils avahi-daemon avahi-utils..."
-# shellcheck disable=SC2086
-apt-get install -y $BASE_PACKAGES
-log_progress "System packages installed"
+# Skip apt-get if all base packages are already installed (firstboot did it)
+_missing_pkgs=""
+for _pkg in $BASE_PACKAGES; do
+    dpkg -s "$_pkg" &>/dev/null || _missing_pkgs="$_missing_pkgs $_pkg"
+done
+if [[ -n "$_missing_pkgs" ]]; then
+    log_progress "apt-get update + install:$_missing_pkgs"
+    apt-get update
+    # shellcheck disable=SC2086
+    apt-get install -y $_missing_pkgs
+    log_progress "System packages installed"
+else
+    log_progress "All base packages already installed, skipping apt-get"
+fi
 
 # Set system locale to C.UTF-8 — prevents warnings from apt and subprocesses.
 # C.UTF-8 is always available on Debian without running locale-gen.

--- a/scripts/common/wait-network.sh
+++ b/scripts/common/wait-network.sh
@@ -77,14 +77,17 @@ _try_recover_network() {
         fi
     fi
 
-    # Stage 3 (90s): Add fallback DNS
+    # Stage 3 (90s): Add fallback DNS (non-destructive)
     if (( i == 45 )); then
         if ping -c1 -W2 1.1.1.1 &>/dev/null && ! getent hosts deb.debian.org &>/dev/null; then
-            log_warn "Adding fallback DNS (1.1.1.1)..."
-            if [[ -f /etc/resolv.conf ]]; then
-                sed -i '1i nameserver 1.1.1.1' /etc/resolv.conf 2>/dev/null || true
-            else
-                echo "nameserver 1.1.1.1" > /etc/resolv.conf
+            log_warn "DNS not working — trying fallback (1.1.1.1)..."
+            if command -v resolvectl &>/dev/null; then
+                # systemd-resolved: set fallback DNS without touching resolv.conf
+                resolvectl dns 1.1.1.1 2>/dev/null || true
+            elif [[ -f /etc/resolv.conf ]] && ! grep -q '1.1.1.1' /etc/resolv.conf; then
+                # Static resolv.conf: add temporarily, mark for cleanup
+                sed -i '1i nameserver 1.1.1.1  # snapmulti-fallback' /etc/resolv.conf 2>/dev/null || true
+                _DNS_FALLBACK_ADDED=true
             fi
         fi
     fi
@@ -123,6 +126,11 @@ wait_for_network() {
             if getent hosts deb.debian.org &>/dev/null; then
                 log_info "Network ready"
                 network_ready=true
+                # Clean up fallback DNS entry if we added one
+                if [[ "${_DNS_FALLBACK_ADDED:-false}" == "true" ]]; then
+                    sed -i '/snapmulti-fallback/d' /etc/resolv.conf 2>/dev/null || true
+                    log_info "Removed fallback DNS entry"
+                fi
                 break
             fi
             _try_recover_network "$i" dns-only

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -581,6 +581,9 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     local_client_healthy=false
     local_client_compose=(-f "$CLIENT_DIR/docker-compose.yml")
     local_client_total=$(docker compose "${local_client_compose[@]}" config --services 2>/dev/null | wc -l)
+    if [[ "$local_client_total" -eq 0 ]]; then
+        log_warn "Could not determine client service count — skipping health check"
+    else
     local_client_hc=$(docker compose "${local_client_compose[@]}" config --format json 2>/dev/null \
         | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || local_client_hc=0
     for attempt in $(seq 1 12); do
@@ -602,6 +605,7 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
             log_warn "  $line"
         done
     fi
+    fi  # local_client_total guard
     checkpoint_done "setup"
   fi  # checkpoint guard
 fi

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -580,18 +580,24 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
     local_client_healthy=false
     local_client_compose=(-f "$CLIENT_DIR/docker-compose.yml")
+    local_client_total=$(docker compose "${local_client_compose[@]}" config --services 2>/dev/null | wc -l)
+    local_client_hc=$(docker compose "${local_client_compose[@]}" config --format json 2>/dev/null \
+        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || local_client_hc=0
     for attempt in $(seq 1 12); do
         local_running=$(docker compose "${local_client_compose[@]}" ps --status running -q 2>/dev/null | wc -l)
-        local_healthy=$(docker compose "${local_client_compose[@]}" ps --status healthy -q 2>/dev/null | wc -l)
-        if [[ "$local_running" -ge 1 ]] && [[ "$local_healthy" -ge 1 ]]; then
-            log_info "Client container running and healthy"
+        local_healthy=$(docker ps --filter "health=healthy" \
+            --filter "label=com.docker.compose.project=$(basename "$CLIENT_DIR")" \
+            -q 2>/dev/null | wc -l)
+        if [[ "$local_running" -ge "$local_client_total" ]] && { [[ "$local_client_hc" -eq 0 ]] || [[ "$local_healthy" -ge "$local_client_hc" ]]; }; then
+            log_info "All $local_client_total client services running ($local_healthy/$local_client_hc healthy)"
             local_client_healthy=true
             break
         fi
+        log_info "Attempt $attempt/12: $local_running/$local_client_total running, $local_healthy/$local_client_hc healthy..."
         sleep 5
     done
     if [[ "$local_client_healthy" == "false" ]]; then
-        log_warn "snapclient not running after 60s"
+        log_warn "Client services not all healthy after 60s"
         docker compose -f "$CLIENT_DIR/docker-compose.yml" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
             log_warn "  $line"
         done


### PR DESCRIPTION
## Summary

3 install chain hardening fixes compatible with server-only, client-only, and both modes.

### 1. firstboot.sh — client verification symmetric with server
- Count expected services + healthcheck-enabled services from compose config
- Require ALL running AND all hc-services healthy (was: `>= 1`)
- Progress logging per attempt

### 2. setup.sh — idempotent base package install
- Check `dpkg -s` for each package before apt-get
- If all present (firstboot already installed): skip apt-get entirely
- If standalone client install (no firstboot): apt-get runs normally

### 3. wait-network.sh — non-destructive DNS fallback
- Use `resolvectl` if available (systemd-resolved aware)
- If modifying resolv.conf: mark entry with `# snapmulti-fallback`
- Remove fallback entry after network is ready
- Prevents permanent DNS config pollution

## Test plan
- [x] shellcheck passes on all 3 files
- [x] bash -n syntax check passes
- [x] All 48 existing tests pass (resource profiles, pull hardening, HAT configs)
- End-to-end Docker test: not executable on Mac (declared)

## Compatibility
- [x] server-only: no client code touched
- [x] client-only: setup.sh works standalone (dpkg check triggers apt-get)
- [x] both: firstboot provisions, setup.sh skips redundant apt-get

🤖 Generated with [Claude Code](https://claude.com/claude-code)