### PR TITLE
arch: systemd single lifecycle owner post-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **In-place update** — `scripts/update.sh` decommissioned per ADR-005. Reflash is the only supported update method.
 
 ### Changed
+- **systemd lifecycle owner** ([#261](https://github.com/lollonet/snapMULTI/pull/261)) — `snapmulti-server.service` created by deploy.sh with Docker readiness check; `snapclient.service` hardened with readiness + both-mode ordering; firstboot delegates to systemctl
 - **Shared host bootstrap** ([#260](https://github.com/lollonet/snapMULTI/pull/260)) — `install-deps.sh` gains `INSTALL_ROLE` (server/client/both) for role-specific packages; deploy.sh and setup.sh delegate to shared module instead of inline installs
 - **Full-width TUI** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — progress display uses full terminal width (auto-detect via `stty` after font change), dynamic log area fills remaining rows instead of fixed 8 lines, WARN/ERROR now visible in TUI output
 - **Serial image pull** ([#246](https://github.com/lollonet/snapMULTI/pull/246)) — removed paired background+foreground pull that caused counter bugs (210/7) and SD card IO contention; per-service timing and callback-aware status logging

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1250,7 +1250,7 @@ fi
 # Docker Compose profiles are handled via COMPOSE_PROFILES in .env
 # In both mode (server + client on same Pi), order client after server
 _after_units="docker.service avahi-daemon.service network-online.target"
-if systemctl list-unit-files snapmulti-server.service &>/dev/null 2>&1 \
+if systemctl list-unit-files snapmulti-server.service &>/dev/null \
     || [[ -f /etc/systemd/system/snapmulti-server.service ]]; then
     _after_units="$_after_units snapmulti-server.service"
 fi

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1248,21 +1248,31 @@ else
 fi
 
 # Docker Compose profiles are handled via COMPOSE_PROFILES in .env
+# In both mode (server + client on same Pi), order client after server
+_after_units="docker.service avahi-daemon.service network-online.target"
+if systemctl list-unit-files snapmulti-server.service &>/dev/null 2>&1 \
+    || [[ -f /etc/systemd/system/snapmulti-server.service ]]; then
+    _after_units="$_after_units snapmulti-server.service"
+fi
+
 cat > /etc/systemd/system/snapclient.service << EOF
 [Unit]
 Description=Snapclient Docker Compose Service
 Requires=docker.service avahi-daemon.service
-After=docker.service avahi-daemon.service network-online.target
+After=${_after_units}
 Wants=network-online.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=${INSTALL_DIR}
+ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do docker info >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'
 ExecStartPre=-/usr/local/bin/snapclient-discover
 ExecStart=/usr/bin/docker compose up -d
 ExecStop=/usr/bin/docker compose down
-TimeoutStartSec=0
+TimeoutStartSec=180
+Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -263,6 +263,32 @@ Per deployment multi-istanza, la rete macvlan assegna a ogni container un indiri
 
 La modalità host è consigliata per deployment con un singolo server.
 
+## Unit Systemd
+
+Dopo l'installazione, systemd gestisce il ciclo di vita dei container (ADR-005). La policy Docker `restart: unless-stopped` gestisce i crash dei singoli container; systemd gestisce l'avvio al boot.
+
+| Unit | Tipo installazione | Scopo |
+|------|-------------------|-------|
+| `snapmulti-server.service` | server, both | Avvia lo stack Docker Compose server al boot |
+| `snapclient.service` | client, both | Avvia lo stack Docker Compose client al boot |
+| `snapclient-discover.timer` | client, both | Riscopre il server via mDNS ogni 5 min |
+| `snapclient-display.service` | client (display) | Rileva HDMI e riconcilia i container display |
+| `snapmulti-boot-tune.service` | tutti | CPU governor, USB autosuspend, WiFi power save |
+
+```bash
+# Controlla stato
+systemctl status snapmulti-server.service
+systemctl status snapclient.service
+
+# Riavvia stack server
+sudo systemctl restart snapmulti-server.service
+
+# Visualizza log
+journalctl -u snapmulti-server.service --since "10 min ago"
+```
+
+In modalita **both**, `snapclient.service` si avvia dopo `snapmulti-server.service` per assicurarsi che il server sia pronto prima che il client si connetta.
+
 ## Interfacce di Controllo
 
 snapMULTI ha tre interfacce di controllo, ognuna per uno scopo diverso:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -263,6 +263,32 @@ Metadata: `tidal-meta-bridge.sh` scrapes `speaker_controller_application`'s tmux
 - Music directory: `/music` (mapped to `MUSIC_PATH` on host)
 - Database: `/data/mpd.db`
 
+## Systemd Units
+
+After installation, systemd owns the container lifecycle (ADR-005). Docker's `restart: unless-stopped` handles individual container crashes; systemd handles boot-time bring-up.
+
+| Unit | Install type | Purpose |
+|------|-------------|---------|
+| `snapmulti-server.service` | server, both | Starts server Docker Compose stack on boot |
+| `snapclient.service` | client, both | Starts client Docker Compose stack on boot |
+| `snapclient-discover.timer` | client, both | Re-discovers server via mDNS every 5 min |
+| `snapclient-display.service` | client (display) | Detects HDMI and reconciles display containers |
+| `snapmulti-boot-tune.service` | all | CPU governor, USB autosuspend, WiFi power save |
+
+```bash
+# Check status
+systemctl status snapmulti-server.service
+systemctl status snapclient.service
+
+# Restart server stack
+sudo systemctl restart snapmulti-server.service
+
+# View logs
+journalctl -u snapmulti-server.service --since "10 min ago"
+```
+
+In **both** mode, `snapclient.service` starts after `snapmulti-server.service` to ensure the server is ready before the client connects.
+
 ## Control Interfaces
 
 snapMULTI has three control interfaces, each for a different purpose:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -852,6 +852,43 @@ show_status() {
 }
 
 #######################################
+# Systemd Service
+#######################################
+
+install_systemd_service() {
+    step "Installing systemd service"
+
+    cat > /etc/systemd/system/snapmulti-server.service <<EOF
+[Unit]
+Description=snapMULTI Docker Compose Server
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=${PROJECT_ROOT}
+ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do docker info >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+TimeoutStartSec=180
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    if systemctl enable snapmulti-server.service >/dev/null 2>&1; then
+        ok "snapmulti-server.service enabled"
+    else
+        warn "snapmulti-server.service could not be enabled"
+    fi
+}
+
+#######################################
 # Version Tracking
 #######################################
 
@@ -970,6 +1007,7 @@ main() {
     pull_images
     start_services
     verify_services
+    install_systemd_service
     write_version
 
     show_status

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -563,11 +563,10 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     next_step "Verifying client..."
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
 
-    # Start client containers (setup.sh only enables the service, doesn't start it)
-    local_client_compose=(-f "$CLIENT_DIR/docker-compose.yml")
-    log_info "Starting client containers..."
+    # Start client via systemd — the lifecycle owner post-install (ADR-005)
+    log_info "Starting client via systemd..."
     cd "$CLIENT_DIR"
-    docker compose "${local_client_compose[@]}" up -d 2>/dev/null || log_warn "docker compose up failed"
+    systemctl start snapclient.service 2>/dev/null || log_warn "systemctl start snapclient failed"
 
     if ! verify_compose_stack "$CLIENT_DIR/docker-compose.yml" "client" 12 5; then
         log_error "Client verify failed — will retry on next boot"

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -565,8 +565,7 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
 
     # Start client via systemd — the lifecycle owner post-install (ADR-005)
     log_info "Starting client via systemd..."
-    cd "$CLIENT_DIR"
-    systemctl start snapclient.service 2>/dev/null || log_warn "systemctl start snapclient failed"
+    systemctl start snapclient.service || log_warn "systemctl start snapclient failed"
 
     if ! verify_compose_stack "$CLIENT_DIR/docker-compose.yml" "client" 12 5; then
         log_error "Client verify failed — will retry on next boot"

--- a/tests/test_deploy_systemd_service.sh
+++ b/tests/test_deploy_systemd_service.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../scripts/deploy.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+service_body="$(sed -n '/^install_systemd_service()/,/^}/p' "$DEPLOY_SH")"
+
+echo "Testing deploy systemd service..."
+
+assert_contains "$service_body" 'snapmulti-server.service' "service file is created"
+assert_contains "$service_body" 'ExecStart=/usr/bin/docker compose up -d' "service starts compose stack"
+assert_contains "$service_body" 'ExecStop=/usr/bin/docker compose down' "service stops compose stack"
+assert_contains "$service_body" 'WorkingDirectory=${PROJECT_ROOT}' "service runs from project root"
+assert_contains "$service_body" 'WantedBy=multi-user.target' "service is enabled at boot"
+assert_contains "$service_body" 'systemctl enable snapmulti-server.service' "service is enabled"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"

--- a/tests/test_device_smoke.sh
+++ b/tests/test_device_smoke.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE_SH="$SCRIPT_DIR/../scripts/device-smoke.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_rc() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got $actual, expected $expected)"
+        fail=$((fail + 1))
+    fi
+}
+
+MOCK_BIN="$(mktemp -d)"
+TMP_SERVER="$(mktemp -d)"
+TMP_CLIENT="$(mktemp -d)"
+trap 'rm -rf "$MOCK_BIN" "$TMP_SERVER" "$TMP_CLIENT"' EXIT
+
+touch "$TMP_SERVER/docker-compose.yml" "$TMP_CLIENT/docker-compose.yml"
+
+cat > "$MOCK_BIN/docker" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == "info" ]]; then
+    echo "${MOCK_DOCKER_DRIVER:-overlayfs}"
+    exit 0
+fi
+if [[ "$1" == "compose" ]]; then
+    shift
+    while [[ "${1:-}" == "-f" ]]; do shift 2; done
+    case "${1:-} ${2:-} ${3:-}" in
+        "config --services "*|"config --services ")
+            case "${MOCK_STACK:-server}" in
+                server) printf 'snapserver\nmpd\n' ;;
+                client) printf 'snapclient\nfb-display\n' ;;
+            esac
+            ;;
+        "config --format json")
+            case "${MOCK_STACK:-server}" in
+                server) printf '{"services":{"snapserver":{"healthcheck":{"test":["CMD","true"]}},"mpd":{"healthcheck":{"test":["CMD","true"]}}}}' ;;
+                client) printf '{"services":{"snapclient":{"healthcheck":{"test":["CMD","true"]}},"fb-display":{"healthcheck":{"test":["CMD","true"]}}}}' ;;
+            esac
+            ;;
+        "ps --status running")
+            seq 1 "${MOCK_RUNNING:-2}" | sed 's/.*/id&/'
+            ;;
+        "ps -q "*|"ps -q ")
+            case "${MOCK_STACK:-server}" in
+                server) printf 'snapserver\nmpd\n' ;;
+                client) printf 'snapclient\nfb-display\n' ;;
+            esac
+            ;;
+    esac
+    exit 0
+fi
+if [[ "$1" == "inspect" ]]; then
+    shift
+    if [[ "${1:-}" == "--format" ]]; then
+        shift 2
+    fi
+    for arg in "$@"; do
+        case "$arg" in
+            snapserver|mpd|snapclient|fb-display)
+                echo "healthy"
+                ;;
+            *)
+                echo "healthy"
+                ;;
+        esac
+    done
+    exit 0
+fi
+exit 0
+MOCK
+chmod +x "$MOCK_BIN/docker"
+
+cat > "$MOCK_BIN/systemctl" <<'MOCK'
+#!/usr/bin/env bash
+case "$1" in
+    is-enabled|is-active) exit 0 ;;
+esac
+exit 0
+MOCK
+chmod +x "$MOCK_BIN/systemctl"
+
+cat > "$MOCK_BIN/mount" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "${MOCK_OVERLAY:-0}" == "1" ]]; then
+    echo "overlayroot on / type overlay (rw,noatime)"
+else
+    echo "/dev/mmcblk0p2 on / type ext4 (rw,noatime)"
+fi
+MOCK
+chmod +x "$MOCK_BIN/mount"
+
+cat > "$MOCK_BIN/hostname" <<'MOCK'
+#!/usr/bin/env bash
+echo snapvideo
+MOCK
+chmod +x "$MOCK_BIN/hostname"
+
+cat > "$MOCK_BIN/uptime" <<'MOCK'
+#!/usr/bin/env bash
+echo "up 5 minutes"
+MOCK
+chmod +x "$MOCK_BIN/uptime"
+
+echo "Testing device-smoke.sh..."
+
+output="$(
+    PATH="$MOCK_BIN:$PATH" \
+    MOCK_OVERLAY=1 \
+    MOCK_DOCKER_DRIVER=fuse-overlayfs \
+    MOCK_STACK=server \
+    bash "$SMOKE_SH" --server --server-dir "$TMP_SERVER" 2>&1
+)"
+rc=$?
+assert_rc "$rc" "0" "server mode passes with overlayroot + fuse-overlayfs"
+assert_contains "$output" "Mode: server" "reports selected mode"
+assert_contains "$output" "Smoke check passed" "reports passing summary"
+assert_contains "$output" "server: 2/2 running, 2/2 healthy" "reports compose counts"
+
+set +e
+output="$(
+    PATH="$MOCK_BIN:$PATH" \
+    MOCK_OVERLAY=0 \
+    MOCK_DOCKER_DRIVER=fuse-overlayfs \
+    MOCK_STACK=client \
+    bash "$SMOKE_SH" --client --client-dir "$TMP_CLIENT" 2>&1
+)"
+rc=$?
+set -e
+assert_rc "$rc" "1" "client mode fails on writable root + fuse-overlayfs"
+assert_contains "$output" "writable root but Docker driver is fuse-overlayfs" "reports overlay mismatch"
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"


### PR DESCRIPTION
Closes #252 | Parent: #247 | Depends on: #251

## Summary

Make systemd the single owner of container lifecycle after firstboot completes (ADR-005).

- **deploy.sh**: create `snapmulti-server.service` with Docker readiness check (ExecStartPre backoff: 60×2s), `Restart=on-failure`, `RestartSec=10`
- **setup.sh**: harden `snapclient.service` with same readiness check, add `After=snapmulti-server.service` for both-mode ordering
- **firstboot.sh**: replace `docker compose up -d` with `systemctl start snapclient.service` ��� first boot passes through the lifecycle owner
- **Keep** `restart: unless-stopped` in docker-compose.yml (council validated)

Runtime evidence: snapvideo v0.5.2 smoke showed 7/7+3/3 healthy but `snapmulti-server.service` disabled/inactive.

## Tests included
- `test_deploy_systemd_service.sh`: verifies service file content and enablement
- `test_device_smoke.sh`: behavioral test for smoke script logic

## Test plan
- [ ] shellcheck clean
- [ ] All tests pass
- [ ] Real reboot on Pi 4: containers come up via systemd
- [ ] Both mode: server starts before client
- [ ] `device-smoke.sh --both` green after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)