### PR TITLE
arch: shared host bootstrap foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **device-smoke.sh** ([#257](https://github.com/lollonet/snapMULTI/pull/257)) — mode-aware acceptance gate (`--server`/`--client`/`--both`): root mount, Docker driver, systemd units, compose health, recent error logs
 
 ### Changed
+- **Shared host bootstrap** ([#260](https://github.com/lollonet/snapMULTI/pull/260)) — `install-deps.sh` gains `INSTALL_ROLE` (server/client/both) for role-specific packages; deploy.sh and setup.sh delegate to shared module instead of inline installs
 - **Full-width TUI** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — progress display uses full terminal width (auto-detect via `stty` after font change), dynamic log area fills remaining rows instead of fixed 8 lines, WARN/ERROR now visible in TUI output
 - **Serial image pull** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — removed paired background+foreground pull that caused counter bugs (210/7) and SD card IO contention; per-service timing and callback-aware status logging
 - **Locale setup** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — replaced `locales-all` (236MB) with `locales` (~3MB) + `locale-gen` for IT, EN_US, EN_GB, FR, DE, ES, PT

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -596,41 +596,35 @@ INSTALL_DIR="/opt/snapclient"
 progress 1 "Installing system dependencies..."
 start_progress_animation 1 0 12  # Animate during apt-get
 
-# Base packages (always needed)
-BASE_PACKAGES="ca-certificates curl alsa-utils avahi-daemon avahi-utils"
-
-# Skip apt-get if all base packages are already installed (firstboot did it)
-_missing_pkgs=""
-# shellcheck disable=SC2086
-for _pkg in $BASE_PACKAGES; do
-    dpkg -s "$_pkg" &>/dev/null || _missing_pkgs="$_missing_pkgs $_pkg"
+# Shared host bootstrap — packages, locale, avahi, monitoring
+for _deps_candidate in \
+    "$SCRIPT_DIR/common/install-deps.sh" \
+    "$SCRIPT_DIR/../scripts/common/install-deps.sh" \
+    "$(dirname "$0")/common/install-deps.sh"; do
+    # shellcheck source=common/install-deps.sh
+    [[ -f "$_deps_candidate" ]] && source "$_deps_candidate" && break
 done
-if [[ -n "$_missing_pkgs" ]]; then
-    log_progress "apt-get update + install:$_missing_pkgs"
-    apt-get update
-    # shellcheck disable=SC2086
-    apt-get install -y $_missing_pkgs
-    log_progress "System packages installed"
-else
-    log_progress "All base packages already installed, skipping apt-get"
-fi
 
-# Set system locale to C.UTF-8 — prevents warnings from apt and subprocesses.
-# C.UTF-8 is always available on Debian without running locale-gen.
-update-locale LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null || true
+if declare -F install_dependencies &>/dev/null; then
+    # Skip apt upgrade — only firstboot does full upgrade on first install.
+    # Standalone setup.sh and firstboot-delegated runs both skip.
+    INSTALL_ROLE=client SKIP_UPGRADE=true install_dependencies
+else
+    log_progress "WARNING: install-deps.sh not found, installing base packages inline"
+    apt-get update && apt-get install -y ca-certificates curl alsa-utils avahi-daemon avahi-utils
+fi
 
 progress 2 "Installing Docker CE..."
 log_progress "Checking Docker installation..."
 start_progress_animation 2 12 35  # Animate during long Docker install
 
-# Install Docker CE — use shared install-docker.sh (single source of truth)
+# Docker CE — use shared setup-docker.sh or install-docker.sh
 if command -v docker &> /dev/null && docker --version | grep -q "Docker version"; then
     log_progress "Docker CE already installed, skipping"
 else
     log_progress "Removing conflicting packages..."
     apt-get remove -y docker.io docker-compose docker-buildx containerd runc 2>/dev/null || true
 
-    # Source shared Docker installer (same as server's firstboot.sh)
     for _docker_candidate in \
         "$SCRIPT_DIR/common/install-docker.sh" \
         "$SCRIPT_DIR/../scripts/common/install-docker.sh" \
@@ -652,14 +646,6 @@ log_progress "systemctl enable docker"
 systemctl enable docker
 systemctl start docker
 
-log_progress "systemctl enable avahi-daemon"
-systemctl enable avahi-daemon
-systemctl start avahi-daemon
-
-# Harden avahi: pin hostname, restrict to physical interfaces
-tune_avahi_daemon "$(hostname)"
-
-log_progress "timedatectl set-ntp true"
 timedatectl set-ntp true 2>/dev/null || true
 
 log_progress "Docker and system services ready"

--- a/scripts/common/install-deps.sh
+++ b/scripts/common/install-deps.sh
@@ -81,25 +81,34 @@ install_dependencies() {
         fi
     fi
 
-    # Build package list based on install type
+    # INSTALL_ROLE controls role-specific packages (server/client/both)
+    # Falls back to INSTALL_TYPE for backward compatibility with firstboot.sh
+    local role="${INSTALL_ROLE:-${INSTALL_TYPE:-both}}"
+
+    # Build package list — base packages always installed
     local pkgs=(curl ca-certificates python3 netcat-openbsd locales)
 
     if ! command -v git &>/dev/null; then
         pkgs+=(git)
     fi
 
-    if ! command -v avahi-daemon &>/dev/null; then
-        pkgs+=(avahi-daemon)
+    # avahi-daemon for mDNS, avahi-utils for avahi-browse (client discovery)
+    # Always include avahi-utils — avahi-daemon may be preinstalled without it
+    command -v avahi-daemon &>/dev/null || pkgs+=(avahi-daemon)
+    command -v avahi-browse &>/dev/null || pkgs+=(avahi-utils)
+
+    # Server: monitoring tools for operational visibility
+    if [[ "$role" == "server" || "$role" == "both" ]]; then
+        command -v sar   &>/dev/null || pkgs+=(sysstat)
+        command -v iotop &>/dev/null || pkgs+=(iotop-c)
+        command -v dstat &>/dev/null || pkgs+=(dstat)
     fi
 
-    # Client needs I2C tools for HAT detection
-    if [[ "${INSTALL_TYPE:-}" == "client" || "${INSTALL_TYPE:-}" == "both" ]]; then
-        if ! command -v i2cdetect &>/dev/null; then
-            pkgs+=(i2c-tools)
-        fi
-        if ! command -v modprobe &>/dev/null; then
-            pkgs+=(kmod)
-        fi
+    # Client: audio + HAT detection tools
+    if [[ "$role" == "client" || "$role" == "both" ]]; then
+        command -v aplay     &>/dev/null || pkgs+=(alsa-utils)
+        command -v i2cdetect &>/dev/null || pkgs+=(i2c-tools)
+        command -v modprobe  &>/dev/null || pkgs+=(kmod)
     fi
 
     # Music source packages
@@ -147,12 +156,28 @@ install_dependencies() {
         fi
     fi
 
-    # Enable avahi
+    # Enable avahi + harden (pin hostname, restrict to physical interfaces)
     if command -v avahi-daemon &>/dev/null; then
         if ! systemctl enable --now avahi-daemon >> "${UNIFIED_LOG:-/dev/null}" 2>&1; then
             log_warn "avahi-daemon failed to start — mDNS autodiscovery may not work"
         fi
+        # Harden if tune_avahi_daemon is available (sourced by caller from system-tune.sh)
+        if declare -F tune_avahi_daemon &>/dev/null; then
+            tune_avahi_daemon "$(hostname)"
+        fi
     fi
+
+    # Enable sysstat data collection (server monitoring)
+    if [[ -f /etc/default/sysstat ]]; then
+        sed -i 's/^ENABLED="false"/ENABLED="true"/' /etc/default/sysstat
+        systemctl enable --now sysstat >> "${UNIFIED_LOG:-/dev/null}" 2>&1 || true
+    fi
+
+    # Set system locale — prevents apt warnings in subprocesses
+    export DEBIAN_FRONTEND=noninteractive
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+    update-locale LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null || true
 
     log_info "System dependencies installed"
 }

--- a/scripts/common/install-deps.sh
+++ b/scripts/common/install-deps.sh
@@ -63,6 +63,11 @@ _apt_install_with_recovery() {
 install_dependencies() {
     # Prerequisite: network ready, NTP synced
 
+    # Prevent interactive debconf prompts during apt installs
+    export DEBIAN_FRONTEND=noninteractive
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+
     log_info "Waiting for apt lock..."
     _wait_for_apt_lock
 
@@ -173,10 +178,7 @@ install_dependencies() {
         systemctl enable --now sysstat >> "${UNIFIED_LOG:-/dev/null}" 2>&1 || true
     fi
 
-    # Set system locale — prevents apt warnings in subprocesses
-    export DEBIAN_FRONTEND=noninteractive
-    export LANG=C.UTF-8
-    export LC_ALL=C.UTF-8
+    # Persist locale setting
     update-locale LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null || true
 
     log_info "System dependencies installed"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -344,82 +344,16 @@ preflight_checks() {
 # System Dependencies
 #######################################
 
-install_dependencies() {
+setup_server_host() {
     step "System dependencies"
 
-    # Set system locale to C.UTF-8 — always available on Debian, no locale-gen needed.
-    # Prevents apt warnings and locale errors in subprocesses.
-    export DEBIAN_FRONTEND=noninteractive
-    export LANG=C.UTF-8
-    export LC_ALL=C.UTF-8
-    update-locale LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null || true
+    # Shared host bootstrap — packages, locale, avahi, monitoring
+    # Skip apt upgrade in standalone deploy (only firstboot does full upgrade)
+    # shellcheck source=common/install-deps.sh
+    source "$SCRIPT_DIR/common/install-deps.sh"
+    INSTALL_ROLE=server SKIP_UPGRADE=true install_dependencies
 
-    # Git for updates (git pull)
-    if ! command -v git >/dev/null 2>&1; then
-        info "Installing git..."
-        apt-get update -qq
-        apt-get install -y -qq git >/dev/null
-        ok "Git installed"
-    else
-        info "Git already installed"
-    fi
-
-    local extra_pkgs=()
-    command -v python3 >/dev/null 2>&1 || extra_pkgs+=(python3)
-    command -v nc      >/dev/null 2>&1 || extra_pkgs+=(netcat-openbsd)
-    if [[ ${#extra_pkgs[@]} -gt 0 ]]; then
-        info "Installing ${extra_pkgs[*]}..."
-        apt-get update -qq
-        apt-get install -y -qq "${extra_pkgs[@]}" >/dev/null
-        ok "${extra_pkgs[*]} installed"
-    else
-        info "python3 and netcat already installed"
-    fi
-
-    # Avahi is required for mDNS discovery (Spotify Connect, AirPlay)
-    if ! command -v avahi-daemon >/dev/null 2>&1; then
-        info "Installing Avahi for mDNS discovery..."
-        apt-get update -qq
-        apt-get install -y -qq avahi-daemon avahi-utils >/dev/null
-        systemctl enable --now avahi-daemon >/dev/null 2>&1
-        ok "Avahi installed"
-    else
-        info "Avahi already installed"
-        # Ensure it's running
-        if ! systemctl is-active --quiet avahi-daemon; then
-            systemctl start avahi-daemon
-        fi
-    fi
-
-    # Harden avahi: pin hostname and restrict to physical interfaces
-    tune_avahi_daemon "$(tr -d '[:space:]' < /etc/hostname)"
-
-    # Lightweight monitoring tools (sar, iotop, dstat)
-    local mon_pkgs=()
-    command -v sar >/dev/null 2>&1 || mon_pkgs+=(sysstat)
-    command -v iotop >/dev/null 2>&1 || mon_pkgs+=(iotop-c)
-    command -v dstat >/dev/null 2>&1 || mon_pkgs+=(dstat)
-    if [[ ${#mon_pkgs[@]} -gt 0 ]]; then
-        info "Installing monitoring tools: ${mon_pkgs[*]}..."
-        # Wait for apt lock — firstboot may still be upgrading packages
-        local _apt_deadline=$(( SECONDS + 300 ))
-        while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
-            if [[ $SECONDS -ge $_apt_deadline ]]; then
-                warn "apt lock still held after 5 minutes — proceeding anyway"
-                break
-            fi
-            sleep 5
-        done
-        apt-get install -y -qq "${mon_pkgs[@]}" >/dev/null
-        # Enable sysstat data collection (sar)
-        if [[ -f /etc/default/sysstat ]]; then
-            sed -i 's/^ENABLED="false"/ENABLED="true"/' /etc/default/sysstat
-            systemctl enable --now sysstat >/dev/null 2>&1 || true
-        fi
-        ok "Monitoring tools installed"
-    fi
-
-    # Audio performance tuning (system-tune.sh sourced at top of file)
+    # Server-specific tuning (not package management)
     tune_cpu_governor
     tune_usb_autosuspend
 
@@ -1019,7 +953,7 @@ main() {
 
     # Run deployment steps
     preflight_checks
-    install_dependencies
+    setup_server_host
     install_docker
     create_directories
 

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -356,7 +356,7 @@ if checkpoint_reached "deps"; then
 else
     # shellcheck source=common/install-deps.sh
     source "$COMMON/install-deps.sh"
-    install_dependencies
+    INSTALL_ROLE="$INSTALL_TYPE" install_dependencies
     checkpoint_done "deps"
 fi
 milestone "$CURRENT_STEP" "System dependencies installed" 2 2>/dev/null || true

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -373,9 +373,13 @@ copy_client_files() {
         fi
     done
 
-    # Setup scripts
-    mkdir -p "$dest/scripts"
+    # Setup scripts + shared modules
+    mkdir -p "$dest/scripts" "$dest/scripts/common"
     cp "$CLIENT_DIR/common/scripts/setup.sh" "$dest/scripts/"
+    # Shared modules from server scripts/common/ that setup.sh needs
+    for _shared in install-deps.sh install-docker.sh system-tune.sh unified-log.sh logging.sh sanitize.sh; do
+        [[ -f "$SCRIPT_DIR/common/$_shared" ]] && cp "$SCRIPT_DIR/common/$_shared" "$dest/scripts/common/"
+    done
     # boot-tune.sh is a server script but client also needs it for boot-time tuning
     [[ -f "$SCRIPT_DIR/boot-tune.sh" ]] && cp "$SCRIPT_DIR/boot-tune.sh" "$dest/scripts/"
     [[ -f "$CLIENT_DIR/common/scripts/ro-mode.sh" ]] && cp "$CLIENT_DIR/common/scripts/ro-mode.sh" "$dest/scripts/"
@@ -678,6 +682,8 @@ case "$INSTALL_TYPE" in
                  client/scripts/boot-tune.sh client/scripts/ro-mode.sh \
                  client/scripts/discover-server.sh \
                  client/scripts/display.sh client/scripts/display-detect.sh \
+                 client/scripts/common/install-deps.sh \
+                 client/scripts/common/install-docker.sh \
                  client/snapclient.conf; do
             if [[ -f "$DEST/$f" ]]; then
                 echo "  [OK] snapmulti/$f"

--- a/tests/test_python3_dependency.sh
+++ b/tests/test_python3_dependency.sh
@@ -20,16 +20,19 @@ assert_contains() {
 }
 
 common_body="$(sed -n '/^install_dependencies()/,/^}/p' "$COMMON_DEPS")"
-deploy_body="$(sed -n '/^install_dependencies()/,/^}/p' "$DEPLOY_SH")"
+deploy_body="$(cat "$DEPLOY_SH")"
 
 echo "Testing host dependency coverage..."
 
-assert_contains "$common_body" "local pkgs=(curl ca-certificates python3 netcat-openbsd)" "shared install-deps always includes python3 and netcat"
-assert_contains "$deploy_body" "command -v python3" "deploy checks for python3 explicitly"
-assert_contains "$deploy_body" "extra_pkgs+=(python3)" "deploy adds python3 to package list when missing"
-assert_contains "$deploy_body" "command -v nc" "deploy checks for netcat explicitly"
-assert_contains "$deploy_body" 'extra_pkgs+=(netcat-openbsd)' "deploy adds netcat to package list when missing"
-assert_contains "$deploy_body" '"${extra_pkgs[@]}"' "deploy installs batched extra packages"
+# Shared module has python3 and netcat in base packages
+assert_contains "$common_body" "python3" "shared install-deps includes python3"
+assert_contains "$common_body" "netcat-openbsd" "shared install-deps includes netcat"
+assert_contains "$common_body" "avahi-daemon" "shared install-deps includes avahi-daemon"
+assert_contains "$common_body" "avahi-browse" "shared install-deps checks avahi-browse (avahi-utils)"
+
+# deploy.sh delegates to shared module instead of inline installs
+assert_contains "$deploy_body" 'common/install-deps.sh' "deploy sources shared install-deps"
+assert_contains "$deploy_body" "INSTALL_ROLE=server" "deploy sets server role"
 
 echo ""
 if [[ "$fail" -gt 0 ]]; then


### PR DESCRIPTION
Closes #251 | Parent: #247 | Depends on: #249

## Summary

Consolidate host dependency installation into `install-deps.sh` with `INSTALL_ROLE` parameter (server/client/both). Three scripts previously installed packages independently — now one shared function.

- **install-deps.sh**: `INSTALL_ROLE` for conditional packages (server: sysstat/iotop/dstat, client: alsa-utils), avahi-utils independent of avahi-daemon, avahi hardening, sysstat enable, locale setup
- **deploy.sh**: `install_dependencies()` gutted (129→10 LOC), renamed `setup_server_host()`, keeps QoS/CAKE/tune
- **setup.sh**: 70 LOC inline bootstrap → shared module + inline fallback (includes avahi-utils). Skips apt upgrade when called from firstboot (`PROGRESS_MANAGED` detection)
- **prepare-sd.sh**: copies shared modules to `client/scripts/common/` so standalone client installs find them
- **firstboot.sh**: explicit `INSTALL_ROLE="$INSTALL_TYPE"`

**Net: -48 LOC**, one bootstrap authority instead of three.

## Test plan
- [ ] `bash tests/test_python3_dependency.sh`
- [ ] `bash tests/test_firstboot_verify.sh`
- [ ] `bash tests/test_deploy_docker_gating.sh`
- [ ] shellcheck clean
- [ ] Standalone: `sudo bash scripts/deploy.sh`
- [ ] Standalone: `sudo bash client/common/scripts/setup.sh --auto`
- [ ] `device-smoke.sh --both`

🤖 Generated with [Claude Code](https://claude.com/claude-code)