### PR TITLE
arch: ADR-005 + formalize device-smoke.sh acceptance gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FIFO health monitoring** ([#224](https://github.com/lollonet/snapMULTI/pull/224)) — `save-diagnostics.sh` records pipe status (reader count via `fuser`) and container restart counts to `audio-health.log`
 - **MPD backup timer** ([#225](https://github.com/lollonet/snapMULTI/pull/225)) — daily backup of `mpd.db` to boot partition; `backup-from-sd.sh` extracts it before reflashing so MPD does fast incremental scan instead of hours-long rescan
 - **QUICKSTART.md** ([#226](https://github.com/lollonet/snapMULTI/pull/226)) — one-page quick start (60 lines); README slimmed from 245 to 72 lines
+- **ADR-005** ([#257](https://github.com/lollonet/snapMULTI/pull/257)) — architecture decision record: reflash-only, systemd lifecycle, robustness-first
+- **device-smoke.sh** ([#257](https://github.com/lollonet/snapMULTI/pull/257)) — mode-aware acceptance gate (`--server`/`--client`/`--both`): root mount, Docker driver, systemd units, compose health, recent error logs
 
 ### Changed
 - **Full-width TUI** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — progress display uses full terminal width (auto-detect via `stty` after font change), dynamic log area fills remaining rows instead of fixed 8 lines, WARN/ERROR now visible in TUI output

--- a/docs/adr/ADR-005.reflash-systemd-robustness.md
+++ b/docs/adr/ADR-005.reflash-systemd-robustness.md
@@ -1,0 +1,44 @@
+---
+id: ADR-005
+status: accepted
+date: 2026-04-22
+---
+
+# ADR-005: Reflash-Only, systemd Lifecycle, Robustness-First
+
+## Context
+
+The install/orchestration layer grew four fragmented authorities:
+- **Host bootstrap**: 3 scripts install packages independently (firstboot.sh, deploy.sh, setup.sh)
+- **Stack lifecycle**: 3 mechanisms restart containers (Docker restart policy, systemd services, imperative `docker compose up -d`)
+- **Read-only transition**: 4 files configure Docker driver and overlayroot
+- **Install logging**: stdout parsed by string filters instead of one log contract
+
+This caused recurring bugs: fuse-overlayfs on writable root (#245), healthcheck counter overflow (#244), inconsistent reboot behavior. Fixes had to land in multiple places.
+
+## Decisions
+
+### 1. Reflash-only — no in-place update path
+
+`scripts/update.sh` is decommissioned. The primary update method is reflashing the SD card via `prepare-sd.sh`. Rationale:
+- Install takes ~10 minutes on Pi 4 — reflash is cheap
+- All config is auto-detected (HAT, display, network) — nothing to preserve except MPD database (backed up to boot partition)
+- Tarball-based update was 350 LOC of transactional staging for a rarely-used path
+- Pi Zero overlayroot makes OTA impossible (227MB images > 128MB tmpfs)
+
+### 2. systemd is the single lifecycle owner post-install
+
+After `firstboot.sh` completes and reboots, container lifecycle is owned exclusively by systemd services (`snapmulti-server.service`, `snapclient.service`). firstboot is a bootstrap-only actor — it installs, verifies, reboots, then never runs again.
+
+Docker `restart: unless-stopped` is kept as crash recovery for individual containers, but boot-time bring-up is systemd's responsibility.
+
+### 3. Robustness on real Pi devices above all else
+
+Architectural changes are gated by `device-smoke.sh --both` on a real Pi, not just CI. LOC reduction is a secondary metric. The primary metric is: snapvideo reboots green without manual intervention.
+
+## Consequences
+
+- `scripts/update.sh` becomes a stub directing users to reflash
+- Each concern gets one owner (see #247 roadmap)
+- `device-smoke.sh` becomes the acceptance gate for architectural PRs
+- Design decisions favor reliability on Pi 4/Zero over code elegance

--- a/docs/adr/ADR-INDEX.md
+++ b/docs/adr/ADR-INDEX.md
@@ -13,3 +13,4 @@ source_of_truth: true
 | ADR-002 | [FIFO Audio Routing](ADR-002.fifo-audio-routing.md) | Accepted | 2026-01-15 |
 | ADR-003 | [Read-Only Containers](ADR-003.read-only-containers.md) | Accepted | 2026-03-01 |
 | ADR-004 | [Centralized Metadata Service](ADR-004.metadata-architecture.md) | Accepted | 2026-02-19 |
+| ADR-005 | [Reflash-Only, systemd Lifecycle, Robustness-First](ADR-005.reflash-systemd-robustness.md) | Accepted | 2026-04-22 |

--- a/scripts/device-smoke.sh
+++ b/scripts/device-smoke.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# device-smoke.sh — mode-aware acceptance smoke check for real snapMULTI devices.
+#
+# Verifies:
+#   - root mount / overlayroot state
+#   - Docker driver + daemon.json storage-driver consistency
+#   - required systemd units
+#   - docker compose expected/running/healthy counts
+#
+# Usage:
+#   sudo bash scripts/device-smoke.sh [--server|--client|--both]
+#   sudo bash scripts/device-smoke.sh --server-dir /opt/snapmulti --client-dir /opt/snapclient
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common/logging.sh
+source "$SCRIPT_DIR/common/logging.sh"
+
+MODE="auto"
+SERVER_DIR=""
+CLIENT_DIR=""
+FAILURES=0
+
+usage() {
+    cat <<'EOF'
+Usage: device-smoke.sh [--server|--client|--both] [--server-dir PATH] [--client-dir PATH]
+
+Mode selection:
+  --server      Expect only server install
+  --client      Expect only client install
+  --both        Expect both server and client installs
+  default       Auto-detect from installed directories
+
+Overrides:
+  --server-dir  Override server install directory
+  --client-dir  Override client install directory
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server|--client|--both)
+            MODE="${1#--}"
+            shift
+            ;;
+        --server-dir)
+            SERVER_DIR="${2:-}"
+            [[ -n "$SERVER_DIR" ]] || { error "--server-dir requires a path"; exit 2; }
+            shift 2
+            ;;
+        --client-dir)
+            CLIENT_DIR="${2:-}"
+            [[ -n "$CLIENT_DIR" ]] || { error "--client-dir requires a path"; exit 2; }
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+detect_dir() {
+    local explicit="$1"
+    shift
+    if [[ -n "$explicit" ]]; then
+        printf '%s\n' "$explicit"
+        return 0
+    fi
+    local candidate
+    for candidate in "$@"; do
+        if [[ -d "$candidate" && -f "$candidate/docker-compose.yml" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+SERVER_DIR="$(detect_dir "$SERVER_DIR" /opt/snapmulti "${SCRIPT_DIR}/.." || true)"
+CLIENT_DIR="$(detect_dir "$CLIENT_DIR" /opt/snapclient "${SCRIPT_DIR}/../client/common" || true)"
+
+if [[ "$MODE" == "auto" ]]; then
+    if [[ -n "$SERVER_DIR" && -n "$CLIENT_DIR" ]]; then
+        MODE="both"
+    elif [[ -n "$SERVER_DIR" ]]; then
+        MODE="server"
+    elif [[ -n "$CLIENT_DIR" ]]; then
+        MODE="client"
+    else
+        error "No snapMULTI installation found"
+        exit 1
+    fi
+fi
+
+require_cmd() {
+    local cmd="$1"
+    command -v "$cmd" >/dev/null 2>&1 || {
+        error "Missing required command: $cmd"
+        exit 1
+    }
+}
+
+section() {
+    printf '\n%s%s==> %s%s\n' "$CYAN" "$BOLD" "$*" "$NC" >&2
+}
+
+pass_check() {
+    ok "$1"
+}
+
+fail_check() {
+    error "$1"
+    FAILURES=$((FAILURES + 1))
+}
+
+check_unit() {
+    local unit="$1"
+    if systemctl is-enabled "$unit" >/dev/null 2>&1 && systemctl is-active "$unit" >/dev/null 2>&1; then
+        pass_check "systemd: $unit enabled and active"
+    else
+        local enabled="disabled"
+        local active="inactive"
+        systemctl is-enabled "$unit" >/dev/null 2>&1 && enabled="enabled" || true
+        systemctl is-active "$unit" >/dev/null 2>&1 && active="active" || true
+        fail_check "systemd: $unit ${enabled}/${active}"
+    fi
+}
+
+compose_hc_total() {
+    local compose_file="$1"
+    docker compose -f "$compose_file" config --format json 2>/dev/null \
+        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" \
+        2>/dev/null || echo 0
+}
+
+check_compose_stack() {
+    local compose_file="$1"
+    local stack_name="$2"
+    local expected=()
+    local running healthy hc_total svc
+
+    while IFS= read -r svc; do
+        [[ -n "$svc" ]] && expected+=("$svc")
+    done < <(docker compose -f "$compose_file" config --services 2>/dev/null || true)
+    if [[ ${#expected[@]} -eq 0 ]]; then
+        fail_check "$stack_name: no services returned by docker compose config"
+        return
+    fi
+
+    running=$(docker compose -f "$compose_file" ps --status running -q 2>/dev/null | wc -l | tr -d ' ')
+    hc_total=$(compose_hc_total "$compose_file")
+    healthy=$(
+        docker compose -f "$compose_file" ps -q 2>/dev/null \
+            | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+            | grep -c '^healthy$' || true
+    )
+
+    if [[ "$running" -ge "${#expected[@]}" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
+        pass_check "$stack_name: ${#expected[@]}/${#expected[@]} running, $healthy/$hc_total healthy"
+    else
+        fail_check "$stack_name: $running/${#expected[@]} running, $healthy/$hc_total healthy"
+    fi
+
+    for svc in "${expected[@]}"; do
+        local status
+        status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$svc" 2>/dev/null || echo "missing")
+        info "  $stack_name/$svc -> $status"
+    done
+}
+
+require_cmd docker
+require_cmd python3
+require_cmd systemctl
+require_cmd mount
+
+section "Host"
+info "Mode: $MODE"
+info "Hostname: $(hostname 2>/dev/null || echo unknown)"
+info "Uptime: $(uptime -p 2>/dev/null || echo unknown)"
+
+root_mount="$(mount | awk '$3 == "/" {print; exit}')"
+overlay_active=false
+if mount | grep -q ' on / type overlay'; then
+    overlay_active=true
+fi
+info "Root mount: ${root_mount:-unknown}"
+info "Overlayroot active: $overlay_active"
+
+docker_driver="$(docker info --format '{{.Driver}}' 2>/dev/null || echo unknown)"
+daemon_storage="default"
+if [[ -f /etc/docker/daemon.json ]]; then
+    daemon_storage=$(
+        python3 -c "import json; import sys; cfg=json.load(open('/etc/docker/daemon.json')); print(cfg.get('storage-driver','default'))" \
+            2>/dev/null || echo unreadable
+    )
+fi
+info "Docker driver: $docker_driver"
+info "daemon.json storage-driver: $daemon_storage"
+
+if [[ "$overlay_active" == true ]]; then
+    [[ "$docker_driver" == "fuse-overlayfs" ]] \
+        && pass_check "overlayroot active -> Docker driver is fuse-overlayfs" \
+        || fail_check "overlayroot active but Docker driver is $docker_driver"
+else
+    [[ "$docker_driver" != "fuse-overlayfs" ]] \
+        && pass_check "writable root -> Docker driver is not fuse-overlayfs" \
+        || fail_check "writable root but Docker driver is fuse-overlayfs"
+fi
+
+section "Systemd"
+case "$MODE" in
+    server)
+        [[ -n "$SERVER_DIR" ]] || fail_check "server install directory missing"
+        check_unit "snapmulti-server.service"
+        ;;
+    client)
+        [[ -n "$CLIENT_DIR" ]] || fail_check "client install directory missing"
+        check_unit "snapclient.service"
+        check_unit "snapclient-discover.timer"
+        ;;
+    both)
+        [[ -n "$SERVER_DIR" ]] || fail_check "server install directory missing"
+        [[ -n "$CLIENT_DIR" ]] || fail_check "client install directory missing"
+        check_unit "snapmulti-server.service"
+        check_unit "snapclient.service"
+        check_unit "snapclient-discover.timer"
+        ;;
+esac
+
+section "Compose"
+case "$MODE" in
+    server)
+        [[ -n "$SERVER_DIR" ]] && check_compose_stack "$SERVER_DIR/docker-compose.yml" "server"
+        ;;
+    client)
+        [[ -n "$CLIENT_DIR" ]] && check_compose_stack "$CLIENT_DIR/docker-compose.yml" "client"
+        ;;
+    both)
+        [[ -n "$SERVER_DIR" ]] && check_compose_stack "$SERVER_DIR/docker-compose.yml" "server"
+        [[ -n "$CLIENT_DIR" ]] && check_compose_stack "$CLIENT_DIR/docker-compose.yml" "client"
+        ;;
+esac
+
+section "Recent Errors"
+_error_count=0
+for log_src in "snapmulti-server" "snapclient" "docker"; do
+    local_errors=$(journalctl -u "${log_src}.service" --since "10 min ago" --priority err --no-pager -q 2>/dev/null | wc -l | tr -d ' ') || local_errors=0
+    if [[ "$local_errors" -gt 0 ]]; then
+        warn "$log_src: $local_errors error(s) in last 10 min"
+        journalctl -u "${log_src}.service" --since "10 min ago" --priority err --no-pager -q 2>/dev/null | tail -3 | while IFS= read -r line; do
+            info "  $line"
+        done
+        _error_count=$((_error_count + local_errors))
+    fi
+done
+if [[ "$_error_count" -eq 0 ]]; then
+    pass_check "No errors in systemd logs (last 10 min)"
+else
+    warn "$_error_count total error(s) in recent logs (non-blocking)"
+fi
+
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+    ok "Smoke check passed"
+    exit 0
+fi
+
+error "Smoke check failed with $FAILURES issue(s)"
+exit 1

--- a/scripts/device-smoke.sh
+++ b/scripts/device-smoke.sh
@@ -169,8 +169,13 @@ check_compose_stack() {
     fi
 
     for svc in "${expected[@]}"; do
-        local status
-        status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$svc" 2>/dev/null || echo "missing")
+        local cid status
+        cid=$(docker compose -f "$compose_file" ps -q "$svc" 2>/dev/null | head -1)
+        if [[ -n "$cid" ]]; then
+            status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid" 2>/dev/null || echo "unknown")
+        else
+            status="missing"
+        fi
         info "  $stack_name/$svc -> $status"
     done
 }


### PR DESCRIPTION
Closes #248 | Parent: #247

## Summary

- **ADR-005**: Documents three product decisions — reflash-only, systemd lifecycle owner, robustness-first on real Pi devices
- **device-smoke.sh**: Formalized as official acceptance gate. Added recent error log scanning (journalctl, non-blocking). Already tested on snapvideo: 7/7 server + 3/3 client healthy, known gap `snapmulti-server.service` disabled (tracked in #252)

## Merge criteria for architectural PRs (defined here)
- `device-smoke.sh --both` green on real device
- No regression on server-only / client-only

## Test plan
- [ ] `shellcheck scripts/device-smoke.sh`
- [ ] `sudo bash scripts/device-smoke.sh --both` on snapvideo
- [ ] ADR content reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)