### PR TITLE
fix: align verify lists and copy commands with deployed files

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -309,6 +309,9 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
         cp "$SNAP_BOOT/server/deploy.sh" "$SERVER_DIR/scripts/"
         cp "$SNAP_BOOT/server/boot-tune.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/status.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
+        cp "$SNAP_BOOT/server/device-smoke.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
+        cp "$SNAP_BOOT/server/docker-driver-reconcile.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
+        cp "$SNAP_BOOT/server/ro-mode.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/.version" "$SERVER_DIR/" 2>/dev/null || true
         if [[ -f "$SNAP_BOOT/server/mpd/data/mpd.db" ]]; then
             mkdir -p "$SERVER_DIR/mpd/data"

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -650,6 +650,7 @@ done
 case "$INSTALL_TYPE" in
     server|both)
         for f in server/docker-compose.yml server/deploy.sh server/boot-tune.sh \
+                 server/device-smoke.sh server/docker-driver-reconcile.sh \
                  server/config/snapserver.conf server/config/mpd.conf \
                  server/config/shairport-sync.conf server/config/go-librespot.yml \
                  server/config/tidal-asound.conf server/ro-mode.sh; do
@@ -674,10 +675,15 @@ case "$INSTALL_TYPE" in
         for f in client/docker-compose.yml client/scripts/setup.sh \
                  client/scripts/audio-hat-detect.sh \
                  client/scripts/boot-tune.sh client/scripts/ro-mode.sh \
+                 client/scripts/docker-driver-reconcile.sh \
                  client/scripts/discover-server.sh \
                  client/scripts/display.sh client/scripts/display-detect.sh \
                  client/scripts/common/install-deps.sh \
                  client/scripts/common/install-docker.sh \
+                 client/scripts/common/system-tune.sh \
+                 client/scripts/common/unified-log.sh \
+                 client/scripts/common/logging.sh \
+                 client/scripts/common/sanitize.sh \
                  client/snapclient.conf; do
             if [[ -f "$DEST/$f" ]]; then
                 echo "  [OK] snapmulti/$f"


### PR DESCRIPTION
## Summary
- **firstboot.sh**: Add missing `cp` commands for `device-smoke.sh`, `docker-driver-reconcile.sh`, `ro-mode.sh` (server install)
- **prepare-sd.sh**: Add those same files to server verify list, plus 5 missing client files (`docker-driver-reconcile.sh`, `system-tune.sh`, `unified-log.sh`, `logging.sh`, `sanitize.sh`)

Previously the verify step would silently skip checking files that were actually copied, or firstboot would miss copying files that prepare-sd verified.

## Test plan
- [ ] `prepare-sd.sh` verify shows `[OK]` for all listed files (server, client, both)
- [ ] `firstboot.sh` copies all 3 new server scripts to `/opt/snapmulti/scripts/`
- [ ] Existing installs unaffected (all new copies use `2>/dev/null || true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)