### PR TITLE
arch: formalize device-smoke.sh as release gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **QUICKSTART.md** ([#226](https://github.com/lollonet/snapMULTI/pull/226)) — one-page quick start (60 lines); README slimmed from 245 to 72 lines
 - **ADR-005** ([#257](https://github.com/lollonet/snapMULTI/pull/257)) — architecture decision record: reflash-only, systemd lifecycle, robustness-first
 - **device-smoke.sh** ([#257](https://github.com/lollonet/snapMULTI/pull/257)) — mode-aware acceptance gate (`--server`/`--client`/`--both`): root mount, Docker driver, systemd units, compose health, recent error logs
+- **Release gate process** — every tag requires `device-smoke.sh --both` green; documented in ADR-005 and CLAUDE.md
 
 ### Removed
 - **In-place update** — `scripts/update.sh` decommissioned per ADR-005. Reflash is the only supported update method.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,9 @@ ARM-only audio source using `edgecrush3r/tidal-connect` as base image (Raspbian 
 - **Multi-arch**: linux/amd64 (studio) + linux/arm64 (raspy), native builds on self-hosted runners
 - **Config paths**: all config in `config/`, all scripts in `scripts/`, shared libs in `scripts/common/`
 - **Deployment**: tag push (`v*`) triggers build → manifest → deploy
+- **Release gate**: every tag requires `device-smoke.sh --both` green on real Pi (ADR-005)
 - **Git workflow**: always use PRs, never push directly to main unless explicitly requested
 - **Audio format**: 44100:16:2 (44.1kHz, 16-bit, stereo) across all sources
-- **CI gates**: shellcheck on all `scripts/**/*.sh`, docker-compose syntax validation
+- **CI gates**: shellcheck on all `scripts/**/*.sh`, docker-compose syntax, server+client bash tests
 - **Debian support**: bookworm (primary) + trixie (Docker repo falls back to bookworm)
 - **Console display**: ASCII-only for `/dev/tty1` output — PSF fonts lack Unicode symbols (✓▶○⠋). Use `[x]`/`[>]`/`[ ]` and `|/-\` spinner

--- a/docs/adr/ADR-005.reflash-systemd-robustness.md
+++ b/docs/adr/ADR-005.reflash-systemd-robustness.md
@@ -42,3 +42,20 @@ Architectural changes are gated by `device-smoke.sh --both` on a real Pi, not ju
 - Each concern gets one owner (see #247 roadmap)
 - `device-smoke.sh` becomes the acceptance gate for architectural PRs
 - Design decisions favor reliability on Pi 4/Zero over code elegance
+
+## Release Gate
+
+Every tagged release requires `device-smoke.sh` validation:
+
+| Gate level | Requirement | When |
+|-----------|-------------|------|
+| **Minimum** (every tag) | `device-smoke.sh --both` green on real Pi | Always |
+| **Strong** (milestone releases) | Additionally `--server` + `--client` on dedicated devices | v0.x.0 releases |
+
+Checklist before tagging:
+- [ ] Root mount coherent (ext4 writable or overlay readonly)
+- [ ] Docker storage driver matches filesystem (overlay2 or fuse-overlayfs)
+- [ ] All systemd units enabled and active
+- [ ] Docker Compose stack running and healthy
+- [ ] Reboot green (containers come back via systemd)
+- [ ] No errors in recent systemd logs


### PR DESCRIPTION
Closes #256 | Parent: #247 | Depends on: #252, #253

## Summary

Formalize device-smoke.sh as the stable release quality gate:
- **Every tag** (minimum): `device-smoke.sh --both` green
- **Milestone releases**: additionally `--server` + `--client` on dedicated devices

Documented in ADR-005 (release gate section + checklist) and CLAUDE.md conventions.

## Test plan
- [ ] ADR-005 checklist reviewed
- [ ] CLAUDE.md references correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)