### PR TITLE
feat: full-width TUI, serial pull, verbose logging, locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **QUICKSTART.md** ([#226](https://github.com/lollonet/snapMULTI/pull/226)) — one-page quick start (60 lines); README slimmed from 245 to 72 lines
 
 ### Changed
+- **Full-width TUI** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — progress display uses full terminal width (auto-detect via `stty` after font change), dynamic log area fills remaining rows instead of fixed 8 lines, WARN/ERROR now visible in TUI output
+- **Serial image pull** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — removed paired background+foreground pull that caused counter bugs (210/7) and SD card IO contention; per-service timing and callback-aware status logging
+- **Locale setup** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — replaced `locales-all` (236MB) with `locales` (~3MB) + `locale-gen` for IT, EN_US, EN_GB, FR, DE, ES, PT
 - **Docker driver selection** ([#245](https://github.com/lollonet/snapMULTI/pull/245)) — fuse-overlayfs now gated on actual overlayroot state (`mount | grep ' on / type overlay'`), not `ENABLE_READONLY` flag. Writable systems keep overlay2 (faster kernel-native driver). `_configure_readonly()` no longer wipes `/var/lib/docker` during install — writes daemon.json for next boot instead. `tune_docker_daemon` can now remove `storage-driver` key on rollback
 
 ### Fixed

--- a/scripts/common/install-deps.sh
+++ b/scripts/common/install-deps.sh
@@ -82,7 +82,7 @@ install_dependencies() {
     fi
 
     # Build package list based on install type
-    local pkgs=(curl ca-certificates python3 netcat-openbsd)
+    local pkgs=(curl ca-certificates python3 netcat-openbsd locales)
 
     if ! command -v git &>/dev/null; then
         pkgs+=(git)
@@ -113,6 +113,37 @@ install_dependencies() {
     log_info "Installing: ${pkgs[*]}"
     if ! _apt_install_with_recovery "${pkgs[@]}"; then
         return 1
+    fi
+
+    # Generate locales (lightweight alternative to locales-all)
+    if command -v locale-gen &>/dev/null; then
+        local wanted_locales=(
+            it_IT.UTF-8
+            en_US.UTF-8
+            en_GB.UTF-8
+            fr_FR.UTF-8
+            de_DE.UTF-8
+            es_ES.UTF-8
+            pt_PT.UTF-8
+        )
+        local gen_file="/etc/locale.gen"
+        local needs_gen=false
+        for loc in "${wanted_locales[@]}"; do
+            if ! locale -a 2>/dev/null | grep -qi "^${loc/UTF-8/utf8}$"; then
+                # Uncomment or append in locale.gen
+                if [[ -f "$gen_file" ]]; then
+                    sed -i "s/^# *${loc} /${loc} /" "$gen_file" 2>/dev/null || true
+                fi
+                if ! grep -q "^${loc}" "$gen_file" 2>/dev/null; then
+                    echo "${loc} UTF-8" >> "$gen_file"
+                fi
+                needs_gen=true
+            fi
+        done
+        if [[ "$needs_gen" == "true" ]]; then
+            log_info "Generating locales: ${wanted_locales[*]}"
+            locale-gen >> "${UNIFIED_LOG:-/dev/null}" 2>&1 || log_warn "locale-gen failed"
+        fi
     fi
 
     # Enable avahi

--- a/scripts/common/install-deps.sh
+++ b/scripts/common/install-deps.sh
@@ -129,12 +129,13 @@ install_dependencies() {
         local gen_file="/etc/locale.gen"
         local needs_gen=false
         for loc in "${wanted_locales[@]}"; do
-            if ! locale -a 2>/dev/null | grep -qi "^${loc/UTF-8/utf8}$"; then
+            if ! locale -a 2>/dev/null | grep -qiF "${loc/UTF-8/utf8}"; then
                 # Uncomment or append in locale.gen
+                local loc_escaped="${loc//./\\.}"
                 if [[ -f "$gen_file" ]]; then
-                    sed -i "s/^# *${loc} /${loc} /" "$gen_file" 2>/dev/null || true
+                    sed -i "s/^# *${loc_escaped} /${loc} /" "$gen_file" 2>/dev/null || true
                 fi
-                if ! grep -q "^${loc}" "$gen_file" 2>/dev/null; then
+                if ! grep -qF "${loc}" "$gen_file" 2>/dev/null; then
                     echo "${loc} UTF-8" >> "$gen_file"
                 fi
                 needs_gen=true

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -56,9 +56,39 @@ progress_init() {
             fi
         fi
     fi
+
+    # Detect size AFTER font change — setfont alters console geometry
+    _detect_tty_size
+}
+
+# Terminal dimensions — set by _detect_tty_size(), called from progress_init()
+# after font setup. Defaults are 800x600 @ 8x16 = 100x37.
+_tty_cols=100
+_tty_rows=37
+_box_width=96
+_inner_width=92
+
+_detect_tty_size() {
+    if [[ -c /dev/tty1 ]]; then
+        _tty_cols=$(stty -F /dev/tty1 size 2>/dev/null | awk '{print $2}') || _tty_cols=100
+        _tty_rows=$(stty -F /dev/tty1 size 2>/dev/null | awk '{print $1}') || _tty_rows=37
+        (( _tty_cols < 40 )) && _tty_cols=100
+        (( _tty_rows < 20 )) && _tty_rows=37
+    fi
+    # Layout constants (2-char margin each side)
+    _box_width=$(( _tty_cols - 4 ))
+    _inner_width=$(( _box_width - 4 ))
 }
 
 # Render progress display to tty1
+#
+# Layout (full width, dynamic log area):
+#   Row 1:    header box (title centered)
+#   Row 2:    elapsed + progress bar + percentage + spinner
+#   Row 3-N:  step checklist
+#   Row N+1:  separator
+#   Row N+2:  log lines (fills remaining rows)
+#   Last row: bottom border
 render_progress() {
     local step=$1 pct=$2 elapsed=$3 spinner=${4:-}
     local total=${#STEP_NAMES[@]}
@@ -69,30 +99,39 @@ render_progress() {
     (( pct < 0 )) && pct=0
     (( pct > 100 )) && pct=100
 
-    # Build progress bar (50 chars wide)
-    local bar_width=50
+    # Build progress bar (fills available width minus labels)
+    # "  [####----] 100% |" = 10 chars overhead
+    local bar_width=$(( _box_width - 14 ))
+    (( bar_width < 20 )) && bar_width=20
     local filled=$(( pct * bar_width / 100 ))
     local empty=$(( bar_width - filled ))
     local bar pad
     printf -v bar '%*s' "$filled" ''; bar="${bar// /#}"
     printf -v pad '%*s' "$empty" ''; bar+="${pad// /-}"
 
-    # Get last 8 lines of log for output area
+    # Calculate rows used by header + steps
+    # header(3) + elapsed+bar(1) + blank(1) + steps(total) + blank(1) + separator(1) + footer(1) = total+8
+    local fixed_rows=$(( total + 8 ))
+    local log_rows=$(( _tty_rows - fixed_rows ))
+    (( log_rows < 4 )) && log_rows=4
+
+    # Get last N lines of log for output area
     local log_lines=""
     if [[ -f "$PROGRESS_LOG" ]]; then
-        log_lines=$(tail -8 "$PROGRESS_LOG" 2>/dev/null | cut -c1-68 || true)
+        log_lines=$(tail -"$log_rows" "$PROGRESS_LOG" 2>/dev/null | cut -c1-"$_inner_width" || true)
     fi
+
+    local hline
+    printf -v hline '%*s' "$_box_width" ''; hline="${hline// /-}"
 
     {
         printf '\033[2J\033[H'
+        printf '  +%s+\n' "$hline"
+        printf '  | \033[1m%-*.*s\033[0m |\n' "$_inner_width" "$_inner_width" "$PROGRESS_TITLE"
+        printf '  +%s+\n' "$hline"
+        printf '  \033[36mElapsed: %02d:%02d\033[0m  \033[33m[%s]\033[0m %3d%% %s\n' \
+            $((elapsed/60)) $((elapsed%60)) "$bar" "$pct" "$spinner"
         printf '\n'
-        printf '  +----------------------------------------------------------------------+\n'
-        # Box interior = 70 chars: 21 leading spaces + 38 title field + 11 trailing spaces
-        printf '  |                     \033[1m%-38.38s\033[0m           |\n' "$PROGRESS_TITLE"
-        printf '  +----------------------------------------------------------------------+\n'
-        printf '\n'
-        printf '  \033[36mElapsed: %02d:%02d\033[0m\n\n' $((elapsed/60)) $((elapsed%60))
-        printf '  \033[33m[%s]\033[0m %3d%% %s\n\n' "$bar" "$pct" "$spinner"
         for i in $(seq 1 "$total"); do
             local name="${STEP_NAMES[$((i-1))]}"
             if (( i < step )); then   printf '  \033[32m[x]\033[0m %s\n' "$name"
@@ -101,18 +140,21 @@ render_progress() {
             fi
         done
         printf '\n'
-        printf '  +------------------------------- Output -------------------------------+\n'
+        local log_label="  Log  "
+        local log_lpad=$(( (_box_width - ${#log_label}) / 2 ))
+        local log_rpad=$(( _box_width - ${#log_label} - log_lpad ))
+        printf '  +%s%s%s+\n' "${hline:0:$log_lpad}" "$log_label" "${hline:0:$log_rpad}"
         if [[ -n "$log_lines" ]]; then
             while IFS= read -r line; do
-                printf '  | \033[90m%-68s\033[0m |\n' "$line"
+                printf '  | \033[90m%-*s\033[0m |\n' "$_inner_width" "$line"
             done <<< "$log_lines"
         fi
-        local line_count
-        line_count=$(printf '%s' "$log_lines" | grep -c '^' || true)
-        for ((i=line_count; i<8; i++)); do
-            printf '  | %-68s |\n' ""
+        local line_count=0
+        [[ -n "$log_lines" ]] && line_count=$(printf '%s' "$log_lines" | grep -c '^' || true)
+        for ((i=line_count; i<log_rows; i++)); do
+            printf '  | %-*s |\n' "$_inner_width" ""
         done
-        printf '  +----------------------------------------------------------------------+\n'
+        printf '  +%s+\n' "$hline"
     } > /dev/tty1
 }
 
@@ -234,8 +276,10 @@ progress_complete() {
 
     [[ -c /dev/tty1 ]] || return
 
+    local bar_width=$(( _box_width - 14 ))
+    (( bar_width < 20 )) && bar_width=20
     local bar
-    printf -v bar '%*s' 50 ''; bar="${bar// /#}"
+    printf -v bar '%*s' "$bar_width" ''; bar="${bar// /#}"
 
     # Collect running container names for the summary
     local services=""
@@ -243,35 +287,42 @@ progress_complete() {
         services=$(docker ps --format '{{.Names}}' 2>/dev/null | sort | tr '\n' ', ' | sed 's/,$//')
     fi
 
+    local hline
+    printf -v hline '%*s' "$_box_width" ''; hline="${hline// /-}"
+
     {
         printf '\033[2J\033[H'
+        printf '  +%s+\n' "$hline"
+        printf '  | \033[1m%-*.*s\033[0m |\n' "$_inner_width" "$_inner_width" "$PROGRESS_TITLE"
+        printf '  +%s+\n' "$hline"
+        printf '  \033[36mElapsed: %02d:%02d\033[0m  \033[32m[%s]\033[0m 100%%\n' \
+            $((elapsed/60)) $((elapsed%60)) "$bar"
         printf '\n'
-        printf '  +----------------------------------------------------------------------+\n'
-        printf '  |                     \033[1m%-38.38s\033[0m           |\n' "$PROGRESS_TITLE"
-        printf '  +----------------------------------------------------------------------+\n'
-        printf '\n'
-        printf '  \033[36mElapsed: %02d:%02d\033[0m\n\n' $((elapsed/60)) $((elapsed%60))
-        printf '  \033[32m[%s]\033[0m 100%%\n\n' "$bar"
         for i in $(seq 1 "$total"); do
             printf '  \033[32m[x]\033[0m %s\n' "${STEP_NAMES[$((i-1))]}"
         done
         printf '\n'
         printf '  \033[32m>>> Installation complete! <<<\033[0m\n'
         printf '\n'
-        printf '  +------------------------------- Summary -------------------------------+\n'
+        local sum_label="  Summary  "
+        local sum_lpad=$(( (_box_width - ${#sum_label}) / 2 ))
+        local sum_rpad=$(( _box_width - ${#sum_label} - sum_lpad ))
+        printf '  +%s%s%s+\n' "${hline:0:$sum_lpad}" "$sum_label" "${hline:0:$sum_rpad}"
+        local summary_rows=$(( _tty_rows - total - 10 ))
+        (( summary_rows < 6 )) && summary_rows=6
         local used_lines=0
-        printf '  | \033[32m%-68s\033[0m |\n' "All steps completed successfully"
+        printf '  | \033[32m%-*s\033[0m |\n' "$_inner_width" "All steps completed successfully"
         (( used_lines++ ))
         if [[ -n "$services" ]]; then
-            printf '  | %-68s |\n' ""
+            printf '  | %-*s |\n' "$_inner_width" ""
             (( used_lines++ ))
-            printf '  | \033[36m%-68s\033[0m |\n' "Running services:"
+            printf '  | \033[36m%-*s\033[0m |\n' "$_inner_width" "Running services:"
             (( used_lines++ ))
-            # Wrap service names to fit the box (68 chars per line)
             local line=""
+            local max_svc_width=$(( _inner_width - 2 ))
             for svc in ${services//,/ }; do
-                if [[ $(( ${#line} + ${#svc} + 2 )) -gt 64 ]]; then
-                    printf '  |   \033[36m%-66s\033[0m |\n' "$line"
+                if [[ $(( ${#line} + ${#svc} + 2 )) -gt $max_svc_width ]]; then
+                    printf '  |   \033[36m%-*s\033[0m |\n' "$(( _inner_width - 2 ))" "$line"
                     (( used_lines++ ))
                     line="$svc"
                 else
@@ -279,19 +330,18 @@ progress_complete() {
                 fi
             done
             if [[ -n "$line" ]]; then
-                printf '  |   \033[36m%-66s\033[0m |\n' "$line"
+                printf '  |   \033[36m%-*s\033[0m |\n' "$(( _inner_width - 2 ))" "$line"
                 (( used_lines++ ))
             fi
         fi
-        printf '  | %-68s |\n' ""
+        printf '  | %-*s |\n' "$_inner_width" ""
         (( used_lines++ ))
-        printf '  | \033[33m%-68s\033[0m |\n' "System will reboot shortly..."
+        printf '  | \033[33m%-*s\033[0m |\n' "$_inner_width" "System will reboot shortly..."
         (( used_lines++ ))
-        # Fill remaining lines to consistent box height
-        for ((i=used_lines; i<8; i++)); do
-            printf '  | %-68s |\n' ""
+        for ((i=used_lines; i<summary_rows; i++)); do
+            printf '  | %-*s |\n' "$_inner_width" ""
         done
-        printf '  +----------------------------------------------------------------------+\n'
+        printf '  +%s+\n' "$hline"
         printf '\n'
         printf '  \033[1;32m  snapMULTI ready\033[0m\n'
     } > /dev/tty1

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -66,7 +66,7 @@ progress_init() {
 _tty_cols=100
 _tty_rows=37
 _box_width=96
-_inner_width=92
+_inner_width=94
 
 _detect_tty_size() {
     if [[ -c /dev/tty1 ]]; then
@@ -77,7 +77,7 @@ _detect_tty_size() {
     fi
     # Layout constants (2-char margin each side)
     _box_width=$(( _tty_cols - 4 ))
-    _inner_width=$(( _box_width - 4 ))
+    _inner_width=$(( _box_width - 2 ))
 }
 
 # Render progress display to tty1

--- a/scripts/common/pull-images.sh
+++ b/scripts/common/pull-images.sh
@@ -131,60 +131,50 @@ pull_compose_images() {
     local pull_failed=()
     local rate_limited=false
 
-    # Pull in pairs: background + foreground
-    for ((i=0; i<${#to_pull[@]}; i+=2)); do
+    # Resolve image name for a service from the cached map
+    _svc_image_name() {
+        grep "^${1}=" "$_svc_image_map" 2>/dev/null | cut -d= -f2- || echo "$1"
+    }
+
+    local pull_start
+    pull_start=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0)
+
+    # Pull sequentially — parallel pulls cause IO contention on SD cards,
+    # producing high iowait and slower overall throughput.
+    for svc in "${to_pull[@]}"; do
         if [[ "$rate_limited" == "true" ]]; then break; fi
 
-        local svc1="${to_pull[$i]}"
-        local svc2="${to_pull[$i+1]:-}"
-
         count=$((count + 1))
-        "$log_fn" "Pulling $svc1 ($count/$total)..."
+        local image
+        image=$(_svc_image_name "$svc")
+        "$log_fn" "Pulling $svc ($count/$total) $image"
 
-        # Start svc2 in background
-        local bg_pid="" bg_log=""
-        if [[ -n "$svc2" ]]; then
-            count=$((count + 1))
-            "$log_fn" "Pulling $svc2 ($count/$total)..."
-            bg_log="$_pi_tmp/bg-$svc2"
-            _pull_one "$svc2" "$log_fn" >"$bg_log" 2>&1 &
-            bg_pid=$!
-        fi
+        local svc_start rc=0
+        svc_start=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0)
+        _pull_one "$svc" "$log_fn" || rc=$?
 
-        # svc1 in foreground
-        local rc=0
-        _pull_one "$svc1" "$log_fn" || rc=$?
+        local svc_end
+        svc_end=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0)
+        local svc_elapsed=$(( svc_end - svc_start ))
+
         if [[ $rc -eq 2 ]]; then
             rate_limited=true
-            pull_failed+=("$svc1")
-            # Kill background pull immediately — no point continuing
-            [[ -n "$bg_pid" ]] && kill "$bg_pid" 2>/dev/null || true
+            pull_failed+=("$svc")
         elif [[ $rc -ne 0 ]]; then
-            if [[ -n "$fail_callback" ]] && "$fail_callback" "$svc1"; then
-                :  # callback handled it
+            if [[ -n "$fail_callback" ]] && "$fail_callback" "$svc"; then
+                "$log_fn" "  $svc pull failed, fallback OK (${svc_elapsed}s)"
             else
-                pull_failed+=("$svc1")
+                "$log_fn" "  $svc FAILED after ${svc_elapsed}s"
+                pull_failed+=("$svc")
             fi
-        fi
-
-        # Always wait for background svc2 before next pair
-        if [[ -n "$bg_pid" ]]; then
-            local bg_rc=0
-            wait "$bg_pid" 2>/dev/null || bg_rc=$?
-            if [[ $bg_rc -ne 0 ]]; then
-                cat "$bg_log" 2>/dev/null
-                if grep -qi "too many requests\|rate limit\|429" "$bg_log" 2>/dev/null; then
-                    rate_limited=true
-                fi
-                if [[ -n "$fail_callback" ]] && "$fail_callback" "$svc2"; then
-                    :  # callback handled it
-                else
-                    pull_failed+=("$svc2")
-                fi
-            fi
-            rm -f "$bg_log"
+        else
+            "$log_fn" "  $svc OK (${svc_elapsed}s)"
         fi
     done
+
+    local pull_end
+    pull_end=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0)
+    local pull_elapsed=$(( pull_end - pull_start ))
 
     # Clean up temp directory and cache (safe — all background jobs have been waited on)
     rm -rf "$_pi_tmp"
@@ -204,6 +194,6 @@ pull_compose_images() {
         return 1
     fi
 
-    "$log_fn" "All $total images pulled successfully"
+    "$log_fn" "All $total images pulled (${pull_elapsed}s)"
     return 0
 }

--- a/scripts/common/unified-log.sh
+++ b/scripts/common/unified-log.sh
@@ -37,12 +37,14 @@ log_msg() {
         >> "$UNIFIED_LOG" 2>/dev/null || true
 
     # Feed TUI progress display (progress.sh reads this file)
-    case "$level" in
-        INFO|OK)
-            [[ -n "${PROGRESS_LOG:-}" ]] && \
-                echo "$msg" >> "$PROGRESS_LOG" 2>/dev/null || true
-            ;;
-    esac
+    # All levels shown so warnings/errors are visible on the HDMI console
+    if [[ -n "${PROGRESS_LOG:-}" ]]; then
+        case "$level" in
+            WARN)  echo "[WARN] $msg" >> "$PROGRESS_LOG" 2>/dev/null || true ;;
+            ERROR) echo "[ERROR] $msg" >> "$PROGRESS_LOG" 2>/dev/null || true ;;
+            *)     echo "$msg" >> "$PROGRESS_LOG" 2>/dev/null || true ;;
+        esac
+    fi
 
     # Show errors and warnings on HDMI console
     case "$level" in

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -131,24 +131,26 @@ source "$COMMON/unified-log.sh"
 # shellcheck disable=SC2034
 case "$INSTALL_TYPE" in
     client)
-        STEP_NAMES=("Network connectivity" "Copy project files"
-                    "Install git and dependencies" "Install Docker"
-                    "Setup audio player" "Verify containers")
+        STEP_NAMES=("Wait for network" "Copy project files"
+                    "Install system packages" "Install Docker engine"
+                    "Setup audio player (HAT detect, pull, configure)"
+                    "Verify services healthy")
         STEP_WEIGHTS=(5 2 10 30 48 5)
         PROGRESS_TITLE="snapMULTI Audio Player"
         ;;
     server)
-        STEP_NAMES=("Network connectivity" "Copy project files"
-                    "Install git and dependencies" "Install Docker"
-                    "Deploy server" "Verify containers")
+        STEP_NAMES=("Wait for network" "Copy project files"
+                    "Install system packages" "Install Docker engine"
+                    "Deploy server (config, pull, start)"
+                    "Verify services healthy")
         STEP_WEIGHTS=(5 2 8 30 45 10)
         PROGRESS_TITLE="snapMULTI Music Server"
         ;;
     both)
-        STEP_NAMES=("Network connectivity" "Copy project files"
-                    "Install git and dependencies" "Install Docker"
-                    "Deploy server" "Verify server"
-                    "Setup audio player" "Verify containers")
+        STEP_NAMES=("Wait for network" "Copy project files"
+                    "Install system packages" "Install Docker engine"
+                    "Deploy server (config, pull, start)" "Verify server"
+                    "Setup audio player (HAT detect, pull)" "Verify all services")
         STEP_WEIGHTS=(4 2 7 25 35 4 18 5)
         PROGRESS_TITLE="snapMULTI Server + Player"
         ;;


### PR DESCRIPTION
## Summary

- **TUI layout** (`progress.sh`): full terminal width (auto-detect via `stty` after font change), dynamic log area fills remaining rows instead of fixed 8 lines, log lines use full width
- **Serial pull** (`pull-images.sh`): removed paired background+foreground pull — sequential only. Fixes counter bug (8/7, 210/7) and reduces SD card IO contention
- **Verbose pull** (`pull-images.sh`): shows image name, per-service timing, callback-aware status (distinguishes "FAILED" from "fallback OK")
- **Log visibility** (`unified-log.sh`): WARN/ERROR now feed into PROGRESS_LOG so they appear in the TUI output area
- **Locales** (`install-deps.sh`): install `locales` package + generate IT, EN_US, EN_GB, FR, DE, ES, PT (was `locales-all` at 236MB)
- **Step names** (`firstboot.sh`): more descriptive (e.g. "Deploy server (config, pull, start)")

## Context

snapvideo install log showed pull counter going to 210/7 with librespot+metadata stuck in infinite paired retry. Root cause: old `pull-images.sh` paired-pull loop with broken counter and IO contention on SD card.

## Test plan

- [ ] shellcheck clean
- [ ] `bash tests/test_setup_docker_driver.sh` passes
- [ ] `bash tests/test_deploy_docker_gating.sh` passes
- [ ] Fresh install: verify serial pull, correct counter, full-width TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)