### PR TITLE
arch: deduplicate readonly helpers — SSH keys + ro-mode

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1363,8 +1363,12 @@ if [[ "${ENABLE_READONLY:-false}" == "true" ]]; then
 
     # ro-mode helper + SSH key persistence (raspi-config call below has rollback)
     local _ro_mode_script=""
-    [[ -f "$COMMON_DIR/scripts/ro-mode.sh" ]] && _ro_mode_script="$COMMON_DIR/scripts/ro-mode.sh"
-    log_progress "Installing ro-mode helper + persisting SSH keys..."
+    if [[ -f "$COMMON_DIR/scripts/ro-mode.sh" ]]; then
+        _ro_mode_script="$COMMON_DIR/scripts/ro-mode.sh"
+    else
+        log_progress "WARNING: ro-mode.sh not found, helper will not be installed"
+    fi
+    log_progress "Persisting SSH host keys..."
     prepare_readonly_helpers "$_ro_mode_script"
 
     # Enable overlayfs (takes effect after reboot)

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1361,39 +1361,13 @@ if [[ "${ENABLE_READONLY:-false}" == "true" ]]; then
         log_progress "         Read-only mode may not work correctly after reboot"
     fi
 
-    # Install ro-mode helper script
-    log_progress "Installing ro-mode helper..."
-    if [[ -f "$COMMON_DIR/scripts/ro-mode.sh" ]]; then
-        install -m 755 "$COMMON_DIR/scripts/ro-mode.sh" /usr/local/bin/ro-mode
-    else
-        echo "Warning: ro-mode.sh not found, skipping helper install"
-    fi
-
-    # Persist SSH host keys so they survive read-only reboots.
-    # Without this, overlayfs generates new keys on every boot,
-    # causing SSH "REMOTE HOST IDENTIFICATION HAS CHANGED" errors.
-    log_progress "Persisting SSH host keys..."
-    if [[ -d /etc/ssh ]]; then
-        mkdir -p /etc/ssh/keys_permanent
-        cp -n /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub /etc/ssh/keys_permanent/ 2>/dev/null || true
-        # Create a service that restores keys from permanent storage on boot
-        cat > /etc/systemd/system/ssh-keys-restore.service << 'SSHEOF'
-[Unit]
-Description=Restore SSH host keys from permanent storage
-Before=ssh.service sshd.service
-ConditionPathExists=/etc/ssh/keys_permanent
-
-[Service]
-Type=oneshot
-ExecStart=/bin/bash -c 'cp /etc/ssh/keys_permanent/ssh_host_* /etc/ssh/ 2>/dev/null && chmod 600 /etc/ssh/ssh_host_*_key'
-
-[Install]
-WantedBy=multi-user.target
-SSHEOF
-        systemctl daemon-reload
-        systemctl enable ssh-keys-restore.service
-        echo "SSH host keys will persist across reboots"
-    fi
+    # Shared readonly helpers: ro-mode script + SSH key persistence
+    # Uses system-tune.sh:prepare_readonly_helpers() to avoid duplication.
+    # raspi-config call stays here (setup.sh has rollback logic).
+    local _ro_mode_script=""
+    [[ -f "$COMMON_DIR/scripts/ro-mode.sh" ]] && _ro_mode_script="$COMMON_DIR/scripts/ro-mode.sh"
+    log_progress "Installing ro-mode helper + persisting SSH keys..."
+    prepare_readonly_helpers "$_ro_mode_script"
 
     # Enable overlayfs (takes effect after reboot)
     log_progress "Enabling overlayfs..."

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1361,9 +1361,7 @@ if [[ "${ENABLE_READONLY:-false}" == "true" ]]; then
         log_progress "         Read-only mode may not work correctly after reboot"
     fi
 
-    # Shared readonly helpers: ro-mode script + SSH key persistence
-    # Uses system-tune.sh:prepare_readonly_helpers() to avoid duplication.
-    # raspi-config call stays here (setup.sh has rollback logic).
+    # ro-mode helper + SSH key persistence (raspi-config call below has rollback)
     local _ro_mode_script=""
     [[ -f "$COMMON_DIR/scripts/ro-mode.sh" ]] && _ro_mode_script="$COMMON_DIR/scripts/ro-mode.sh"
     log_progress "Installing ro-mode helper + persisting SSH keys..."

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -242,11 +242,8 @@ tune_avahi_daemon() {
 }
 
 # ── Read-only filesystem (overlayroot) ──────────────────────────
-# Configures overlayfs for SD card protection. Requires raspi-config.
-# Call from firstboot.sh/deploy.sh/setup.sh when ENABLE_READONLY=true.
-# Assumes fuse-overlayfs and Docker storage driver are already configured.
-# Install ro-mode helper and persist SSH host keys.
-# Called by both setup_readonly_fs() and setup.sh:_configure_readonly().
+
+# Install ro-mode helper and persist SSH host keys for overlayroot.
 prepare_readonly_helpers() {
     local ro_mode_script="${1:-}"
 
@@ -279,6 +276,7 @@ SSHEOF
     fi
 }
 
+# Configure overlayfs for SD card protection. Requires raspi-config.
 setup_readonly_fs() {
     local ro_mode_script="${1:-}"
 

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -245,7 +245,9 @@ tune_avahi_daemon() {
 # Configures overlayfs for SD card protection. Requires raspi-config.
 # Call from firstboot.sh/deploy.sh/setup.sh when ENABLE_READONLY=true.
 # Assumes fuse-overlayfs and Docker storage driver are already configured.
-setup_readonly_fs() {
+# Install ro-mode helper and persist SSH host keys.
+# Called by both setup_readonly_fs() and setup.sh:_configure_readonly().
+prepare_readonly_helpers() {
     local ro_mode_script="${1:-}"
 
     # Install ro-mode helper if available
@@ -275,6 +277,12 @@ SSHEOF
         systemctl enable ssh-keys-restore.service 2>/dev/null
         ok "SSH host keys persisted"
     fi
+}
+
+setup_readonly_fs() {
+    local ro_mode_script="${1:-}"
+
+    prepare_readonly_helpers "$ro_mode_script"
 
     # Enable overlayfs via raspi-config (takes effect after reboot)
     if command -v raspi-config &>/dev/null; then


### PR DESCRIPTION
Closes #253 | Parent: #247 | Depends on: #252

## Summary

Extract `prepare_readonly_helpers()` in system-tune.sh for ro-mode install and SSH key persistence. setup.sh `_configure_readonly()` now calls the shared function instead of its own copy (~18 LOC dedup).

- **system-tune.sh**: new `prepare_readonly_helpers()` — ro-mode install + SSH key persistence. `setup_readonly_fs()` calls it as wrapper (+ raspi-config)
- **setup.sh**: `_configure_readonly()` calls `prepare_readonly_helpers()`, keeps its own raspi-config call with rollback logic
- **ro-mode.sh**: unchanged (standalone script, inline `mount | grep` kept)
- Two-phase timing preserved per council validation

## Test plan
- [ ] `bash tests/test_setup_docker_driver.sh` passes
- [ ] shellcheck clean
- [ ] `device-smoke.sh --both` after reflash with ENABLE_READONLY=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)