### PR TITLE
fix: healthcheck verification, script hardening, tests

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1534,6 +1534,20 @@ fi
 progress_complete
 
 _elapsed="$((SECONDS / 60))m$((SECONDS % 60))s"
+
+# Exit early with clear error if pull failed — don't show success banner.
+# firstboot won't mark .done-setup, so it retries on next boot
+# (fuse-overlayfs already configured, no wipe)
+if [[ "${PULL_FAILED:-false}" == "true" ]]; then
+    echo "========================================="
+    echo "Setup Incomplete ($_elapsed)"
+    echo "========================================="
+    echo ""
+    echo "WARNING: Image pull failed — will retry on next boot"
+    echo "  To retry manually: cd $INSTALL_DIR && docker compose pull"
+    exit 1
+fi
+
 echo "========================================="
 echo "Setup Complete! ($_elapsed)"
 echo "========================================="
@@ -1573,12 +1587,5 @@ if [[ "$NEEDS_REBOOT" == "true" ]]; then
 echo ""
 echo "NOTE: Boot configuration was modified."
 echo "  A reboot is required for changes to take effect."
-fi
-
-# Exit with error if pull failed — firstboot won't mark .done-setup,
-# so it retries on next boot (fuse-overlayfs already configured, no wipe)
-if [[ "${PULL_FAILED:-false}" == "true" ]]; then
-    echo "WARNING: Setup completed but image pull failed — will retry on next boot"
-    exit 1
 fi
 echo ""

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1160,7 +1160,10 @@ declare -A env_vars=(
     ["IMAGE_TAG"]="${IMAGE_TAG:-latest}"
     # Version tag (for display) — prefer VERSION file baked by prepare-sd.sh,
     # fall back to git describe (dev clones), then short SHA, then "dev".
-    ["APP_VERSION"]="$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "dev")"
+    ["APP_VERSION"]="$(cat "$INSTALL_DIR/VERSION" 2>/dev/null \
+        || git -C "$INSTALL_DIR" describe --tags --always 2>/dev/null \
+        || git -C "$INSTALL_DIR" rev-parse --short HEAD 2>/dev/null \
+        || echo "dev")"
 )
 
 for key in "${!env_vars[@]}"; do

--- a/client/tests/test_discover_server.sh
+++ b/client/tests/test_discover_server.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DISCOVER_SH="$SCRIPT_DIR/../common/scripts/discover-server.sh"
-
 pass=0
 fail=0
 

--- a/client/tests/test_discover_server.sh
+++ b/client/tests/test_discover_server.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISCOVER_SH="$SCRIPT_DIR/../common/scripts/discover-server.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got '$actual', expected '$expected')"
+        fail=$((fail + 1))
+    fi
+}
+
+_write_server() {
+    local host="$1"
+    printf 'SNAPSERVER_HOST=%s\n' "$host" > "$ENV_FILE"
+}
+
+_restart_stack() {
+    grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2 > "$LOG_FILE"
+    return "${RESTART_RC:-0}"
+}
+
+_apply_server_change() {
+    local new_host="$1"
+    local current
+    current=$(grep "^SNAPSERVER_HOST=" "$ENV_FILE" 2>/dev/null | cut -d= -f2) || true
+    if [[ "$new_host" != "$current" ]]; then
+        _write_server "$new_host"
+        echo "$new_host" > "$LAST_IP_FILE"
+        if [[ "${WATCH_MODE:-false}" == "true" ]]; then
+            _restart_stack || return 2
+        fi
+        return 0
+    fi
+    return 1
+}
+
+echo "Testing discover-server restart ordering..."
+
+test_apply_change() {
+    local initial="$1" new_host="$2" watch_mode="$3" restart_rc="$4" expected_rc="$5" expected_host="$6" desc="$7"
+    local tmpdir env_file ip_file log_file
+    tmpdir=$(mktemp -d)
+    env_file="$tmpdir/.env"
+    ip_file="$tmpdir/last-ip"
+    log_file="$tmpdir/restart.log"
+
+    printf 'SNAPSERVER_HOST=%s\n' "$initial" > "$env_file"
+
+    ENV_FILE="$env_file"
+    LAST_IP_FILE="$ip_file"
+    WATCH_MODE="$watch_mode"
+    LOG_FILE="$log_file"
+    RESTART_RC="$restart_rc"
+
+    local rc=0 current restarted_with
+    _apply_server_change "$new_host" || rc=$?
+    current=$(grep '^SNAPSERVER_HOST=' "$env_file" | cut -d= -f2)
+    restarted_with="$(cat "$log_file" 2>/dev/null || echo '')"
+
+    assert_eq "$rc" "$expected_rc" "$desc: return code"
+    assert_eq "$current" "$expected_host" "$desc: .env updated"
+    if [[ "$watch_mode" == "true" ]]; then
+        assert_eq "$restarted_with" "$expected_host" "$desc: restart sees new host"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+test_apply_change "10.0.0.5" "127.0.0.1" "true" 0 0 "127.0.0.1" "both mode change"
+test_apply_change "10.0.0.5" "192.168.1.20" "true" 0 0 "192.168.1.20" "mDNS host change"
+test_apply_change "10.0.0.5" "127.0.0.1" "true" 1 2 "127.0.0.1" "restart failure preserves updated host"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/client/tests/test_discover_server.sh
+++ b/client/tests/test_discover_server.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISCOVER_SH="$SCRIPT_DIR/../common/scripts/discover-server.sh"
+
 pass=0
 fail=0
 
@@ -15,66 +18,72 @@ assert_eq() {
     fi
 }
 
-_write_server() {
-    local host="$1"
-    printf 'SNAPSERVER_HOST=%s\n' "$host" > "$ENV_FILE"
-}
+# Extract production functions from discover-server.sh
+# _update_server writes to ENV_FILE and LAST_IP_FILE (module-level vars)
+eval "$(sed -n '/^_update_server()/,/^}/p' "$DISCOVER_SH")"
 
-_restart_stack() {
-    grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2 > "$LOG_FILE"
-    return "${RESTART_RC:-0}"
-}
+# macOS sed -i requires '' arg; production targets Linux (GNU sed).
+# Wrap sed so -i works portably in test environment.
+MOCK_BIN=$(mktemp -d)
+trap 'rm -rf "$MOCK_BIN"' EXIT
+REAL_SED=$(command -v sed)
+cat > "$MOCK_BIN/sed" <<WRAPPER
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "-i" ]]; then
+    shift
+    "$REAL_SED" -i '' "\$@"
+else
+    "$REAL_SED" "\$@"
+fi
+WRAPPER
+chmod +x "$MOCK_BIN/sed"
+export PATH="$MOCK_BIN:$PATH"
 
-_apply_server_change() {
-    local new_host="$1"
-    local current
-    current=$(grep "^SNAPSERVER_HOST=" "$ENV_FILE" 2>/dev/null | cut -d= -f2) || true
-    if [[ "$new_host" != "$current" ]]; then
-        _write_server "$new_host"
-        echo "$new_host" > "$LAST_IP_FILE"
-        if [[ "${WATCH_MODE:-false}" == "true" ]]; then
-            _restart_stack || return 2
-        fi
-        return 0
-    fi
-    return 1
-}
+echo "Testing discover-server _update_server + restart ordering..."
 
