### PR TITLE
fix: start client containers, both-mode detect, fuse-overlayfs gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **QUICKSTART.md** ([#226](https://github.com/lollonet/snapMULTI/pull/226)) — one-page quick start (60 lines); README slimmed from 245 to 72 lines
 
 ### Fixed
+- **Client verify + start** ([#243](https://github.com/lollonet/snapMULTI/pull/243)) — start client containers before verify, block checkpoint on failure, detect "both" mode via install.conf, restart all services on server change, gate fuse-overlayfs on ENABLE_READONLY, fix resolvectl interface arg
 - **Install log flood** ([#237](https://github.com/lollonet/snapMULTI/pull/237)) — suppress Docker Compose per-layer progress lines in install log (hundreds of "Pulling" lines that looked like an infinite loop)
 - **Health check logic** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)
 - **fuse-overlayfs broken binary** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — setup-docker.sh now returns error (was silently succeeding)

--- a/client/common/scripts/discover-server.sh
+++ b/client/common/scripts/discover-server.sh
@@ -16,13 +16,13 @@ WATCH_MODE=false
 # "Both" mode: local snapserver always wins.
 # Detect via install.conf or server directory (robust — doesn't depend on container state).
 _is_both_mode() {
-    # Check install.conf (set by prepare-sd.sh)
+    # Check install.conf (set by prepare-sd.sh) — single source of truth.
+    # No filesystem fallback: /opt/snapmulti may survive from a previous
+    # server install, causing false-positive pinning on client-only reflash.
     local conf
     for conf in /boot/firmware/snapmulti/install.conf /boot/snapmulti/install.conf; do
         if grep -q '^INSTALL_TYPE=both' "$conf" 2>/dev/null; then return 0; fi
     done
-    # Fallback: server compose file exists alongside client
-    [[ -f /opt/snapmulti/docker-compose.yml ]] && return 0
     return 1
 }
 

--- a/client/common/scripts/discover-server.sh
+++ b/client/common/scripts/discover-server.sh
@@ -13,13 +13,25 @@ LAST_IP_FILE="/run/snapclient-server-ip"
 WATCH_MODE=false
 [[ "${1:-}" == "--watch" ]] && WATCH_MODE=true
 
-# "Both" mode: local snapserver always wins
-if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^snapserver$'; then
+# "Both" mode: local snapserver always wins.
+# Detect via install.conf or server directory (robust — doesn't depend on container state).
+_is_both_mode() {
+    # Check install.conf (set by prepare-sd.sh)
+    local conf
+    for conf in /boot/firmware/snapmulti/install.conf /boot/snapmulti/install.conf; do
+        if grep -q '^INSTALL_TYPE=both' "$conf" 2>/dev/null; then return 0; fi
+    done
+    # Fallback: server compose file exists alongside client
+    [[ -f /opt/snapmulti/docker-compose.yml ]] && return 0
+    return 1
+}
+
+if _is_both_mode; then
     current=$(grep "^SNAPSERVER_HOST=" "$ENV_FILE" 2>/dev/null | cut -d= -f2) || true
     if [[ "$current" != "127.0.0.1" ]]; then
         echo "snapclient-discover: local snapserver detected, switching to 127.0.0.1"
         if $WATCH_MODE; then
-            if cd /opt/snapclient && docker compose restart snapclient 2>/dev/null; then
+            if cd /opt/snapclient && docker compose restart 2>/dev/null; then
                 sed -i "s|^SNAPSERVER_HOST=.*|SNAPSERVER_HOST=127.0.0.1|" "$ENV_FILE" 2>/dev/null \
                     || echo "SNAPSERVER_HOST=127.0.0.1" >> "$ENV_FILE"
             else
@@ -63,8 +75,8 @@ _update_server() {
 host=$(_discover_ipv4) || true
 if [[ -n "$host" ]] && [[ "$host" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     if _update_server "$host" && $WATCH_MODE; then
-        echo "snapclient-discover: restarting client for new server"
-        cd /opt/snapclient && docker compose restart snapclient 2>/dev/null || true
+        echo "snapclient-discover: restarting services for new server"
+        cd /opt/snapclient && docker compose restart 2>/dev/null || true
     fi
 else
     echo "snapclient-discover: no snapserver found via mDNS"

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -601,6 +601,7 @@ BASE_PACKAGES="ca-certificates curl alsa-utils avahi-daemon avahi-utils"
 
 # Skip apt-get if all base packages are already installed (firstboot did it)
 _missing_pkgs=""
+# shellcheck disable=SC2086
 for _pkg in $BASE_PACKAGES; do
     dpkg -s "$_pkg" &>/dev/null || _missing_pkgs="$_missing_pkgs $_pkg"
 done

--- a/scripts/common/setup-docker.sh
+++ b/scripts/common/setup-docker.sh
@@ -69,7 +69,13 @@ setup_docker() {
         return 1
     fi
 
-    # Switch to fuse-overlayfs (required for read-only filesystem)
+    # Switch to fuse-overlayfs only when read-only mode is enabled.
+    # Normal installs keep the default overlay2 driver (no wipe needed).
+    if [[ "${ENABLE_READONLY:-false}" != "true" ]]; then
+        log_info "Docker ready (overlay2, read-only mode disabled)"
+        return 0
+    fi
+
     local current_driver
     current_driver=$(docker info --format '{{.Driver}}' 2>/dev/null || echo "none")
     if [[ "$current_driver" != "fuse-overlayfs" ]]; then

--- a/scripts/common/wait-network.sh
+++ b/scripts/common/wait-network.sh
@@ -82,8 +82,12 @@ _try_recover_network() {
         if ping -c1 -W2 1.1.1.1 &>/dev/null && ! getent hosts deb.debian.org &>/dev/null; then
             log_warn "DNS not working — trying fallback (1.1.1.1)..."
             if command -v resolvectl &>/dev/null; then
-                # systemd-resolved: set fallback DNS without touching resolv.conf
-                resolvectl dns 1.1.1.1 2>/dev/null || true
+                # systemd-resolved: set fallback DNS on default interface
+                local _iface
+                _iface=$(ip route show default 2>/dev/null | awk '/default/{print $5; exit}')
+                if [[ -n "$_iface" ]]; then
+                    resolvectl dns "$_iface" 1.1.1.1 2>/dev/null || true
+                fi
             elif [[ -f /etc/resolv.conf ]] && ! grep -q '1.1.1.1' /etc/resolv.conf; then
                 # Static resolv.conf: add temporarily, mark for cleanup
                 sed -i '1i nameserver 1.1.1.1  # snapmulti-fallback' /etc/resolv.conf 2>/dev/null || true

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -578,8 +578,14 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     set_module "verify-client"
     next_step "Verifying client..."
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
-    local_client_healthy=false
+
+    # Start client containers (setup.sh only enables the service, doesn't start it)
     local_client_compose=(-f "$CLIENT_DIR/docker-compose.yml")
+    log_info "Starting client containers..."
+    cd "$CLIENT_DIR"
+    docker compose "${local_client_compose[@]}" up -d 2>/dev/null || log_warn "docker compose up failed"
+
+    local_client_healthy=false
     local_client_total=$(docker compose "${local_client_compose[@]}" config --services 2>/dev/null | wc -l)
     if [[ "$local_client_total" -eq 0 ]]; then
         log_warn "Could not determine client service count — skipping health check"

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -606,10 +606,12 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
         sleep 5
     done
     if [[ "$local_client_healthy" == "false" ]]; then
-        log_warn "Client services not all healthy after 60s"
+        log_error "Client services not all healthy after 60s"
         docker compose -f "$CLIENT_DIR/docker-compose.yml" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
-            log_warn "  $line"
+            log_error "  $line"
         done
+        log_error "Client verify failed — will retry on next boot"
+        exit 1
     fi
     fi  # local_client_total guard
     checkpoint_done "setup"


### PR DESCRIPTION
## Summary
6 install/runtime fixes for server-only, client-only, and both modes.

### Fixes
1. **firstboot.sh**: Start client containers before verify (setup.sh only `systemctl enable`, doesn't start)
2. **discover-server.sh**: Detect "both" mode via install.conf / `/opt/snapmulti` existence (was: `docker ps grep` — race at boot)
3. **discover-server.sh**: Restart ALL client services on server change (was: only snapclient — fb-display stayed on old host)
4. **setup-docker.sh**: Only switch to fuse-overlayfs when `ENABLE_READONLY=true` (was: always — unnecessary Docker wipe on normal installs)
5. **wait-network.sh**: Pass interface to `resolvectl dns` (was: treating IP as interface name — silent no-op)
6. **setup.sh**: Add shellcheck disable for intentional word-split

### Compatibility
- [x] server-only: setup-docker.sh skips fuse-overlayfs switch
- [x] client-only: discover-server.sh does mDNS discovery (not "both" pinning)
- [x] both: discover-server.sh pins to 127.0.0.1 via install.conf check

## Test plan
- [x] shellcheck passes (5 files)
- [x] bash -n syntax check passes (5 files)
- [x] 48 existing tests pass
- E2E with Docker/systemd: not executable on Mac (declared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)