### PR TITLE
fix: gate fuse-overlayfs on actual overlayroot, not ENABLE_READONLY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MPD backup timer** ([#225](https://github.com/lollonet/snapMULTI/pull/225)) — daily backup of `mpd.db` to boot partition; `backup-from-sd.sh` extracts it before reflashing so MPD does fast incremental scan instead of hours-long rescan
 - **QUICKSTART.md** ([#226](https://github.com/lollonet/snapMULTI/pull/226)) — one-page quick start (60 lines); README slimmed from 245 to 72 lines
 
+### Changed
+- **Docker driver selection** ([#245](https://github.com/lollonet/snapMULTY/pull/245)) — fuse-overlayfs now gated on actual overlayroot state (`mount | grep ' on / type overlay'`), not `ENABLE_READONLY` flag. Writable systems keep overlay2 (faster kernel-native driver). `_configure_readonly()` no longer wipes `/var/lib/docker` during install — writes daemon.json for next boot instead. `tune_docker_daemon` can now remove `storage-driver` key on rollback
+
 ### Fixed
-- **Client verify + start** ([#243](https://github.com/lollonet/snapMULTI/pull/243)) — start client containers before verify, block checkpoint on failure, detect "both" mode via install.conf, restart all services on server change, gate fuse-overlayfs on ENABLE_READONLY, fix resolvectl interface arg
-- **Install log flood** ([#237](https://github.com/lollonet/snapMULTI/pull/237)) — suppress Docker Compose per-layer progress lines in install log (hundreds of "Pulling" lines that looked like an infinite loop)
+- **fuse-overlayfs on writable root** ([#245](https://github.com/lollonet/snapMULTY/pull/245)) — Pi installs with `ENABLE_READONLY=true` (default) incorrectly forced fuse-overlayfs on writable ext4, adding ~20-40% IO overhead to Docker pulls. Root cause: `setup_docker()` checked config flag intent instead of filesystem state
+- **Healthcheck verification** ([#244](https://github.com/lollonet/snapMULTY/pull/244)) — replace `docker ps --filter "health=healthy"` with `docker inspect` (label filter was unreliable); extract `verify_compose_stack()` helper; add `xargs -r` to skip empty input; batch python3+netcat install
+- **setup.sh false success** ([#244](https://github.com/lollonet/snapMULTY/pull/244)) — exit early with "Setup Incomplete" banner when image pull fails instead of printing success message
+- **status.sh profile-aware** ([#244](https://github.com/lollonet/snapMULTY/pull/244)) — query `docker compose config --services` instead of hardcoded container lists; require `.env` for install detection
+- **update.sh transactional** ([#244](https://github.com/lollonet/snapMULTY/pull/244)) — stage changes in temp copy and atomic-swap; remove stale files/symlinks/dirs absent from new release; add `parse_latest_tag()` helper; handle unknown local version
+- **Pre-push hook scope** ([#244](https://github.com/lollonet/snapMULTY/pull/244)) — shellcheck now covers `client/tests/*.sh` (was missing, caused local-passes-but-CI-fails)
+- **Client verify + start** ([#243](https://github.com/lollonet/snapMULTY/pull/243)) — start client containers before verify, block checkpoint on failure, detect "both" mode via install.conf, restart all services on server change, gate fuse-overlayfs on ENABLE_READONLY, fix resolvectl interface arg
+- **Install log flood** ([#237](https://github.com/lollonet/snapMULTY/pull/237)) — suppress Docker Compose per-layer progress lines in install log (hundreds of "Pulling" lines that looked like an infinite loop)
 - **Health check logic** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — require running AND healthy (was OR, could pass with 0 healthy containers)
 - **fuse-overlayfs broken binary** ([#220](https://github.com/lollonet/snapMULTI/pull/220)) — setup-docker.sh now returns error (was silently succeeding)
 - **Shell injection in _image_exists** ([#219](https://github.com/lollonet/snapMULTI/pull/219)) — pass service name via env var instead of string interpolation

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1337,60 +1337,32 @@ _setup_systemd_services
 _configure_readonly() {
 if [[ "${ENABLE_READONLY:-false}" == "true" ]]; then
     progress 9 "Configuring read-only filesystem..."
+
+    # Install fuse-overlayfs package (needed after reboot when overlayroot is active)
     log_progress "Installing fuse-overlayfs..."
+    if ! apt-get install -y fuse-overlayfs; then
+        log_progress "ERROR: fuse-overlayfs not available — read-only mode will be skipped"
+        ENABLE_READONLY=false
+        return 0
+    fi
 
-    # Install fuse-overlayfs for Docker compatibility with overlayfs root
-    apt-get install -y fuse-overlayfs
+    # Verify binary works
+    if ! fuse-overlayfs --version >/dev/null 2>&1; then
+        log_progress "ERROR: fuse-overlayfs binary broken — read-only mode will be skipped"
+        ENABLE_READONLY=false
+        return 0
+    fi
 
-    # Wait for Docker to be fully ready after any previous restarts
-    log_progress "Waiting for Docker service..."
-    for i in {1..30}; do
-        if docker info >/dev/null 2>&1; then
-            break
-        fi
-        sleep 1
-    done
-
-    # Configure Docker daemon (live-restore + fuse-overlayfs for overlayroot)
+    # Write fuse-overlayfs to daemon.json for NEXT boot (when overlayroot is active).
+    # Do NOT switch the running driver or wipe /var/lib/docker — that would destroy
+    # images already pulled by deploy.sh (server) or earlier in this script.
+    # After reboot with overlayroot, Docker data lives on tmpfs overlay anyway,
+    # so images are re-pulled from the baked SD card layer.
+    log_progress "Configuring Docker for fuse-overlayfs (activates after reboot)..."
     tune_docker_daemon --live-restore --fuse-overlayfs
-
-    current_driver=$(docker info --format '{{.Driver}}' 2>/dev/null || echo "none")
-    if [[ "$current_driver" != "fuse-overlayfs" ]]; then
-        # Verify fuse-overlayfs is available before wiping Docker data
-        if ! command -v fuse-overlayfs &>/dev/null; then
-            log_progress "Installing fuse-overlayfs..."
-            apt-get install -y -qq fuse-overlayfs >/dev/null 2>&1 || true
-        fi
-        if ! command -v fuse-overlayfs &>/dev/null; then
-            log_progress "ERROR: fuse-overlayfs not available — keeping current storage driver"
-            log_progress "       Read-only mode will be skipped to avoid frozen broken state"
-            ENABLE_READONLY=false
-        else
-            log_progress "Switching Docker storage driver to fuse-overlayfs..."
-            systemctl stop docker
-            rm -rf /var/lib/docker/*
-            systemctl start docker
-            for i in {1..60}; do
-                if docker info >/dev/null 2>&1; then
-                    new_driver=$(docker info --format '{{.Driver}}' 2>/dev/null)
-                    if [[ "$new_driver" == "fuse-overlayfs" ]]; then
-                        log_progress "Docker ready with fuse-overlayfs storage driver"
-                    else
-                        log_progress "WARNING: Docker started but driver is '$new_driver', not fuse-overlayfs"
-                        log_progress "         Read-only mode will be skipped"
-                        ENABLE_READONLY=false
-                    fi
-                    break
-                fi
-                sleep 1
-                if [[ $i -eq 60 ]]; then
-                    log_progress "ERROR: Docker failed to start after storage driver change"
-                    exit 1
-                fi
-            done
-        fi
-    else
-        log_progress "Docker already using fuse-overlayfs, skipping reconfiguration..."
+    if ! grep -q 'fuse-overlayfs' /etc/docker/daemon.json 2>/dev/null; then
+        log_progress "WARNING: Failed to write fuse-overlayfs to daemon.json"
+        log_progress "         Read-only mode may not work correctly after reboot"
     fi
 
     # Install ro-mode helper script
@@ -1432,7 +1404,7 @@ SSHEOF
     raspi-config nonint do_overlayfs 0
 
     echo "Read-only filesystem configured"
-    echo "  - Docker storage driver: fuse-overlayfs"
+    echo "  - Docker storage driver: fuse-overlayfs (activates after reboot)"
     echo "  - SSH host keys: persisted"
     echo "  - Helper script: /usr/local/bin/ro-mode"
     echo "  - Status: Will activate after reboot"

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1403,19 +1403,28 @@ SSHEOF
     log_progress "Enabling overlayfs..."
     if ! raspi-config nonint do_overlayfs 0; then
         log_progress "WARNING: raspi-config failed to enable overlayfs"
-        log_progress "         Read-only mode will NOT be active after reboot"
+        log_progress "         Reverting Docker config to overlay2"
+        # Roll back: remove fuse-overlayfs from daemon.json so Docker
+        # doesn't start with the wrong driver on a writable root.
+        tune_docker_daemon --live-restore
         ENABLE_READONLY=false
+        echo ""
+        echo "Read-only filesystem: FAILED"
+        echo "  - overlayfs could not be enabled (raspi-config error)"
+        echo "  - Docker storage driver: overlay2 (unchanged)"
+        echo "  - System will boot normally (writable root)"
+        echo ""
+    else
+        echo "Read-only filesystem configured"
+        echo "  - Docker storage driver: fuse-overlayfs (activates after reboot)"
+        echo "  - SSH host keys: persisted"
+        echo "  - Helper script: /usr/local/bin/ro-mode"
+        echo "  - Status: Will activate after reboot"
+        echo ""
+        echo "To temporarily disable for updates:"
+        echo "  sudo ro-mode disable && sudo reboot"
+        echo ""
     fi
-
-    echo "Read-only filesystem configured"
-    echo "  - Docker storage driver: fuse-overlayfs (activates after reboot)"
-    echo "  - SSH host keys: persisted"
-    echo "  - Helper script: /usr/local/bin/ro-mode"
-    echo "  - Status: Will activate after reboot"
-    echo ""
-    echo "To temporarily disable for updates:"
-    echo "  sudo ro-mode disable && sudo reboot"
-    echo ""
 else
     echo "Read-only filesystem: skipped (ENABLE_READONLY=false)"
 fi

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1401,7 +1401,11 @@ SSHEOF
 
     # Enable overlayfs (takes effect after reboot)
     log_progress "Enabling overlayfs..."
-    raspi-config nonint do_overlayfs 0
+    if ! raspi-config nonint do_overlayfs 0; then
+        log_progress "WARNING: raspi-config failed to enable overlayfs"
+        log_progress "         Read-only mode will NOT be active after reboot"
+        ENABLE_READONLY=false
+    fi
 
     echo "Read-only filesystem configured"
     echo "  - Docker storage driver: fuse-overlayfs (activates after reboot)"

--- a/scripts/common/setup-docker.sh
+++ b/scripts/common/setup-docker.sh
@@ -78,10 +78,11 @@ setup_docker() {
     # is required. But on a normal writable ext4 root, overlay2 is faster
     # (no FUSE userspace overhead).
     #
-    # Decision is based on /proc/mounts, not ENABLE_READONLY — the flag
-    # expresses intent (will be readonly after reboot), not current state.
-    # At this point in the install, overlayroot is never active yet.
-    if ! grep -q 'overlayroot' /proc/mounts 2>/dev/null; then
+    # Detection uses the same pattern as system-tune.sh:is_overlayroot()
+    # and ro-mode.sh: "on / type overlay" in mount output.
+    # NOT gated on ENABLE_READONLY — that flag expresses intent (will be
+    # readonly after reboot), not current state.
+    if ! mount 2>/dev/null | grep -q ' on / type overlay'; then
         log_info "Docker ready (overlay2, writable root filesystem)"
         return 0
     fi

--- a/scripts/common/setup-docker.sh
+++ b/scripts/common/setup-docker.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# Install Docker CE and configure fuse-overlayfs storage driver.
+# Install Docker CE and configure storage driver.
 #
-# Handles: Docker CE installation, daemon config, fuse-overlayfs
-# switch with safety verification (council fix #2: verify binary
-# before wiping Docker storage).
+# Uses overlay2 (kernel native) by default. Only switches to
+# fuse-overlayfs when overlayroot is actually active — kernel
+# overlay2 cannot work on an overlayfs root filesystem.
+#
+# Decision is based on actual filesystem state (/proc/mounts),
+# NOT the ENABLE_READONLY config flag (which expresses intent,
+# not current state).
 #
 # Expects:
 #   install-docker.sh sourced (provides install_docker_apt, tune_docker_daemon)
@@ -69,10 +73,16 @@ setup_docker() {
         return 1
     fi
 
-    # Switch to fuse-overlayfs only when read-only mode is enabled.
-    # Normal installs keep the default overlay2 driver (no wipe needed).
-    if [[ "${ENABLE_READONLY:-false}" != "true" ]]; then
-        log_info "Docker ready (overlay2, read-only mode disabled)"
+    # Switch to fuse-overlayfs ONLY when overlayroot is actually active.
+    # Kernel overlay2 cannot work on an overlayfs root, so fuse-overlayfs
+    # is required. But on a normal writable ext4 root, overlay2 is faster
+    # (no FUSE userspace overhead).
+    #
+    # Decision is based on /proc/mounts, not ENABLE_READONLY — the flag
+    # expresses intent (will be readonly after reboot), not current state.
+    # At this point in the install, overlayroot is never active yet.
+    if ! grep -q 'overlayroot' /proc/mounts 2>/dev/null; then
+        log_info "Docker ready (overlay2, writable root filesystem)"
         return 0
     fi
 

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -129,7 +129,12 @@ tune_docker_daemon() {
     # Build desired config as Python dict literal
     local py_updates='cfg.setdefault("log-driver", "json-file"); cfg.setdefault("log-opts", {"max-size": "10m", "max-file": "3"})'
     [[ "$want_live_restore" == "true" ]] && py_updates="$py_updates; cfg['live-restore'] = True"
-    [[ "$want_fuse_overlayfs" == "true" ]] && py_updates="$py_updates; cfg['storage-driver'] = 'fuse-overlayfs'"
+    if [[ "$want_fuse_overlayfs" == "true" ]]; then
+        py_updates="$py_updates; cfg['storage-driver'] = 'fuse-overlayfs'"
+    else
+        # Remove storage-driver if present — reverts Docker to its default (overlay2)
+        py_updates="$py_updates; cfg.pop('storage-driver', None)"
+    fi
 
     if [[ -f /etc/docker/daemon.json ]]; then
         # Check if already configured
@@ -138,6 +143,10 @@ tune_docker_daemon() {
             needs_update=true
         fi
         if [[ "$want_fuse_overlayfs" == "true" ]] && ! grep -q '"fuse-overlayfs"' /etc/docker/daemon.json 2>/dev/null; then
+            needs_update=true
+        fi
+        # Also update if fuse-overlayfs is present but not wanted (rollback)
+        if [[ "$want_fuse_overlayfs" != "true" ]] && grep -q '"storage-driver"' /etc/docker/daemon.json 2>/dev/null; then
             needs_update=true
         fi
         if ! grep -q '"log-driver"' /etc/docker/daemon.json 2>/dev/null; then

--- a/tests/test_setup_docker_driver.sh
+++ b/tests/test_setup_docker_driver.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_DOCKER_SH="$SCRIPT_DIR/../scripts/common/setup-docker.sh"
+CLIENT_SETUP_SH="$SCRIPT_DIR/../client/common/scripts/setup.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  FAIL: $desc (unexpected '$needle')"
+        fail=$((fail + 1))
+    else
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    fi
+}
+
+setup_docker_body="$(sed -n '/^setup_docker()/,/^}/p' "$SETUP_DOCKER_SH")"
+readonly_body="$(sed -n '/^_configure_readonly()/,/^}/p' "$CLIENT_SETUP_SH")"
+
+echo "Testing Docker storage driver selection..."
+
+# setup_docker() should check actual filesystem state, not ENABLE_READONLY
+assert_contains "$setup_docker_body" '/proc/mounts' "setup_docker gates on /proc/mounts (actual filesystem)"
+# Check that ENABLE_READONLY is not used in executable code (comments are OK)
+setup_docker_code=$(echo "$setup_docker_body" | grep -v '^\s*#')
+assert_not_contains "$setup_docker_code" 'ENABLE_READONLY' "setup_docker code does not use ENABLE_READONLY flag"
+
+# _configure_readonly() should write config but not wipe Docker
+assert_contains "$readonly_body" 'tune_docker_daemon --live-restore --fuse-overlayfs' "readonly config writes fuse-overlayfs to daemon.json"
+assert_not_contains "$readonly_body" 'rm -rf /var/lib/docker' "readonly config does not wipe Docker storage"
+assert_contains "$readonly_body" 'fuse-overlayfs --version' "readonly config verifies fuse-overlayfs binary"
+assert_contains "$readonly_body" 'activates after reboot' "readonly config defers driver switch to reboot"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_setup_docker_driver.sh
+++ b/tests/test_setup_docker_driver.sh
@@ -47,6 +47,8 @@ assert_contains "$readonly_body" 'tune_docker_daemon --live-restore --fuse-overl
 assert_not_contains "$readonly_body" 'rm -rf /var/lib/docker' "readonly config does not wipe Docker storage"
 assert_contains "$readonly_body" 'fuse-overlayfs --version' "readonly config verifies fuse-overlayfs binary"
 assert_contains "$readonly_body" 'activates after reboot' "readonly config defers driver switch to reboot"
+assert_contains "$readonly_body" 'tune_docker_daemon --live-restore' "readonly config rolls back to overlay2 on raspi-config failure"
+assert_contains "$readonly_body" 'FAILED' "readonly config shows failure message when overlayfs fails"
 
 echo ""
 if [[ "$fail" -gt 0 ]]; then

--- a/tests/test_setup_docker_driver.sh
+++ b/tests/test_setup_docker_driver.sh
@@ -47,7 +47,15 @@ assert_contains "$readonly_body" 'tune_docker_daemon --live-restore --fuse-overl
 assert_not_contains "$readonly_body" 'rm -rf /var/lib/docker' "readonly config does not wipe Docker storage"
 assert_contains "$readonly_body" 'fuse-overlayfs --version' "readonly config verifies fuse-overlayfs binary"
 assert_contains "$readonly_body" 'activates after reboot' "readonly config defers driver switch to reboot"
-assert_contains "$readonly_body" 'tune_docker_daemon --live-restore' "readonly config rolls back to overlay2 on raspi-config failure"
+# Rollback needs a second --live-restore call (the first is --live-restore --fuse-overlayfs)
+tune_lr_count=$(grep -cF 'tune_docker_daemon --live-restore' <<<"$readonly_body" || true)
+if [[ "$tune_lr_count" -ge 2 ]]; then
+    echo "  PASS: readonly config rolls back to overlay2 on raspi-config failure"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: readonly config rollback call missing (only $tune_lr_count occurrence(s))"
+    fail=$((fail + 1))
+fi
 assert_contains "$readonly_body" 'FAILED' "readonly config shows failure message when overlayfs fails"
 
 echo ""

--- a/tests/test_setup_docker_driver.sh
+++ b/tests/test_setup_docker_driver.sh
@@ -35,8 +35,9 @@ readonly_body="$(sed -n '/^_configure_readonly()/,/^}/p' "$CLIENT_SETUP_SH")"
 
 echo "Testing Docker storage driver selection..."
 
-# setup_docker() should check actual filesystem state, not ENABLE_READONLY
-assert_contains "$setup_docker_body" '/proc/mounts' "setup_docker gates on /proc/mounts (actual filesystem)"
+# setup_docker() should detect overlayroot the same way as the rest of the codebase:
+# system-tune.sh:is_overlayroot() and ro-mode.sh both use "on / type overlay"
+assert_contains "$setup_docker_body" ' on / type overlay' "setup_docker detects overlayroot via mount (matches is_overlayroot)"
 # Check that ENABLE_READONLY is not used in executable code (comments are OK)
 setup_docker_code=$(echo "$setup_docker_body" | grep -v '^\s*#')
 assert_not_contains "$setup_docker_code" 'ENABLE_READONLY' "setup_docker code does not use ENABLE_READONLY flag"


### PR DESCRIPTION
## Summary

- **Root cause**: `setup_docker()` checked `ENABLE_READONLY=true` (intent flag) to decide Docker storage driver. On writable ext4 systems where the flag defaults to true, this forced fuse-overlayfs (FUSE userspace) instead of kernel-native overlay2 — adding ~20-40% IO overhead to image pulls
- **setup-docker.sh**: Now checks `/proc/mounts` for actual overlayroot presence. Writable systems keep overlay2
- **setup.sh `_configure_readonly()`**: Writes fuse-overlayfs config to daemon.json for next boot but no longer wipes `/var/lib/docker` or switches the running driver. Preserves images already pulled by deploy.sh in "both" mode
- **New test**: `test_setup_docker_driver.sh` validates both behaviors

Found via 7-agent council investigation of high iowait during image pull on snapvideo (Pi 4, writable ext4, fuse-overlayfs incorrectly active).

## Test plan

- [ ] `bash tests/test_setup_docker_driver.sh` passes
- [ ] `bash tests/test_deploy_docker_gating.sh` passes
- [ ] shellcheck clean
- [ ] Fresh "both" mode install: overlay2 during install, fuse-overlayfs config written for post-reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)