### PR TITLE
arch: shared verify policy — verify-compose.sh

### DIFF
--- a/scripts/common/verify-compose.sh
+++ b/scripts/common/verify-compose.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# verify-compose.sh — shared compose stack verification policy
+#
+# Single contract: all expected services running, only healthcheck-enabled
+# ones must be healthy. Retries with configurable attempts and delay.
+#
+# Usage:
+#   source scripts/common/verify-compose.sh
+#   verify_compose_stack <compose_file> <stack_name> <attempts> <delay_seconds>
+#
+# Returns 0 if all services healthy, 1 otherwise.
+# Logging: uses log_info/log_error if available, falls back to echo.
+
+# Ensure logging functions exist (callers should source their own logger first)
+if ! declare -F log_info &>/dev/null; then
+    if declare -F info &>/dev/null; then
+        log_info()  { info "$@"; }
+        log_error() { error "$@"; }
+    else
+        log_info()  { echo "[INFO] $*"; }
+        log_error() { echo "[ERROR] $*" >&2; }
+    fi
+fi
+
+# Count services with healthcheck defined in a compose file.
+# Returns the count via stdout.
+_compose_hc_total() {
+    local compose_file="$1"
+    docker compose -f "$compose_file" config --format json 2>/dev/null \
+        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" \
+        2>/dev/null || echo 0
+}
+
+# Count healthy containers in a compose project.
+_compose_healthy_count() {
+    local compose_file="$1"
+    docker compose -f "$compose_file" ps -q 2>/dev/null \
+        | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
+        | grep -c '^healthy$' || true
+}
+
+# Verify all services in a compose stack are running and healthy.
+#
+# Args:
+#   $1  compose_file   Path to docker-compose.yml
+#   $2  stack_name     Human label for log messages (e.g. "server", "client")
+#   $3  attempts       Number of retry attempts
+#   $4  delay          Seconds between attempts
+#
+# Returns 0 on success, 1 on failure.
+verify_compose_stack() {
+    local compose_file="$1"
+    local stack_name="$2"
+    local attempts="$3"
+    local delay="$4"
+    local total hc_total running healthy attempt
+
+    total=$(docker compose -f "$compose_file" config --services 2>/dev/null | wc -l)
+    if [[ "$total" -eq 0 ]]; then
+        log_error "Could not determine ${stack_name} service count"
+        return 1
+    fi
+
+    hc_total=$(_compose_hc_total "$compose_file")
+
+    for attempt in $(seq 1 "$attempts"); do
+        running=$(docker compose -f "$compose_file" ps --status running -q 2>/dev/null | wc -l)
+        healthy=$(_compose_healthy_count "$compose_file")
+
+        if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
+            log_info "All $total ${stack_name} services running ($healthy/$hc_total healthy)"
+            return 0
+        fi
+
+        log_info "Attempt $attempt/$attempts: $running/$total running, $healthy/$hc_total healthy..."
+        [[ "$attempt" -lt "$attempts" ]] && sleep "$delay"
+    done
+
+    log_error "$stack_name services not all healthy after $(( attempts * delay ))s"
+    docker compose -f "$compose_file" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
+        log_error "  $line"
+    done
+    return 1
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -876,13 +876,6 @@ start_services() {
 verify_services() {
     step "Verifying services"
 
-    # Derive expected services from active compose config (respects profiles)
-    local expected_services
-    mapfile -t expected_services < <(docker compose config --services)
-    if [[ ${#expected_services[@]} -eq 0 ]]; then
-        error "No services returned from docker compose config — check compose file"
-        exit 1
-    fi
     # Use MPD_START_PERIOD from .env (default 30s) to set verification timeout.
     # NFS mounts may need 300s for MPD to become healthy.
     local start_period
@@ -890,53 +883,12 @@ verify_services() {
     start_period=${start_period:-30}
     local wait_seconds=15
     local max_attempts=$(( (start_period / wait_seconds) + 2 ))
-    local attempt=1
-
-    # Count services with healthcheck defined (only those need to be "healthy")
-    local hc_total
-    hc_total=$(docker compose config --format json 2>/dev/null \
-        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || hc_total=0
 
     info "Checking services (up to ${start_period}s, ${wait_seconds}s interval)..."
 
-    while [[ $attempt -le $max_attempts ]]; do
-        local running healthy
-        running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
-        healthy=$(
-            docker compose ps -q 2>/dev/null \
-                | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
-                | grep -c '^healthy$' || true
-        )
-        local total=${#expected_services[@]}
-
-        # All services running AND all healthcheck-enabled services healthy
-        if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
-            for service in "${expected_services[@]}"; do
-                ok "$service running"
-            done
-            ok "All $total services running ($healthy/$hc_total healthy)"
-            return 0
-        fi
-
-        if [[ $attempt -lt $max_attempts ]]; then
-            info "Attempt $attempt/$max_attempts: $running/$total running, $healthy/$hc_total healthy, waiting ${wait_seconds}s..."
-            sleep "$wait_seconds"
-        fi
-
-        attempt=$((attempt + 1))
-    done
-
-    # Final report
-    warn "Service verification incomplete after $max_attempts attempts"
-    for service in "${expected_services[@]}"; do
-        if docker ps --format '{{.Names}}' | grep -q "^${service}$"; then
-            ok "$service running"
-        else
-            error "$service not running"
-        fi
-    done
-    warn "Check logs: docker compose logs"
-    return 1
+    # shellcheck source=common/verify-compose.sh
+    source "$SCRIPT_DIR/common/verify-compose.sh"
+    verify_compose_stack "$PROJECT_ROOT/docker-compose.yml" "server" "$max_attempts" "$wait_seconds"
 }
 
 show_status() {

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -251,46 +251,8 @@ cumulative_pct() {
     echo $(( weight_sum * 100 / total_weight ))
 }
 
-verify_compose_stack() {
-    local compose_file="$1"
-    local stack_name="$2"
-    local attempts="$3"
-    local delay="$4"
-    local compose_args=(-f "$compose_file")
-    local total hc_total running healthy attempt
-
-    total=$(docker compose "${compose_args[@]}" config --services 2>/dev/null | wc -l)
-    if [[ "$total" -eq 0 ]]; then
-        log_error "Could not determine ${stack_name} service count"
-        return 1
-    fi
-
-    hc_total=$(docker compose "${compose_args[@]}" config --format json 2>/dev/null \
-        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || hc_total=0
-
-    for attempt in $(seq 1 "$attempts"); do
-        running=$(docker compose "${compose_args[@]}" ps --status running -q 2>/dev/null | wc -l)
-        healthy=$(
-            docker compose "${compose_args[@]}" ps -q 2>/dev/null \
-                | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
-                | grep -c '^healthy$' || true
-        )
-
-        if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
-            log_info "All $total ${stack_name} services running ($healthy/$hc_total healthy)"
-            return 0
-        fi
-
-        log_info "Attempt $attempt/$attempts: $running/$total running, $healthy/$hc_total healthy..."
-        [[ "$attempt" -lt "$attempts" ]] && sleep "$delay"
-    done
-
-    log_error "$stack_name services not all healthy after $(( attempts * delay ))s"
-    docker compose "${compose_args[@]}" ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
-        log_error "  $line"
-    done
-    return 1
-}
+# shellcheck source=common/verify-compose.sh
+source "$COMMON/verify-compose.sh"
 
 # Headless detection (for client modes)
 has_display() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -210,41 +210,13 @@ pull_and_restart() {
 
 verify_services() {
     info "Verifying services..."
-    local max_attempts=6
-    local total hc_total
-    total=$(docker compose config --services 2>/dev/null | wc -l)
-    # Count services that define a healthcheck (only those report "healthy")
-    hc_total=$(docker compose config --format json 2>/dev/null \
-        | python3 -c "import sys,json; c=json.load(sys.stdin)['services']; print(sum(1 for s in c.values() if 'healthcheck' in s))" 2>/dev/null) || hc_total=0
-
     sleep 5
 
-    for attempt in $(seq 1 "$max_attempts"); do
-        local running healthy
-        running=$(docker compose ps --status running -q 2>/dev/null | wc -l)
-        healthy=$(
-            docker compose ps -q 2>/dev/null \
-                | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' 2>/dev/null \
-                | grep -c '^healthy$' || true
-        )
-
-        # All services running AND all healthcheck-enabled services healthy
-        if [[ "$running" -ge "$total" ]] && { [[ "$hc_total" -eq 0 ]] || [[ "$healthy" -ge "$hc_total" ]]; }; then
-            ok "All $total services running ($healthy/$hc_total healthy)"
-            return 0
-        fi
-
-        if [[ $attempt -lt $max_attempts ]]; then
-            info "Attempt $attempt/$max_attempts: $running/$total running, $healthy/$hc_total healthy..."
-            sleep 10
-        fi
-    done
-
-    error "Not all services healthy after verification"
-    docker compose ps --format 'table {{.Name}}\t{{.Status}}' 2>/dev/null | while read -r line; do
-        error "  $line"
-    done
-    return 1
+    # shellcheck source=common/verify-compose.sh
+    source "$(dirname "${BASH_SOURCE[0]}")/common/verify-compose.sh" 2>/dev/null \
+        || source "$INSTALL_DIR/scripts/common/verify-compose.sh" 2>/dev/null \
+        || { error "verify-compose.sh not found"; return 1; }
+    verify_compose_stack "$INSTALL_DIR/docker-compose.yml" "server" 6 10
 }
 
 #######################################

--- a/tests/test_firstboot_verify.sh
+++ b/tests/test_firstboot_verify.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FIRSTBOOT_SH="$SCRIPT_DIR/../scripts/firstboot.sh"
+VERIFY_SH="$SCRIPT_DIR/../scripts/common/verify-compose.sh"
 
 pass=0
 fail=0
@@ -18,8 +18,9 @@ assert_eq() {
     fi
 }
 
-# Extract the production function from firstboot.sh rather than maintaining a copy
-eval "$(sed -n '/^verify_compose_stack()/,/^}/p' "$FIRSTBOOT_SH")"
+# Source the shared verify module directly
+# shellcheck source=../scripts/common/verify-compose.sh
+source "$VERIFY_SH"
 
 # Create mock docker script on PATH so xargs can invoke it
 MOCK_BIN=$(mktemp -d)


### PR DESCRIPTION
Closes #249 | Parent: #247 | Depends on: #248

## Summary

Extract `verify_compose_stack()` into `scripts/common/verify-compose.sh` — single contract replacing 3 duplicated implementations:

- **firstboot.sh**: 40 LOC inline → `source verify-compose.sh`
- **deploy.sh**: 64 LOC `verify_services()` → sources shared module with dynamic timeout from MPD_START_PERIOD
- **update.sh**: 37 LOC `verify_services()` → sources shared module

Net: **-29 LOC**, one verify policy instead of three.

## Contract
All expected services running + only healthcheck-enabled ones must be healthy. Configurable attempts and delay. Consistent exit codes and log output.

## Test plan
- [ ] `bash tests/test_firstboot_verify.sh` passes (sources shared module)
- [ ] shellcheck clean
- [ ] `device-smoke.sh --both` on snapvideo

🤖 Generated with [Claude Code](https://claude.com/claude-code)