-echo "Testing discover-server restart ordering..."
-
-test_apply_change() {
-    local initial="$1" new_host="$2" watch_mode="$3" restart_rc="$4" expected_rc="$5" expected_host="$6" desc="$7"
-    local tmpdir env_file ip_file log_file
+test_update_and_restart() {
+    local initial="$1" new_host="$2" do_restart="$3" restart_rc="$4" expected_rc="$5" expected_host="$6" desc="$7"
+    local tmpdir
     tmpdir=$(mktemp -d)
-    env_file="$tmpdir/.env"
-    ip_file="$tmpdir/last-ip"
-    log_file="$tmpdir/restart.log"
 
-    printf 'SNAPSERVER_HOST=%s\n' "$initial" > "$env_file"
+    # Set module-level vars used by the eval'd _update_server function
+    ENV_FILE="$tmpdir/.env"
+    # shellcheck disable=SC2034  # used by eval'd _update_server
+    LAST_IP_FILE="$tmpdir/last-ip"
+    local log_file="$tmpdir/restart.log"
 
-    ENV_FILE="$env_file"
-    LAST_IP_FILE="$ip_file"
-    WATCH_MODE="$watch_mode"
-    LOG_FILE="$log_file"
-    RESTART_RC="$restart_rc"
+    printf 'SNAPSERVER_HOST=%s\n' "$initial" > "$ENV_FILE"
 
-    local rc=0 current restarted_with
-    _apply_server_change "$new_host" || rc=$?
-    current=$(grep '^SNAPSERVER_HOST=' "$env_file" | cut -d= -f2)
+    # Simulate the production pattern: _update_server writes .env,
+    # then caller restarts if in watch mode (same ordering as discover-server.sh:77-79)
+    local rc=0
+    if _update_server "$new_host"; then
+        # .env updated — now simulate restart (reads .env like docker compose would)
+        if [[ "$do_restart" == "true" ]]; then
+            grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2 > "$log_file"
+            (exit "$restart_rc") || rc=2
+        fi
+    else
+        rc=1  # unchanged
+    fi
+
+    local current restarted_with
+    current=$(grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2)
     restarted_with="$(cat "$log_file" 2>/dev/null || echo '')"
 
     assert_eq "$rc" "$expected_rc" "$desc: return code"
     assert_eq "$current" "$expected_host" "$desc: .env updated"
-    if [[ "$watch_mode" == "true" ]]; then
+    if [[ "$do_restart" == "true" && "$rc" -ne 1 ]]; then
         assert_eq "$restarted_with" "$expected_host" "$desc: restart sees new host"
     fi
 
     rm -rf "$tmpdir"
 }
 
-test_apply_change "10.0.0.5" "127.0.0.1" "true" 0 0 "127.0.0.1" "both mode change"
-test_apply_change "10.0.0.5" "192.168.1.20" "true" 0 0 "192.168.1.20" "mDNS host change"
-test_apply_change "10.0.0.5" "127.0.0.1" "true" 1 2 "127.0.0.1" "restart failure preserves updated host"
+test_update_and_restart "10.0.0.5" "127.0.0.1" "true"  0 0 "127.0.0.1"    "both mode change"
+test_update_and_restart "10.0.0.5" "192.168.1.20" "true"  0 0 "192.168.1.20" "mDNS host change"
+test_update_and_restart "10.0.0.5" "127.0.0.1" "true"  1 2 "127.0.0.1"    "restart failure preserves updated host"
+test_update_and_restart "10.0.0.5" "10.0.0.5"  "true"  0 1 "10.0.0.5"     "same host is no-op"
 
 echo ""
 if [[ "$fail" -gt 0 ]]; then

--- a/scripts/common/install-deps.sh
+++ b/scripts/common/install-deps.sh
@@ -82,7 +82,7 @@ install_dependencies() {
     fi
 
     # Build package list based on install type
-    local pkgs=(curl ca-certificates)
+    local pkgs=(curl ca-certificates python3 netcat-openbsd)
 
     if ! command -v git &>/dev/null; then
         pkgs+=(git)

--- a/scripts/common/mount-music.sh
+++ b/scripts/common/mount-music.sh
@@ -105,6 +105,9 @@ setup_music_source() {
                 export MUSIC_PATH="$mount_point"
                 log_info "SMB mounted: $mount_point"
             else
+                if [[ -f "$creds_file" ]]; then
+                    rm -f "$creds_file" 2>/dev/null || true
+                fi
                 log_warn "SMB mount failed — falling back to auto-detect"
             fi
             ;;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -364,6 +364,24 @@ install_dependencies() {
         info "Git already installed"
     fi
 
+    if ! command -v python3 >/dev/null 2>&1; then
+        info "Installing python3..."
+        apt-get update -qq
+        apt-get install -y -qq python3 >/dev/null
+        ok "python3 installed"
+    else
+        info "python3 already installed"
+    fi
+
+    if ! command -v nc >/dev/null 2>&1; then
+        info "Installing netcat..."
+        apt-get update -qq
+        apt-get install -y -qq netcat-openbsd >/dev/null
+        ok "netcat installed"
+    else
+        info "netcat already installed"
+    fi
+
     # Avahi is required for mDNS discovery (Spotify Connect, AirPlay)
     if ! command -v avahi-daemon >/dev/null 2>&1; then
         info "Installing Avahi for mDNS discovery..."
@@ -506,14 +524,10 @@ install_docker() {
         info "Added $real_user to docker group (re-login to take effect)"
     fi
 
-    # Install fuse-overlayfs (required for read-only FS support)
-    if ! command -v fuse-overlayfs &>/dev/null; then
-        apt-get install -y fuse-overlayfs >/dev/null 2>&1 \
-            || warn "fuse-overlayfs install failed — read-only mode may not work"
-    fi
-
-    # Docker daemon config (live-restore + fuse-overlayfs for read-only FS)
-    tune_docker_daemon --live-restore --fuse-overlayfs
+    # Generic server deploy keeps Docker's default storage driver.
+    # fuse-overlayfs is only required for overlayroot/read-only installs,
+    # which are handled in the dedicated firstboot/client flows.
+    tune_docker_daemon --live-restore
 
     # Enable and start Docker
     systemctl enable docker >/dev/null 2>&1 || true
@@ -894,9 +908,11 @@ verify_services() {
     while [[ $attempt -le $max_attempts ]]; do
         local running healthy
         running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
-        healthy=$(docker ps --filter "health=healthy" \
-            --filter "label=com.docker.compose.project=$(basename "$PWD")" \
-            -q 2>/dev/null | wc -l)
+        healthy=$(
+            docker compose ps -q 2>/dev/null \
+                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+                | grep -c '^healthy$' || true
+        )
         local total=${#expected_services[@]}
 
         # All services running AND all healthcheck-enabled services healthy

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -364,22 +364,16 @@ install_dependencies() {
         info "Git already installed"
     fi
 
-    if ! command -v python3 >/dev/null 2>&1; then
-        info "Installing python3..."
+    local extra_pkgs=()
+    command -v python3 >/dev/null 2>&1 || extra_pkgs+=(python3)
+    command -v nc      >/dev/null 2>&1 || extra_pkgs+=(netcat-openbsd)
+    if [[ ${#extra_pkgs[@]} -gt 0 ]]; then
+        info "Installing ${extra_pkgs[*]}..."
         apt-get update -qq
-        apt-get install -y -qq python3 >/dev/null
-        ok "python3 installed"
+        apt-get install -y -qq "${extra_pkgs[@]}" >/dev/null
+        ok "${extra_pkgs[*]} installed"
     else
-        info "python3 already installed"
-    fi
-
-    if ! command -v nc >/dev/null 2>&1; then
-        info "Installing netcat..."
-        apt-get update -qq
-        apt-get install -y -qq netcat-openbsd >/dev/null
-        ok "netcat installed"
-    else
-        info "netcat already installed"
+        info "python3 and netcat already installed"
     fi
 
     # Avahi is required for mDNS discovery (Spotify Connect, AirPlay)
@@ -910,7 +904,7 @@ verify_services() {
         running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
         healthy=$(
             docker compose ps -q 2>/dev/null \
-                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+                | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
                 | grep -c '^healthy$' || true
         )
         local total=${#expected_services[@]}

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -89,7 +89,7 @@ if [[ -f "$SNAP_BOOT/install.conf" ]]; then
     NFS_EXPORT=$(sanitize_nfs_export "$(grep -m1 '^NFS_EXPORT=' "$SNAP_BOOT/install.conf" | cut -d= -f2 | tr -d '[:space:]')")
     SMB_SERVER=$(sanitize_hostname "$(grep -m1 '^SMB_SERVER=' "$SNAP_BOOT/install.conf" | cut -d= -f2 | tr -d '[:space:]')")
     SMB_SHARE=$(sanitize_smb_share "$(grep -m1 '^SMB_SHARE=' "$SNAP_BOOT/install.conf" | cut -d= -f2 | tr -d '[:space:]')")
-    SMB_USER=$(grep -m1 '^SMB_USER=' "$SNAP_BOOT/install.conf" | cut -d= -f2- | tr -d '[:space:]')
+    SMB_USER=$(sanitize_smb_user "$(grep -m1 '^SMB_USER=' "$SNAP_BOOT/install.conf" | cut -d= -f2- | tr -d '\r')")
     SMB_PASS=$(grep -m1 '^SMB_PASS=' "$SNAP_BOOT/install.conf" | cut -d= -f2- | tr -d '\r')
 fi
 
@@ -247,6 +247,47 @@ cumulative_pct() {
         weight_sum=$(( weight_sum + STEP_WEIGHTS[i] ))
     done
     echo $(( weight_sum * 100 / total_weight ))
+}
+
+verify_compose_stack() {
+    local compose_file="$1"
+    local stack_name="$2"
+    local attempts="$3"
+    local delay="$4"
+    local compose_args=(-f "$compose_file")
+    local total hc_total running healthy attempt
+
+    total=$(docker compose "${compose_args[@]}" config --services 2>/dev/null | wc -l)
+    if [[ "$total" -eq 0 ]]; then
+        log_error "Could not determine ${stack_name} service count"
+        return 1
+    fi
+
+    hc_total=$(docker compose "${compose_args[@]}" config --format json 2>/dev/null \
+        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || hc_total=0
+
+    for attempt in $(seq 1 "$attempts"); do
+        running=$(docker compose "${compose_args[@]}" ps --status running -q 2>/dev/null | wc -l)
+        healthy=$(
+            docker compose "${compose_args[@]}" ps -q 2>/dev/null \
+                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+                | grep -c '^healthy$' || true
+        )
+
+        if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
+            log_info "All $total ${stack_name} services running ($healthy/$hc_total healthy)"
+            return 0
+        fi
+
+        log_info "Attempt $attempt/$attempts: $running/$total running, $healthy/$hc_total healthy..."
+        [[ "$attempt" -lt "$attempts" ]] && sleep "$delay"
+    done
+
+    log_error "$stack_name services not all healthy after $(( attempts * delay ))s"
+    docker compose "${compose_args[@]}" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
+        log_error "  $line"
+    done
+    return 1
 }
 
 # Headless detection (for client modes)
@@ -447,30 +488,10 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
     next_step "Verifying server containers..."
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
 
-    local_healthy=false
     local_compose=(-f "$SERVER_DIR/docker-compose.yml")
-    local_total=$(docker compose "${local_compose[@]}" config --services 2>/dev/null | wc -l)
-    # Count services with healthcheck defined (only those report "healthy")
-    local_hc_total=$(docker compose "${local_compose[@]}" config --format json 2>/dev/null \
-        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || local_hc_total=0
-    for attempt in $(seq 1 18); do
-        local_up=$(docker compose "${local_compose[@]}" ps --status running -q 2>/dev/null | wc -l)
-        local_health=$(docker compose "${local_compose[@]}" ps --status healthy -q 2>/dev/null | wc -l)
-        # All containers running AND all healthcheck-enabled containers healthy
-        if [[ "$local_up" -ge "$local_total" ]] && { [[ "$local_hc_total" -eq 0 ]] || [[ "$local_health" -ge "$local_hc_total" ]]; }; then
-            log_info "All $local_total server containers running ($local_health healthy)"
-            local_healthy=true
-            break
-        fi
-        log_info "Attempt $attempt/18: $local_up/$local_total running, $local_health/$local_hc_total healthy..."
-        sleep 10
-    done
-
-    if [[ "$local_healthy" == "false" ]]; then
-        log_warn "Not all server containers healthy after 3 minutes"
-        docker compose "${local_compose[@]}" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
-            log_warn "  $line"
-        done
+    if ! verify_compose_stack "$SERVER_DIR/docker-compose.yml" "server" 18 10; then
+        log_error "Server verify failed — will retry on next boot"
+        exit 1
     fi
     checkpoint_done "deploy"
   fi  # checkpoint guard
@@ -585,35 +606,10 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     cd "$CLIENT_DIR"
     docker compose "${local_client_compose[@]}" up -d 2>/dev/null || log_warn "docker compose up failed"
 
-    local_client_healthy=false
-    local_client_total=$(docker compose "${local_client_compose[@]}" config --services 2>/dev/null | wc -l)
-    if [[ "$local_client_total" -eq 0 ]]; then
-        log_warn "Could not determine client service count — skipping health check"
-    else
-    local_client_hc=$(docker compose "${local_client_compose[@]}" config --format json 2>/dev/null \
-        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || local_client_hc=0
-    for attempt in $(seq 1 12); do
-        local_running=$(docker compose "${local_client_compose[@]}" ps --status running -q 2>/dev/null | wc -l)
-        local_healthy=$(docker ps --filter "health=healthy" \
-            --filter "label=com.docker.compose.project=$(basename "$CLIENT_DIR")" \
-            -q 2>/dev/null | wc -l)
-        if [[ "$local_running" -ge "$local_client_total" ]] && { [[ "$local_client_hc" -eq 0 ]] || [[ "$local_healthy" -ge "$local_client_hc" ]]; }; then
-            log_info "All $local_client_total client services running ($local_healthy/$local_client_hc healthy)"
-            local_client_healthy=true
-            break
-        fi
-        log_info "Attempt $attempt/12: $local_running/$local_client_total running, $local_healthy/$local_client_hc healthy..."
-        sleep 5
-    done
-    if [[ "$local_client_healthy" == "false" ]]; then
-        log_error "Client services not all healthy after 60s"
-        docker compose -f "$CLIENT_DIR/docker-compose.yml" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
-            log_error "  $line"
-        done
+    if ! verify_compose_stack "$CLIENT_DIR/docker-compose.yml" "client" 12 5; then
         log_error "Client verify failed — will retry on next boot"
         exit 1
     fi
-    fi  # local_client_total guard
     checkpoint_done "setup"
   fi  # checkpoint guard
 fi

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -270,7 +270,7 @@ verify_compose_stack() {
         running=$(docker compose "${compose_args[@]}" ps --status running -q 2>/dev/null | wc -l)
         healthy=$(
             docker compose "${compose_args[@]}" ps -q 2>/dev/null \
-                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+                | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
                 | grep -c '^healthy$' || true
         )
 

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -488,7 +488,6 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
     next_step "Verifying server containers..."
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
 
-    local_compose=(-f "$SERVER_DIR/docker-compose.yml")
     if ! verify_compose_stack "$SERVER_DIR/docker-compose.yml" "server" 18 10; then
         log_error "Server verify failed — will retry on next boot"
         exit 1

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -38,7 +38,7 @@ fi
 
 # Shellcheck
 if command -v shellcheck &> /dev/null; then
-    run_check "Shellcheck (scripts)" "shellcheck -x -S warning scripts/*.sh scripts/**/*.sh"
+    run_check "Shellcheck (scripts)" "shellcheck -x -S warning scripts/*.sh scripts/**/*.sh client/common/scripts/*.sh client/tests/*.sh"
 else
     printf "${YELLOW}  shellcheck not installed - skipping${NC}\n"
 fi

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -52,6 +52,142 @@ function Assert-ClientDir {
     }
 }
 
+function Update-UserDataRuncmd {
+    param(
+        [string]$Content,
+        [string]$HookPath
+    )
+
+    $entry = "  - [bash, $HookPath]"
+    $lines = $Content -split "`r?`n"
+    $result = New-Object System.Collections.Generic.List[string]
+    $patched = $false
+
+    foreach ($line in $lines) {
+        if ((-not $patched) -and ($line -match '^(\s*)runcmd:\s*(\[\]|null|~)?\s*$')) {
+            $indent = $Matches[1]
+            $result.Add("${indent}runcmd:")
+            $result.Add("${indent}  - [bash, $HookPath]")
+            $patched = $true
+        } else {
+            $result.Add($line)
+        }
+    }
+
+    if (-not $patched) {
+        if ($result.Count -gt 0 -and $result[$result.Count - 1] -ne '') {
+            $result.Add('')
+        }
+        $result.Add('runcmd:')
+        $result.Add($entry)
+    }
+
+    return (($result -join "`n").TrimEnd("`r", "`n") + "`n")
+}
+
+function Assert-PreparedSdCard {
+    param(
+        [string]$Dest,
+        [string]$Boot,
+        [string]$InstallType
+    )
+
+    Write-Host ''
+    Write-Host '=== Verifying SD card ==='
+    $verifyErrors = 0
+
+    Write-Host ''
+    Write-Host '--- snapMULTI files ---'
+    $requiredBase = @(
+        'install.conf',
+        'firstboot.sh',
+        'common/progress.sh',
+        'common/logging.sh',
+        'common/unified-log.sh',
+        'common/sanitize.sh',
+        'common/system-tune.sh',
+        'common/install-docker.sh',
+        'common/install-deps.sh',
+        'common/setup-docker.sh',
+        'common/wait-network.sh',
+        'common/mount-music.sh'
+    )
+    foreach ($file in $requiredBase) {
+        $path = Join-Path $Dest $file
+        if (Test-Path $path) {
+            Write-Host "  [OK] snapmulti/$file"
+        } else {
+            Write-Host "  [MISSING] snapmulti/$file"
+            $verifyErrors++
+        }
+    }
+
+    if ($InstallType -in @('server', 'both')) {
+        foreach ($file in @(
+            'server/docker-compose.yml',
+            'server/deploy.sh',
+            'server/config/snapserver.conf',
+            'server/config/mpd.conf',
+            'server/config/shairport-sync.conf'
+        )) {
+            $path = Join-Path $Dest $file
+            if (Test-Path $path) {
+                Write-Host "  [OK] snapmulti/$file"
+            } else {
+                Write-Host "  [MISSING] snapmulti/$file"
+                $verifyErrors++
+            }
+        }
+    }
+
+    if ($InstallType -in @('client', 'both')) {
+        foreach ($file in @(
+            'client/docker-compose.yml',
+            'client/scripts/setup.sh',
+            'client/scripts/discover-server.sh',
+            'client/scripts/display.sh',
+            'client/scripts/display-detect.sh',
+            'client/snapclient.conf'
+        )) {
+            $path = Join-Path $Dest $file
+            if (Test-Path $path) {
+                Write-Host "  [OK] snapmulti/$file"
+            } else {
+                Write-Host "  [MISSING] snapmulti/$file"
+                $verifyErrors++
+            }
+        }
+    }
+
+    Write-Host ''
+    Write-Host '--- OS configuration ---'
+    $userData = Join-Path $Boot 'user-data'
+    $firstrun = Join-Path $Boot 'firstrun.sh'
+    if (Test-Path $userData) {
+        if (Select-String -Path $userData -SimpleMatch 'snapmulti/firstboot.sh' -Quiet) {
+            Write-Host '  [OK] user-data: runcmd hook present'
+        } else {
+            Write-Host '  [MISSING] user-data: runcmd hook for firstboot.sh'
+            $verifyErrors++
+        }
+    } elseif (Test-Path $firstrun) {
+        if (Select-String -Path $firstrun -SimpleMatch 'snapmulti/firstboot.sh' -Quiet) {
+            Write-Host '  [OK] firstrun.sh: hook present'
+        } else {
+            Write-Host '  [MISSING] firstrun.sh: hook for firstboot.sh'
+            $verifyErrors++
+        }
+    } else {
+        Write-Host '  [WARN] No firstrun.sh or user-data found (manual boot required)'
+    }
+
+    Write-Host ''
+    if ($verifyErrors -gt 0) {
+        throw "Verification failed: $verifyErrors issue(s) found on SD card."
+    }
+    Write-Host 'All checks passed.'
+}
+
 # ── Show install menu ─────────────────────────────────────────────
 function Show-Menu {
     Write-Host ''
@@ -157,6 +293,11 @@ function Sanitize-ShareName {
     return ($Value -replace '[^A-Za-z0-9._\-]', '')
 }
 
+function Sanitize-SmbUser {
+    param([string]$Value)
+    return ($Value -replace '[^A-Za-z0-9._@\-]', '')
+}
+
 function Get-NfsConfig {
     Write-Host ''
     Write-Host '  NFS Server Configuration'
@@ -209,7 +350,11 @@ function Get-SmbConfig {
     }
 
     Write-Host ''
-    $user = Read-Host '  Username (leave empty for guest)'
+    $rawUser = Read-Host '  Username (leave empty for guest)'
+    $user = Sanitize-SmbUser $rawUser
+    if ($rawUser -and $rawUser -ne $user) {
+        Write-Host "  Note: username adjusted to '$user' (unsupported characters removed)"
+    }
     $pass = ''
     if ($user) {
         $secPass = Read-Host '  Password' -AsSecureString
@@ -443,10 +588,10 @@ try {
     $gitVersion = 'dev'
 }
 if ($InstallType -in @('server', 'both')) {
-    [System.IO.File]::WriteAllText((Join-Path $Dest 'server/.version'), $gitVersion)
+    [System.IO.File]::WriteAllText((Join-Path $Dest 'server/.version'), $gitVersion, $Utf8NoBom)
 }
 if ($InstallType -in @('client', 'both')) {
-    [System.IO.File]::WriteAllText((Join-Path $Dest 'client/VERSION'), $gitVersion)
+    [System.IO.File]::WriteAllText((Join-Path $Dest 'client/VERSION'), $gitVersion, $Utf8NoBom)
 }
 
 $size = (Get-ChildItem $Dest -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
@@ -497,14 +642,8 @@ if (Test-Path $firstrun) {
         Write-Host 'user-data already patched, skipping.'
     } else {
         Write-Host 'Patching user-data to run installer on first boot ...'
-        # Derive runcmd YAML entry from $hook ("bash /path" -> "[bash, /path]")
         $hookPath = $hook -replace '^bash ', ''
-        $runcmdEntry = "  - [bash, $hookPath]"
-        if ($udContent -match '(?m)^runcmd:') {
-            $udContent = $udContent -replace '(?m)(^runcmd:)', "`$1`n$runcmdEntry"
-        } else {
-            $udContent += "`n`nruncmd:`n$runcmdEntry`n"
-        }
+        $udContent = Update-UserDataRuncmd -Content $udContent -HookPath $hookPath
         [System.IO.File]::WriteAllText($userData, $udContent, $Utf8NoBom)
         Write-Host '  user-data patched.'
     }
@@ -515,6 +654,9 @@ if (Test-Path $firstrun) {
     Write-Host '    sudo bash /boot/firmware/snapmulti/firstboot.sh'
     Write-Host ''
 }
+
+# ── Verify SD card contents ───────────────────────────────────────
+Assert-PreparedSdCard -Dest $Dest -Boot $Boot -InstallType $InstallType
 
 # ── Eject SD card ─────────────────────────────────────────────────
 Write-Host ''

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -29,6 +29,45 @@ check_client_dir() {
     fi
 }
 
+patch_user_data_runcmd() {
+    local user_data="$1"
+    local hook_path="$2"
+    local tmp
+    tmp=$(mktemp)
+
+    if ! awk -v hook="$hook_path" '
+        BEGIN {
+            entry = "  - [bash, " hook "]"
+            patched = 0
+        }
+        /^[[:space:]]*runcmd:[[:space:]]*(\[\]|null|~)?[[:space:]]*$/ {
+            indent = ""
+            if (match($0, /^[[:space:]]*/)) {
+                indent = substr($0, 1, RLENGTH)
+            }
+            print indent "runcmd:"
+            print indent entry
+            patched = 1
+            next
+        }
+        {
+            print
+        }
+        END {
+            if (!patched) {
+                print ""
+                print "runcmd:"
+                print entry
+            }
+        }
+    ' "$user_data" > "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+
+    mv "$tmp" "$user_data"
+}
+
 # ── Auto-detect boot partition ────────────────────────────────────
 detect_boot() {
     local candidates=()
@@ -575,15 +614,9 @@ elif [[ -f "$USERDATA" ]]; then
         echo "Patching user-data to run installer on first boot ..."
         # Convert "bash /path/to/firstboot.sh" to YAML list "[bash, /path/to/firstboot.sh]"
         HOOK_PATH="${HOOK#bash }"
-        RUNCMD_ENTRY="  - [bash, $HOOK_PATH]"
-        if grep -q '^runcmd:' "$USERDATA"; then
-            # Append to existing runcmd section
-            sed -i.bak "/^runcmd:/a\\
-$RUNCMD_ENTRY" "$USERDATA"
-            rm -f "${USERDATA}.bak"
-        else
-            # Add runcmd section
-            printf '\nruncmd:\n%s\n' "$RUNCMD_ENTRY" >> "$USERDATA"
+        if ! patch_user_data_runcmd "$USERDATA" "$HOOK_PATH"; then
+            echo "  ERROR: failed to patch user-data runcmd"
+            exit 1
         fi
         if grep -qF "snapmulti/firstboot.sh" "$USERDATA"; then
             echo "  user-data patched."
@@ -608,7 +641,7 @@ VERIFY_ERRORS=0
 # -- snapMULTI files --
 echo ""
 echo "--- snapMULTI files ---"
-for f in install.conf firstboot.sh common/progress.sh common/logging.sh common/sanitize.sh common/system-tune.sh common/install-docker.sh; do
+for f in install.conf firstboot.sh common/progress.sh common/logging.sh common/unified-log.sh common/sanitize.sh common/system-tune.sh common/install-docker.sh common/install-deps.sh common/setup-docker.sh common/wait-network.sh common/mount-music.sh; do
     if [[ -f "$DEST/$f" ]]; then
         echo "  [OK] snapmulti/$f"
     else

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -19,20 +19,22 @@ source "${SCRIPT_DIR}/common/logging.sh"
 [[ -t 1 ]] || { GREEN=''; RED=''; YELLOW=''; CYAN=''; BOLD=''; NC=''; }
 
 # ---------------------------------------------------------------------------
-# Install detection
+# Install detection — prefer /opt install dirs; fall back to repo checkout
+# only if a .env file exists (indicates a configured deployment, not a bare
+# checkout).
 # ---------------------------------------------------------------------------
 SERVER_DIR=""
 CLIENT_DIR=""
 
 for path in /opt/snapmulti "${SCRIPT_DIR}/.."; do
-    if [[ -d "$path" && -f "${path}/docker-compose.yml" ]]; then
+    if [[ -d "$path" && -f "${path}/docker-compose.yml" && -f "${path}/.env" ]]; then
         SERVER_DIR="$(cd "$path" && pwd)"
         break
     fi
 done
 
 for path in /opt/snapclient "${SCRIPT_DIR}/../client/common"; do
-    if [[ -d "$path" && -f "${path}/docker-compose.yml" ]]; then
+    if [[ -d "$path" && -f "${path}/docker-compose.yml" && -f "${path}/.env" ]]; then
         CLIENT_DIR="$(cd "$path" && pwd)"
         break
     fi
@@ -40,7 +42,7 @@ done
 
 if [[ -z "$SERVER_DIR" && -z "$CLIENT_DIR" ]]; then
     error "No snapMULTI installation found"
-    error "Expected docker-compose.yml in /opt/snapmulti or /opt/snapclient"
+    error "Expected docker-compose.yml + .env in /opt/snapmulti or /opt/snapclient"
     exit 1
 fi
 
@@ -65,8 +67,21 @@ declare -A HEALTH=()
 HEALTHY=0
 TOTAL=0
 
-SERVER_CONTAINERS=(snapserver mpd shairport-sync librespot mympd metadata tidal-connect)
-CLIENT_CONTAINERS=(snapclient audio-visualizer fb-display)
+# Query actual services from docker compose (profile-aware) instead of
+# hardcoded lists — catches optional services like watchtower, tidal-connect.
+SERVER_CONTAINERS=()
+CLIENT_CONTAINERS=()
+
+if [[ -n "$SERVER_DIR" ]]; then
+    mapfile -t SERVER_CONTAINERS < <(
+        docker compose -f "$SERVER_DIR/docker-compose.yml" config --services 2>/dev/null || true
+    )
+fi
+if [[ -n "$CLIENT_DIR" ]]; then
+    mapfile -t CLIENT_CONTAINERS < <(
+        docker compose -f "$CLIENT_DIR/docker-compose.yml" config --services 2>/dev/null || true
+    )
+fi
 
 count_health() {
     local cname
@@ -85,8 +100,8 @@ count_health() {
     done
 }
 
-[[ -n "$SERVER_DIR" ]] && count_health "${SERVER_CONTAINERS[@]}"
-[[ -n "$CLIENT_DIR" ]] && count_health "${CLIENT_CONTAINERS[@]}"
+[[ ${#SERVER_CONTAINERS[@]} -gt 0 ]] && count_health "${SERVER_CONTAINERS[@]}"
+[[ ${#CLIENT_CONTAINERS[@]} -gt 0 ]] && count_health "${CLIENT_CONTAINERS[@]}"
 
 if [[ "$TOTAL" -eq 0 ]]; then
     error "No running snapMULTI containers found"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -88,6 +88,12 @@ count_health() {
 [[ -n "$SERVER_DIR" ]] && count_health "${SERVER_CONTAINERS[@]}"
 [[ -n "$CLIENT_DIR" ]] && count_health "${CLIENT_CONTAINERS[@]}"
 
+if [[ "$TOTAL" -eq 0 ]]; then
+    error "No running snapMULTI containers found"
+    error "Start the stack first with docker compose up -d"
+    exit 1
+fi
+
 show_container() {
     local cname="$1"
     local health="${HEALTH[$cname]:-}"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -128,40 +128,66 @@ download_and_extract() {
 
 apply_update() {
     local src_dir="$1"
+    local ts
+    ts=$(date +%Y%m%d-%H%M%S)
 
     info "Applying update..."
 
+    # Stage the update in a temporary copy so a failed cp doesn't leave
+    # the live install half-mutated. On success we swap; on failure we
+    # restore the backup.
+    local backup_root="$HOME/.claude-backups/update/$ts"
+    local staging_dir
+    staging_dir=$(mktemp -d "${INSTALL_DIR}.staging.XXXXXX")
+
+    # Snapshot current install into staging (hard-link where possible for speed)
+    cp -al "$INSTALL_DIR/." "$staging_dir/" 2>/dev/null \
+        || cp -a "$INSTALL_DIR/." "$staging_dir/"
+
+    # Apply changes to the staging copy
     for target in "${UPDATE_TARGETS[@]}"; do
         if [[ -e "$src_dir/$target" ]]; then
             if [[ -d "$src_dir/$target" ]]; then
-                # Directory: replace contents so files removed upstream don't linger.
-                # Backup removed files to ~/.claude-backups in case of rollback.
-                if [[ -d "$INSTALL_DIR/$target" ]]; then
-                    local backup_dir
-                    backup_dir="$HOME/.claude-backups/update/$(date +%Y%m%d-%H%M%S)/$target"
-                    mkdir -p "$backup_dir"
-                    # Identify files present locally but absent in new release
+                # Remove entries (files, symlinks, empty dirs) absent from new release
+                if [[ -d "$staging_dir/$target" ]]; then
                     while IFS= read -r rel_path; do
                         if [[ ! -e "$src_dir/$target/$rel_path" ]]; then
-                            local parent
-                            parent=$(dirname "$backup_dir/$rel_path")
-                            mkdir -p "$parent"
-                            mv "$INSTALL_DIR/$target/$rel_path" "$backup_dir/$rel_path"
+                            local dest="$staging_dir/$target/$rel_path"
+                            mkdir -p "$backup_root/$target/$(dirname "$rel_path")"
+                            mv "$dest" "$backup_root/$target/$rel_path" 2>/dev/null || true
                         fi
-                    done < <(cd "$INSTALL_DIR/$target" && find . -type f | sed 's|^\./||')
-                    rmdir "$backup_dir" 2>/dev/null || true  # clean up if empty
+                    done < <(cd "$staging_dir/$target" && find . \( -type f -o -type l \) | sed 's|^\./||')
+                    # Prune empty directories not present in new release
+                    (cd "$staging_dir/$target" && find . -depth -type d -empty -exec rmdir {} \; 2>/dev/null) || true
                 fi
-                cp -r "$src_dir/$target/." "$INSTALL_DIR/$target/"
+                mkdir -p "$staging_dir/$target"
+                cp -r "$src_dir/$target/." "$staging_dir/$target/"
             else
-                # File: overwrite
-                cp "$src_dir/$target" "$INSTALL_DIR/$target"
+                cp "$src_dir/$target" "$staging_dir/$target"
             fi
-            ok "Updated: $target"
         fi
     done
 
     # Ensure scripts are executable
-    chmod +x "$INSTALL_DIR/scripts/"*.sh 2>/dev/null || true
+    chmod +x "$staging_dir/scripts/"*.sh 2>/dev/null || true
+
+    # Atomic swap: move live → backup, staging → live
+    # If the swap fails, restore the backup.
+    local live_backup="${INSTALL_DIR}.pre-update.$ts"
+    if mv "$INSTALL_DIR" "$live_backup" && mv "$staging_dir" "$INSTALL_DIR"; then
+        rm -rf "$live_backup"
+        # Clean up empty backup dir
+        rmdir "$backup_root" 2>/dev/null || true
+        for target in "${UPDATE_TARGETS[@]}"; do
+            [[ -e "$src_dir/$target" ]] && ok "Updated: $target"
+        done
+    else
+        error "Swap failed — restoring previous install"
+        # Restore: put back whatever we moved
+        [[ -d "$live_backup" && ! -d "$INSTALL_DIR" ]] && mv "$live_backup" "$INSTALL_DIR"
+        rm -rf "$staging_dir"
+        exit 1
+    fi
 }
 
 pull_and_restart() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -141,8 +141,9 @@ apply_update() {
     staging_dir=$(mktemp -d "${INSTALL_DIR}.staging.XXXXXX")
 
     # Snapshot current install into staging (hard-link where possible for speed)
-    cp -al "$INSTALL_DIR/." "$staging_dir/" 2>/dev/null \
-        || cp -a "$INSTALL_DIR/." "$staging_dir/"
+    # Full copy (not hard links) so staging is fully isolated from live install.
+    # Hard links would share inodes — cp overwrites would mutate INSTALL_DIR.
+    cp -a "$INSTALL_DIR/." "$staging_dir/"
 
     # Apply changes to the staging copy
     for target in "${UPDATE_TARGETS[@]}"; do

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -181,7 +181,7 @@ verify_services() {
         running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
         healthy=$(
             docker compose ps -q 2>/dev/null \
-                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+                | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
                 | grep -c '^healthy$' || true
         )
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -134,8 +134,24 @@ apply_update() {
     for target in "${UPDATE_TARGETS[@]}"; do
         if [[ -e "$src_dir/$target" ]]; then
             if [[ -d "$src_dir/$target" ]]; then
-                # Directory: sync contents (don't delete existing extra files)
-                cp -r "$src_dir/$target" "$INSTALL_DIR/"
+                # Directory: replace contents so files removed upstream don't linger.
+                # Backup removed files to ~/.claude-backups in case of rollback.
+                if [[ -d "$INSTALL_DIR/$target" ]]; then
+                    local backup_dir
+                    backup_dir="$HOME/.claude-backups/update/$(date +%Y%m%d-%H%M%S)/$target"
+                    mkdir -p "$backup_dir"
+                    # Identify files present locally but absent in new release
+                    while IFS= read -r rel_path; do
+                        if [[ ! -e "$src_dir/$target/$rel_path" ]]; then
+                            local parent
+                            parent=$(dirname "$backup_dir/$rel_path")
+                            mkdir -p "$parent"
+                            mv "$INSTALL_DIR/$target/$rel_path" "$backup_dir/$rel_path"
+                        fi
+                    done < <(cd "$INSTALL_DIR/$target" && find . -type f | sed 's|^\./||')
+                    rmdir "$backup_dir" 2>/dev/null || true  # clean up if empty
+                fi
+                cp -r "$src_dir/$target/." "$INSTALL_DIR/$target/"
             else
                 # File: overwrite
                 cp "$src_dir/$target" "$INSTALL_DIR/$target"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -39,7 +39,7 @@ error() { echo -e "\033[31m[ERROR]\033[0m $*" >&2; }
 
 check_dependencies() {
     local missing=()
-    for cmd in curl tar docker; do
+    for cmd in curl tar docker python3; do
         command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
     done
     if [[ ${#missing[@]} -gt 0 ]]; then
@@ -56,6 +56,13 @@ get_current_version() {
     fi
 }
 
+parse_latest_tag() {
+    local response="$1"
+    echo "$response" \
+        | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        | head -n1
+}
+
 get_latest_release() {
     local response
     response=$(curl -sf --max-time 15 \
@@ -66,7 +73,7 @@ get_latest_release() {
 
     # Extract tag_name without jq dependency
     local tag
-    tag=$(echo "$response" | grep -o '"tag_name":"[^"]*"' | cut -d'"' -f4)
+    tag=$(parse_latest_tag "$response")
     if [[ -z "$tag" ]]; then
         error "Could not parse latest release tag"
         exit 1
@@ -76,6 +83,10 @@ get_latest_release() {
 
 compare_versions() {
     local current="$1" latest="$2"
+
+    if [[ -z "$current" ]] || [[ "$current" == "unknown" ]]; then
+        return 1  # unknown local version: allow update
+    fi
 
     # Strip leading 'v' for comparison
     local current_clean="${current#v}"
@@ -168,9 +179,11 @@ verify_services() {
     for attempt in $(seq 1 "$max_attempts"); do
         local running healthy
         running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
-        healthy=$(docker ps --filter "health=healthy" \
-            --filter "label=com.docker.compose.project=$(basename "$PWD")" \
-            -q 2>/dev/null | wc -l)
+        healthy=$(
+            docker compose ps -q 2>/dev/null \
+                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+                | grep -c '^healthy$' || true
+        )
 
         # All services running AND all healthcheck-enabled services healthy
         if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then

--- a/tests/test_deploy_docker_gating.sh
+++ b/tests/test_deploy_docker_gating.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../scripts/deploy.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  FAIL: $desc (unexpected '$needle')"
+        fail=$((fail + 1))
+    else
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    fi
+}
+
+install_docker_body="$(sed -n '/^install_docker()/,/^}/p' "$DEPLOY_SH")"
+
+echo "Testing deploy.sh Docker driver gating..."
+
+assert_contains "$install_docker_body" "tune_docker_daemon --live-restore" "deploy configures live-restore"
+assert_not_contains "$install_docker_body" "--fuse-overlayfs" "deploy does not force fuse-overlayfs"
+assert_not_contains "$install_docker_body" "apt-get install -y fuse-overlayfs" "deploy does not install fuse-overlayfs eagerly"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_firstboot_verify.sh
+++ b/tests/test_firstboot_verify.sh
@@ -18,85 +18,67 @@ assert_eq() {
     fi
 }
 
-verify_compose_stack() {
-    local compose_file="$1"
-    local stack_name="$2"
-    local attempts="$3"
-    local delay="$4"
-    local compose_args=(-f "$compose_file")
-    local total hc_total running healthy attempt
+# Extract the production function from firstboot.sh rather than maintaining a copy
+eval "$(sed -n '/^verify_compose_stack()/,/^}/p' "$FIRSTBOOT_SH")"
 
-    total=$(docker compose "${compose_args[@]}" config --services 2>/dev/null | wc -l)
-    if [[ "$total" -eq 0 ]]; then
-        log_error "Could not determine ${stack_name} service count"
-        return 1
-    fi
-
-    hc_total=$(docker compose "${compose_args[@]}" config --format json 2>/dev/null \
-        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || hc_total=0
-
-    for attempt in $(seq 1 "$attempts"); do
-        running=$(docker compose "${compose_args[@]}" ps --status running -q 2>/dev/null | wc -l)
-        healthy=$(
-            docker compose "${compose_args[@]}" ps -q 2>/dev/null \
-                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
-                | grep -c '^healthy$' || true
-        )
-
-        if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
-            return 0
-        fi
-
-        [[ "$attempt" -lt "$attempts" ]] && sleep "$delay"
-    done
-
-    docker compose "${compose_args[@]}" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null >/dev/null
-    return 1
-}
-
-run_case() {
-    local total="$1" hc_total="$2" running="$3" healthy="$4" expect_rc="$5" desc="$6"
-    MOCK_TOTAL="$total"
-    MOCK_HC_TOTAL="$hc_total"
-    MOCK_RUNNING="$running"
-    MOCK_HEALTHY="$healthy"
-
-    log_info() { :; }
-    log_error() { :; }
-    sleep() { :; }
-    docker() {
-        local args="$*"
-        if [[ "$args" == "compose -f /tmp/stack.yml config --services" ]]; then
+# Create mock docker script on PATH so xargs can invoke it
+MOCK_BIN=$(mktemp -d)
+cat > "$MOCK_BIN/docker" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == "compose" ]]; then
+    shift  # consume "compose"
+    # Skip flags like -f <file>
+    while [[ "${1:-}" == "-f" ]]; do shift 2; done
+    case "${1:-} ${2:-} ${3:-}" in
+        "config --services "*|"config --services ")
             if [[ "${MOCK_TOTAL:-0}" -gt 0 ]]; then
                 seq 1 "${MOCK_TOTAL:-0}" | sed 's/.*/svc&/'
             fi
-            return 0
-        fi
-        if [[ "$args" == "compose -f /tmp/stack.yml config --format json" ]]; then
-            python3 - <<'PY'
+            ;;
+        "config --format json")
+            python3 -c "
 import json, os
 hc = int(os.environ.get('MOCK_HC_TOTAL', '0'))
 services = {}
 for i in range(max(hc, 1)):
     services[f'svc{i}'] = {'healthcheck': {'test': ['CMD', 'true']}} if i < hc else {}
 print(json.dumps({'services': services}))
-PY
-            return 0
-        fi
-        if [[ "$args" == "compose -f /tmp/stack.yml ps --status running -q" ]]; then
+"
+            ;;
+        "ps --status running")
             seq 1 "${MOCK_RUNNING:-0}" | sed 's/.*/id&/'
-            return 0
-        fi
-        if [[ "$args" == "compose -f /tmp/stack.yml ps -q" ]]; then
+            ;;
+        "ps -q "*)
             seq 1 "${MOCK_HEALTHY:-0}" | sed 's/.*/id&/'
-            return 0
-        fi
-        if [[ "$1" == "inspect" ]]; then
-            seq 1 "${MOCK_HEALTHY:-0}" | sed 's/.*/healthy/'
-            return 0
-        fi
-        return 0
-    }
+            ;;
+    esac
+elif [[ "$1" == "inspect" ]]; then
+    # Called by xargs with container IDs as trailing args
+    for arg in "${@:2}"; do
+        [[ "$arg" == --* ]] && continue
+        echo "healthy"
+    done
+fi
+MOCK
+chmod +x "$MOCK_BIN/docker"
+# Also create a mock sleep to avoid delays
+cat > "$MOCK_BIN/sleep" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+chmod +x "$MOCK_BIN/sleep"
+export PATH="$MOCK_BIN:$PATH"
+trap 'rm -rf "$MOCK_BIN"' EXIT
+
+log_info() { :; }
+log_error() { :; }
+
+run_case() {
+    local total="$1" hc_total="$2" running="$3" healthy="$4" expect_rc="$5" desc="$6"
+    export MOCK_TOTAL="$total"
+    export MOCK_HC_TOTAL="$hc_total"
+    export MOCK_RUNNING="$running"
+    export MOCK_HEALTHY="$healthy"
 
     local rc=0
     verify_compose_stack /tmp/stack.yml stack 2 0 || rc=$?

--- a/tests/test_firstboot_verify.sh
+++ b/tests/test_firstboot_verify.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIRSTBOOT_SH="$SCRIPT_DIR/../scripts/firstboot.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got '$actual', expected '$expected')"
+        fail=$((fail + 1))
+    fi
+}
+
+verify_compose_stack() {
+    local compose_file="$1"
+    local stack_name="$2"
+    local attempts="$3"
+    local delay="$4"
+    local compose_args=(-f "$compose_file")
+    local total hc_total running healthy attempt
+
+    total=$(docker compose "${compose_args[@]}" config --services 2>/dev/null | wc -l)
+    if [[ "$total" -eq 0 ]]; then
+        log_error "Could not determine ${stack_name} service count"
+        return 1
+    fi
+
+    hc_total=$(docker compose "${compose_args[@]}" config --format json 2>/dev/null \
+        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || hc_total=0
+
+    for attempt in $(seq 1 "$attempts"); do
+        running=$(docker compose "${compose_args[@]}" ps --status running -q 2>/dev/null | wc -l)
+        healthy=$(
+            docker compose "${compose_args[@]}" ps -q 2>/dev/null \
+                | xargs docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+                | grep -c '^healthy$' || true
+        )
+
+        if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
+            return 0
+        fi
+
+        [[ "$attempt" -lt "$attempts" ]] && sleep "$delay"
+    done
+
+    docker compose "${compose_args[@]}" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null >/dev/null
+    return 1
+}
+
+run_case() {
+    local total="$1" hc_total="$2" running="$3" healthy="$4" expect_rc="$5" desc="$6"
+    MOCK_TOTAL="$total"
+    MOCK_HC_TOTAL="$hc_total"
+    MOCK_RUNNING="$running"
+    MOCK_HEALTHY="$healthy"
+
+    log_info() { :; }
+    log_error() { :; }
+    sleep() { :; }
+    docker() {
+        local args="$*"
+        if [[ "$args" == "compose -f /tmp/stack.yml config --services" ]]; then
+            if [[ "${MOCK_TOTAL:-0}" -gt 0 ]]; then
+                seq 1 "${MOCK_TOTAL:-0}" | sed 's/.*/svc&/'
+            fi
+            return 0
+        fi
+        if [[ "$args" == "compose -f /tmp/stack.yml config --format json" ]]; then
+            python3 - <<'PY'
+import json, os
+hc = int(os.environ.get('MOCK_HC_TOTAL', '0'))
+services = {}
+for i in range(max(hc, 1)):
+    services[f'svc{i}'] = {'healthcheck': {'test': ['CMD', 'true']}} if i < hc else {}
+print(json.dumps({'services': services}))
+PY
+            return 0
+        fi
+        if [[ "$args" == "compose -f /tmp/stack.yml ps --status running -q" ]]; then
+            seq 1 "${MOCK_RUNNING:-0}" | sed 's/.*/id&/'
+            return 0
+        fi
+        if [[ "$args" == "compose -f /tmp/stack.yml ps -q" ]]; then
+            seq 1 "${MOCK_HEALTHY:-0}" | sed 's/.*/id&/'
+            return 0
+        fi
+        if [[ "$1" == "inspect" ]]; then
+            seq 1 "${MOCK_HEALTHY:-0}" | sed 's/.*/healthy/'
+            return 0
+        fi
+        return 0
+    }
+
+    local rc=0
+    verify_compose_stack /tmp/stack.yml stack 2 0 || rc=$?
+    assert_eq "$rc" "$expect_rc" "$desc"
+}
+
+echo "Testing verify_compose_stack()..."
+run_case 0 0 0 0 1 "zero services fails"
+run_case 2 1 2 1 0 "healthy stack passes"
+run_case 2 1 1 0 1 "incomplete stack fails"
+run_case 2 1 2 1 0 "health count via docker inspect passes"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_mount_music.sh
+++ b/tests/test_mount_music.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOUNT_SH="$SCRIPT_DIR/../scripts/common/mount-music.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got '$actual', expected '$expected')"
+        fail=$((fail + 1))
+    fi
+}
+
+eval "$(sed -n '/^setup_music_source()/,/^}/p' "$MOUNT_SH")"
+
+log_info() { :; }
+log_warn() { :; }
+log_error() { :; }
+
+echo "Testing mount-music SMB credential cleanup..."
+
+test_smb_cleanup() {
+    local tmpdir creds_file fstab_file mount_point mount_ok expected_creds expected_fstab desc
+    mount_ok="$1"
+    expected_creds="$2"
+    expected_fstab="$3"
+    desc="$4"
+    tmpdir=$(mktemp -d)
+    creds_file="$tmpdir/smb-creds"
+    fstab_file="$tmpdir/fstab"
+    mount_point="$tmpdir/smb-mount"
+    : > "$fstab_file"
+
+    MUSIC_SOURCE="smb"
+    SMB_SERVER="nas"
+    SMB_SHARE="Music"
+    SMB_USER="alice"
+    SMB_PASS="secret"
+
+    mkdir() { command mkdir "$@"; }
+    chmod() { command chmod "$@"; }
+    timeout() { shift; "$@"; }
+    mount() { [[ "${MOUNT_OK:-false}" == "true" ]]; }
+    grep() {
+        if [[ "$1" == "-qF" ]]; then
+            local needle="$2" file="$3"
+            command grep -qF "$needle" "$file"
+            return $?
+        fi
+        command grep "$@"
+    }
+    rm() { command rm "$@"; }
+
+    export MUSIC_PATH=""
+
+    # Override paths by temporarily editing function-local expectations via subshell
+    local run_rc=0
+    MOUNT_OK="$mount_ok" CREDS_FILE="$creds_file" FSTAB_FILE="$fstab_file" MOUNT_POINT="$mount_point" bash -c '
+        set -euo pipefail
+        '"$(declare -f setup_music_source)"'
+        log_info() { :; }
+        log_warn() { :; }
+        log_error() { :; }
+        mkdir() { command mkdir "$@"; }
+        chmod() { command chmod "$@"; }
+        timeout() { shift; "$@"; }
+        mount() { [[ "${MOUNT_OK:-false}" == "true" ]]; }
+        grep() {
+            if [[ "$1" == "-qF" ]]; then
+                local needle="$2" file="$3"
+                command grep -qF "$needle" "$file"
+                return $?
+            fi
+            command grep "$@"
+        }
+        rm() { command rm "$@"; }
+        MUSIC_SOURCE="smb"
+        SMB_SERVER="nas"
+        SMB_SHARE="Music"
+        SMB_USER="alice"
+        SMB_PASS="secret"
+        # shellcheck disable=SC2016
+        eval "$(declare -f setup_music_source | sed "s|/etc/snapmulti-smb-credentials|$CREDS_FILE|g; s|/etc/fstab|$FSTAB_FILE|g; s|/media/smb-music|$MOUNT_POINT|g")"
+        setup_music_source
+    ' >/dev/null 2>&1 || run_rc=$?
+
+    local creds_exists="false" fstab_has="false"
+    [[ -f "$creds_file" ]] && creds_exists="true"
+    grep -qF '//nas/Music' "$fstab_file" && fstab_has="true" || true
+
+    assert_eq "$run_rc" "0" "$desc: helper exits cleanly"
+    assert_eq "$creds_exists" "$expected_creds" "$desc: creds file state"
+    assert_eq "$fstab_has" "$expected_fstab" "$desc: fstab state"
+
+    rm -rf "$tmpdir"
+}
+
+test_smb_cleanup "false" "false" "false" "failed mount cleans creds"
+test_smb_cleanup "true" "true" "true" "successful mount keeps creds for fstab"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_prepare_sd_ps1_static.sh
+++ b/tests/test_prepare_sd_ps1_static.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PS1_FILE="$SCRIPT_DIR/../scripts/prepare-sd.ps1"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+content="$(cat "$PS1_FILE")"
+
+echo "Testing prepare-sd.ps1 parity guards..."
+
+assert_contains "$content" 'function Update-UserDataRuncmd' "user-data patch helper exists"
+assert_contains "$content" "common/unified-log.sh" "unified-log is verified"
+assert_contains "$content" "common/install-deps.sh" "install-deps is verified"
+assert_contains "$content" "common/setup-docker.sh" "setup-docker is verified"
+assert_contains "$content" "common/wait-network.sh" "wait-network is verified"
+assert_contains "$content" "common/mount-music.sh" "mount-music is verified"
+assert_contains "$content" "WriteAllText((Join-Path \$Dest 'server/.version'), \$gitVersion, \$Utf8NoBom)" "server version uses UTF-8 without BOM"
+assert_contains "$content" "WriteAllText((Join-Path \$Dest 'client/VERSION'), \$gitVersion, \$Utf8NoBom)" "client version uses UTF-8 without BOM"
+assert_contains "$content" 'Assert-PreparedSdCard -Dest $Dest -Boot $Boot -InstallType $InstallType' "verification runs before eject"
+assert_contains "$content" "runcmd:\\s*(\\[\\]|null|~)?" "inline/empty runcmd cases handled"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_prepare_sd_required_files.sh
+++ b/tests/test_prepare_sd_required_files.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREPARE_SD_SH="$SCRIPT_DIR/../scripts/prepare-sd.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "Testing prepare-sd required file verification list..."
+
+verify_block=$(sed -n '/for f in install.conf/,/^done/p' "$PREPARE_SD_SH")
+
+assert_contains "$verify_block" "common/progress.sh" "progress.sh is required"
+assert_contains "$verify_block" "common/logging.sh" "logging.sh is required"
+assert_contains "$verify_block" "common/unified-log.sh" "unified-log.sh is required"
+assert_contains "$verify_block" "common/install-docker.sh" "install-docker.sh is required"
+assert_contains "$verify_block" "common/install-deps.sh" "install-deps.sh is required"
+assert_contains "$verify_block" "common/setup-docker.sh" "setup-docker.sh is required"
+assert_contains "$verify_block" "common/wait-network.sh" "wait-network.sh is required"
+assert_contains "$verify_block" "common/mount-music.sh" "mount-music.sh is required"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_prepare_sd_userdata_patch.sh
+++ b/tests/test_prepare_sd_userdata_patch.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREPARE_SD_SH="$SCRIPT_DIR/../scripts/prepare-sd.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local file="$1" needle="$2" desc="$3"
+    if grep -qF "$needle" "$file"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_not_contains() {
+    local file="$1" needle="$2" desc="$3"
+    if grep -qF "$needle" "$file"; then
+        echo "  FAIL: $desc (found '$needle')"
+        fail=$((fail + 1))
+    else
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    fi
+}
+
+eval "$(sed -n '/^patch_user_data_runcmd()/,/^}/p' "$PREPARE_SD_SH")"
+
+echo "Testing prepare-sd user-data patching..."
+
+run_case() {
+    local name="$1" content="$2"
+    local tmp
+    tmp=$(mktemp)
+    printf '%s\n' "$content" > "$tmp"
+    patch_user_data_runcmd "$tmp" "/boot/firmware/snapmulti/firstboot.sh"
+    echo "$tmp"
+}
+
+tmp1=$(run_case "plain-runcmd" $'#cloud-config\nruncmd:\n  - [ sh, -c, echo first ]')
+assert_contains "$tmp1" '  - [bash, /boot/firmware/snapmulti/firstboot.sh]' "plain runcmd gets hook"
+
+tmp2=$(run_case "inline-empty" $'#cloud-config\nruncmd: []')
+assert_contains "$tmp2" 'runcmd:' "inline [] converted to block key"
+assert_contains "$tmp2" '  - [bash, /boot/firmware/snapmulti/firstboot.sh]' "inline [] gets hook"
+assert_not_contains "$tmp2" 'runcmd: []' "inline [] removed"
+
+tmp3=$(run_case "inline-null" $'#cloud-config\nruncmd: null')
+assert_contains "$tmp3" 'runcmd:' "inline null converted to block key"
+assert_contains "$tmp3" '  - [bash, /boot/firmware/snapmulti/firstboot.sh]' "inline null gets hook"
+assert_not_contains "$tmp3" 'runcmd: null' "inline null removed"
+
+tmp4=$(run_case "indented" $'#cloud-config\n  runcmd:\n    - [ sh, -c, echo first ]')
+assert_contains "$tmp4" '  runcmd:' "indented runcmd preserved"
+assert_contains "$tmp4" '    - [bash, /boot/firmware/snapmulti/firstboot.sh]' "indented hook matches indentation"
+
+rm -f "$tmp1" "$tmp2" "$tmp3" "$tmp4"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_python3_dependency.sh
+++ b/tests/test_python3_dependency.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DEPS="$SCRIPT_DIR/../scripts/common/install-deps.sh"
+DEPLOY_SH="$SCRIPT_DIR/../scripts/deploy.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+common_body="$(sed -n '/^install_dependencies()/,/^}/p' "$COMMON_DEPS")"
+deploy_body="$(sed -n '/^install_dependencies()/,/^}/p' "$DEPLOY_SH")"
+
+echo "Testing host dependency coverage..."
+
+assert_contains "$common_body" "local pkgs=(curl ca-certificates python3 netcat-openbsd)" "shared install-deps always includes python3 and netcat"
+assert_contains "$deploy_body" "command -v python3" "deploy checks for python3 explicitly"
+assert_contains "$deploy_body" "apt-get install -y -qq python3" "deploy installs python3 when missing"
+assert_contains "$deploy_body" "command -v nc" "deploy checks for netcat explicitly"
+assert_contains "$deploy_body" "apt-get install -y -qq netcat-openbsd" "deploy installs netcat when missing"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_python3_dependency.sh
+++ b/tests/test_python3_dependency.sh
@@ -26,9 +26,10 @@ echo "Testing host dependency coverage..."
 
 assert_contains "$common_body" "local pkgs=(curl ca-certificates python3 netcat-openbsd)" "shared install-deps always includes python3 and netcat"
 assert_contains "$deploy_body" "command -v python3" "deploy checks for python3 explicitly"
-assert_contains "$deploy_body" "apt-get install -y -qq python3" "deploy installs python3 when missing"
+assert_contains "$deploy_body" "extra_pkgs+=(python3)" "deploy adds python3 to package list when missing"
 assert_contains "$deploy_body" "command -v nc" "deploy checks for netcat explicitly"
-assert_contains "$deploy_body" "apt-get install -y -qq netcat-openbsd" "deploy installs netcat when missing"
+assert_contains "$deploy_body" 'extra_pkgs+=(netcat-openbsd)' "deploy adds netcat to package list when missing"
+assert_contains "$deploy_body" '"${extra_pkgs[@]}"' "deploy installs batched extra packages"
 
 echo ""
 if [[ "$fail" -gt 0 ]]; then

--- a/tests/test_smb_user_sanitization.sh
+++ b/tests/test_smb_user_sanitization.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIRSTBOOT_SH="$SCRIPT_DIR/../scripts/firstboot.sh"
+PS1_FILE="$SCRIPT_DIR/../scripts/prepare-sd.ps1"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+firstboot_content="$(cat "$FIRSTBOOT_SH")"
+ps1_content="$(cat "$PS1_FILE")"
+
+echo "Testing SMB user sanitization parity..."
+
+assert_contains "$firstboot_content" 'SMB_USER=$(sanitize_smb_user' "firstboot sanitizes SMB_USER on read"
+assert_contains "$ps1_content" 'function Sanitize-SmbUser' "prepare-sd.ps1 defines SMB username sanitizer"
+assert_contains "$ps1_content" '$user = Sanitize-SmbUser $rawUser' "prepare-sd.ps1 sanitizes SMB username input"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_status_guards.sh
+++ b/tests/test_status_guards.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS_SH="$SCRIPT_DIR/../scripts/status.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+content="$(cat "$STATUS_SH")"
+
+echo "Testing status.sh safety guards..."
+
+assert_contains "$content" 'if [[ "$TOTAL" -eq 0 ]]; then' "status exits when no snapMULTI containers are found"
+assert_contains "$content" 'error "No running snapMULTI containers found"' "status emits explicit no-container error"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_status_guards.sh
+++ b/tests/test_status_guards.sh
@@ -24,6 +24,8 @@ echo "Testing status.sh safety guards..."
 
 assert_contains "$content" 'if [[ "$TOTAL" -eq 0 ]]; then' "status exits when no snapMULTI containers are found"
 assert_contains "$content" 'error "No running snapMULTI containers found"' "status emits explicit no-container error"
+assert_contains "$content" 'docker compose' "status uses docker compose config for service discovery"
+assert_contains "$content" '-f "${path}/.env"' "install detection requires .env (not bare checkout)"
 
 echo ""
 if [[ "$fail" -gt 0 ]]; then

--- a/tests/test_update_helpers.sh
+++ b/tests/test_update_helpers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPDATE_SH="$SCRIPT_DIR/../scripts/update.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got '$actual', expected '$expected')"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_status() {
+    local expected="$1" desc="$2"
+    shift 2
+    if "$@"; then
+        actual=0
+    else
+        actual=$?
+    fi
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got exit $actual, expected $expected)"
+        fail=$((fail + 1))
+    fi
+}
+
+eval "$(sed -n '/^parse_latest_tag()/,/^}/p' "$UPDATE_SH")"
+eval "$(sed -n '/^compare_versions()/,/^}/p' "$UPDATE_SH")"
+
+echo "Testing update.sh helper semantics..."
+
+compact_json='{"tag_name":"v1.2.3","name":"snapMULTI"}'
+spaced_json='{"tag_name": "v2.0.1", "name": "snapMULTI"}'
+
+assert_eq "$(parse_latest_tag "$compact_json")" "v1.2.3" "parse_latest_tag handles compact JSON"
+assert_eq "$(parse_latest_tag "$spaced_json")" "v2.0.1" "parse_latest_tag handles spaced JSON"
+
+assert_status 1 "compare_versions allows update from unknown local version" compare_versions "unknown" "v1.4.0"
+assert_status 0 "compare_versions returns same-version status" compare_versions "v1.4.0" "v1.4.0"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"


### PR DESCRIPTION
## Summary

- **Healthcheck counting**: Replace `docker ps --filter "health=healthy"` with `docker inspect` across deploy.sh, firstboot.sh, and update.sh — the filter was unreliable when compose project labels didn't match
- **verify_compose_stack()**: Extract duplicated server/client verification into a reusable function in firstboot.sh
- **Dependencies**: Add `python3` and `netcat-openbsd` to base install packages (install-deps.sh, deploy.sh, update.sh)
- **SMB hardening**: Clean up credentials file on mount failure (mount-music.sh), sanitize SMB_USER in firstboot.sh
- **user-data patching**: Rewrite with awk (prepare-sd.sh) and dedicated `Update-UserDataRuncmd` function (prepare-sd.ps1) — handles edge cases (empty runcmd, null, missing section)
- **SD verification**: Expand file checklist in prepare-sd.sh, add full `Assert-PreparedSdCard` to prepare-sd.ps1
- **status.sh**: Early exit with error when no containers found
- **update.sh**: `parse_latest_tag()` helper, handle unknown local version gracefully
- **fuse-overlayfs**: Remove from server deploy.sh (only needed for readonly/client flows)
- **11 new test files** covering deploy docker gating, firstboot verify, mount-music, prepare-sd (bash + ps1), user-data patching, python3 deps, SMB sanitization, status guards, update helpers, discover-server

## Test plan

- [ ] `shellcheck scripts/**/*.sh` passes (verified by pre-push hook)
- [ ] Run new tests: `bash tests/test_deploy_docker_gating.sh && bash tests/test_firstboot_verify.sh && bash tests/test_mount_music.sh && bash tests/test_prepare_sd_required_files.sh && bash tests/test_prepare_sd_userdata_patch.sh && bash tests/test_python3_dependency.sh && bash tests/test_smb_user_sanitization.sh && bash tests/test_status_guards.sh && bash tests/test_update_helpers.sh`
- [ ] CI green on validate.yml workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)