### PR TITLE
fix: restore daemon.json creation + boot-time driver reconciliation

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1152,12 +1152,11 @@ if [[ "${ENABLE_READONLY:-false}" == "true" ]]; then
         return 0
     fi
 
-    # Do NOT write fuse-overlayfs to daemon.json here.
-    # boot-tune.sh reconciles the Docker driver at boot time based on actual
-    # root filesystem state (overlayroot active → fuse-overlayfs, writable → overlay2).
-    # Writing it at install time caused Docker to use the wrong driver when
-    # overlayroot failed to activate on reboot.
-    log_progress "Docker driver will be set at boot time based on filesystem state"
+    # Create daemon.json with live-restore but WITHOUT fuse-overlayfs.
+    # The boot-time reconciliation service (docker-driver-reconcile.sh) sets
+    # the storage driver based on actual root mount state, not install intent.
+    log_progress "Ensuring daemon.json exists (driver set at boot time)..."
+    tune_docker_daemon --live-restore
 
     # ro-mode helper + SSH key persistence (raspi-config call below has rollback)
     local _ro_mode_script=""

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1183,9 +1183,7 @@ SYSDEOF
     log_progress "Enabling overlayfs..."
     if ! raspi-config nonint do_overlayfs 0; then
         log_progress "WARNING: raspi-config failed to enable overlayfs"
-        log_progress "         Reverting Docker config and systemd workaround"
-        # Roll back: remove fuse-overlayfs from daemon.json and systemd override
-        tune_docker_daemon --live-restore
+        log_progress "         Reverting systemd workaround"
         rm -f /etc/systemd/system.conf.d/overlayfs-workaround.conf
         ENABLE_READONLY=false
         echo ""

--- a/scripts/docker-driver-reconcile.sh
+++ b/scripts/docker-driver-reconcile.sh
@@ -15,6 +15,8 @@ path = '/etc/docker/daemon.json'
 cfg = json.load(open(path)) if os.path.exists(path) else {}
 cfg['storage-driver'] = 'fuse-overlayfs'
 cfg.setdefault('live-restore', True)
+cfg.setdefault('log-driver', 'json-file')
+cfg.setdefault('log-opts', {'max-size': '10m', 'max-file': '3'})
 with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
 " 2>/dev/null && logger -t docker-driver "Set fuse-overlayfs (overlayroot active)"
     fi

--- a/scripts/docker-driver-reconcile.sh
+++ b/scripts/docker-driver-reconcile.sh
@@ -3,22 +3,24 @@
 # Runs Before=docker.service so daemon.json is correct before Docker starts.
 set -euo pipefail
 
-[[ -f /etc/docker/daemon.json ]] || exit 0
 command -v python3 &>/dev/null || exit 0
+mkdir -p /etc/docker
 
 if mount 2>/dev/null | grep -q ' on / type overlay'; then
     # Overlayroot active: Docker needs fuse-overlayfs
     if ! grep -q '"fuse-overlayfs"' /etc/docker/daemon.json 2>/dev/null; then
         python3 -c "
-import json
-with open('/etc/docker/daemon.json') as f: cfg = json.load(f)
+import json, os
+path = '/etc/docker/daemon.json'
+cfg = json.load(open(path)) if os.path.exists(path) else {}
 cfg['storage-driver'] = 'fuse-overlayfs'
-with open('/etc/docker/daemon.json', 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
+cfg.setdefault('live-restore', True)
+with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
 " 2>/dev/null && logger -t docker-driver "Set fuse-overlayfs (overlayroot active)"
     fi
 else
     # Writable root: remove forced storage-driver (Docker defaults to overlay2)
-    if grep -q '"storage-driver"' /etc/docker/daemon.json 2>/dev/null; then
+    if [[ -f /etc/docker/daemon.json ]] && grep -q '"storage-driver"' /etc/docker/daemon.json 2>/dev/null; then
         python3 -c "
 import json
 with open('/etc/docker/daemon.json') as f: cfg = json.load(f)

--- a/scripts/docker-driver-reconcile.sh
+++ b/scripts/docker-driver-reconcile.sh
@@ -12,7 +12,9 @@ if mount 2>/dev/null | grep -q ' on / type overlay'; then
         python3 -c "
 import json, os
 path = '/etc/docker/daemon.json'
-cfg = json.load(open(path)) if os.path.exists(path) else {}
+cfg = {}
+if os.path.exists(path):
+    with open(path) as f: cfg = json.load(f)
 cfg['storage-driver'] = 'fuse-overlayfs'
 cfg.setdefault('live-restore', True)
 cfg.setdefault('log-driver', 'json-file')

--- a/tests/test_setup_docker_driver.sh
+++ b/tests/test_setup_docker_driver.sh
@@ -42,20 +42,13 @@ assert_contains "$setup_docker_body" ' on / type overlay' "setup_docker detects 
 setup_docker_code=$(echo "$setup_docker_body" | grep -v '^\s*#')
 assert_not_contains "$setup_docker_code" 'ENABLE_READONLY' "setup_docker code does not use ENABLE_READONLY flag"
 
-# _configure_readonly() should write config but not wipe Docker
-assert_contains "$readonly_body" 'tune_docker_daemon --live-restore --fuse-overlayfs' "readonly config writes fuse-overlayfs to daemon.json"
+# _configure_readonly() creates daemon.json but does NOT force fuse-overlayfs
+# (boot-time reconciliation handles the driver based on actual mount state)
+assert_contains "$readonly_body" 'tune_docker_daemon --live-restore' "readonly config creates daemon.json with live-restore"
+assert_not_contains "$readonly_body" '--fuse-overlayfs' "readonly config does NOT force fuse-overlayfs at install time"
 assert_not_contains "$readonly_body" 'rm -rf /var/lib/docker' "readonly config does not wipe Docker storage"
 assert_contains "$readonly_body" 'fuse-overlayfs --version' "readonly config verifies fuse-overlayfs binary"
-assert_contains "$readonly_body" 'activates after reboot' "readonly config defers driver switch to reboot"
-# Rollback needs a second --live-restore call (the first is --live-restore --fuse-overlayfs)
-tune_lr_count=$(grep -cF 'tune_docker_daemon --live-restore' <<<"$readonly_body" || true)
-if [[ "$tune_lr_count" -ge 2 ]]; then
-    echo "  PASS: readonly config rolls back to overlay2 on raspi-config failure"
-    pass=$((pass + 1))
-else
-    echo "  FAIL: readonly config rollback call missing (only $tune_lr_count occurrence(s))"
-    fail=$((fail + 1))
-fi
+assert_contains "$readonly_body" 'boot time' "readonly config defers driver to boot-time reconciliation"
 assert_contains "$readonly_body" 'FAILED' "readonly config shows failure message when overlayfs fails"
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes two regressions from the boot-time driver reconciliation commits:

1. **P1**: `_configure_readonly()` no longer created daemon.json at all — standalone client installs with `ENABLE_READONLY=true` would boot without daemon.json, and the reconciler would skip (file missing). Now calls `tune_docker_daemon --live-restore` (without `--fuse-overlayfs`) to ensure the file exists.

2. **docker-driver-reconcile.sh**: handles missing daemon.json on overlayroot boot — creates it with `fuse-overlayfs` + `live-restore` if needed.

3. **Test updated**: new contract — readonly config creates daemon.json but does NOT force fuse-overlayfs at install time.

Boot-tune service ordering (P2) was already correct in the split commit (`After=docker.service`).

## Test plan
- [ ] `bash tests/test_setup_docker_driver.sh` passes
- [ ] shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)