### PR TITLE
fix: pre-configure fuse-overlayfs before image pulls on readonly installs

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1148,11 +1148,15 @@ if [[ "${ENABLE_READONLY:-false}" == "true" ]]; then
         return 0
     fi
 
-    # Create daemon.json with live-restore but WITHOUT fuse-overlayfs.
-    # The boot-time reconciliation service (docker-driver-reconcile.sh) sets
-    # the storage driver based on actual root mount state, not install intent.
-    log_progress "Ensuring daemon.json exists (driver set at boot time)..."
-    tune_docker_daemon --live-restore
+    # Ensure daemon.json exists. Preserve fuse-overlayfs if already configured
+    # (firstboot pre-sets it for read-only installs so images land with the
+    # correct driver). docker-driver-reconcile.sh remains as boot-time safety net.
+    log_progress "Ensuring daemon.json exists..."
+    local _tune_args=(--live-restore)
+    if docker info --format '{{.Driver}}' 2>/dev/null | grep -q fuse-overlayfs; then
+        _tune_args+=(--fuse-overlayfs)
+    fi
+    tune_docker_daemon "${_tune_args[@]}"
 
     # ro-mode helper + SSH key persistence (raspi-config call below has rollback)
     local _ro_mode_script=""

--- a/scripts/boot-tune.sh
+++ b/scripts/boot-tune.sh
@@ -66,9 +66,20 @@ if mount | grep -q ' on / type overlay'; then
         # Floor at 256MB, cap at 2048MB
         [ "$target_mb" -lt 256 ] && target_mb=256
         [ "$target_mb" -gt 2048 ] && target_mb=2048
-        # Find the tmpfs backing the overlay upper dir (not / which is overlayfs)
-        tmpfs_mp=$(awk '$3 == "tmpfs" {print $2}' /proc/mounts | grep -E '^/overlay' | head -1)
-        [ -z "$tmpfs_mp" ] && tmpfs_mp="/overlay"  # Raspberry Pi OS default
+        # Find the tmpfs backing the overlay upper dir.
+        # Raspberry Pi OS mounts it at /media/root-rw (not /overlay).
+        # Extract upperdir from the overlay mount, then walk up to the tmpfs.
+        tmpfs_mp=""
+        if command -v findmnt &>/dev/null; then
+            # upperdir=/media/root-rw/overlay → parent tmpfs at /media/root-rw
+            _upper=$(findmnt -n -o OPTIONS / 2>/dev/null | sed -n 's/.*upperdir=\([^,]*\).*/\1/p') || true
+            if [ -n "${_upper:-}" ]; then
+                # The tmpfs is the parent of the upperdir (e.g. /media/root-rw)
+                tmpfs_mp=$(findmnt -n -o TARGET -T "$(dirname "$_upper")" 2>/dev/null) || true
+            fi
+        fi
+        [ -z "$tmpfs_mp" ] && tmpfs_mp=$(awk '$3 == "tmpfs" && $2 ~ /root-rw|overlay/ {print $2; exit}' /proc/mounts)
+        [ -z "$tmpfs_mp" ] && tmpfs_mp="/media/root-rw"  # last resort default
         # Remount with explicit size (idempotent — safe to re-run)
         if mount -o "remount,size=${target_mb}M" "$tmpfs_mp" 2>/dev/null; then
             logger -t boot-tune "Overlayroot tmpfs sized to ${target_mb}MB at $tmpfs_mp (RAM: ${total_mb}MB)"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -452,10 +452,14 @@ install_docker() {
         info "Added $real_user to docker group (re-login to take effect)"
     fi
 
-    # Generic server deploy keeps Docker's default storage driver.
-    # fuse-overlayfs is only required for overlayroot/read-only installs,
-    # which are handled in the dedicated firstboot/client flows.
-    tune_docker_daemon --live-restore
+    # Preserve fuse-overlayfs if already configured (firstboot pre-sets it
+    # for read-only installs so images land with the correct driver).
+    # Otherwise keep Docker's default overlay2.
+    local _tune_args=(--live-restore)
+    if docker info --format '{{.Driver}}' 2>/dev/null | grep -q fuse-overlayfs; then
+        _tune_args+=(--fuse-overlayfs)
+    fi
+    tune_docker_daemon "${_tune_args[@]}"
 
     # Enable and start Docker
     systemctl enable docker >/dev/null 2>&1 || true

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -379,6 +379,48 @@ else
 fi
 milestone "$CURRENT_STEP" "Docker installed" 2 2>/dev/null || true
 
+# ── Pre-configure fuse-overlayfs when readonly is planned ─────────
+# On first boot root is still writable ext4, so setup-docker.sh keeps
+# Docker's default overlay2 driver. But when ENABLE_READONLY=true,
+# overlayroot will activate after reboot — Docker must use fuse-overlayfs.
+#
+# If we defer the switch to boot-time (docker-driver-reconcile.sh),
+# overlay2 images from the first boot become invisible to Docker under
+# fuse-overlayfs. Docker re-pulls ~1.5 GB into the tmpfs upper layer,
+# filling it immediately and leaving no room for client images.
+#
+# Fix: switch to fuse-overlayfs NOW, before any images are pulled.
+# Images land on the writable SD card with the correct driver and
+# survive the overlayroot transition in the read-only lower layer.
+# docker-driver-reconcile.sh remains as a safety net for edge cases
+# (e.g. overlayroot fails to activate → reconciler reverts to overlay2).
+if [[ "${ENABLE_READONLY}" == "true" ]]; then
+    current_driver=$(docker info --format '{{.Driver}}' 2>/dev/null || echo "unknown")
+    if [[ "$current_driver" != "fuse-overlayfs" ]]; then
+        log_info "Pre-configuring fuse-overlayfs for read-only mode..."
+        if ! fuse-overlayfs --version &>/dev/null; then
+            if declare -F _wait_for_apt_lock &>/dev/null; then
+                _wait_for_apt_lock
+            fi
+            apt-get install -y fuse-overlayfs >> "$UNIFIED_LOG" 2>&1 || true
+        fi
+        if fuse-overlayfs --version &>/dev/null; then
+            # Source system-tune for tune_docker_daemon if not already loaded
+            if ! declare -F tune_docker_daemon &>/dev/null; then
+                # shellcheck source=common/system-tune.sh
+                source "$COMMON/system-tune.sh"
+            fi
+            tune_docker_daemon --live-restore --fuse-overlayfs
+            systemctl stop docker
+            rm -rf /var/lib/docker/*
+            systemctl start docker
+            log_info "Docker switched to fuse-overlayfs (images will persist through overlayroot)"
+        else
+            log_warn "fuse-overlayfs not available — images will need re-pull after reboot"
+        fi
+    fi
+fi
+
 # ══════════════════════════════════════════════════════════════════
 # SERVER INSTALL
 # ══════════════════════════════════════════════════════════════════

--- a/tests/test_deploy_docker_gating.sh
+++ b/tests/test_deploy_docker_gating.sh
@@ -33,8 +33,10 @@ install_docker_body="$(sed -n '/^install_docker()/,/^}/p' "$DEPLOY_SH")"
 
 echo "Testing deploy.sh Docker driver gating..."
 
-assert_contains "$install_docker_body" "tune_docker_daemon --live-restore" "deploy configures live-restore"
-assert_not_contains "$install_docker_body" "--fuse-overlayfs" "deploy does not force fuse-overlayfs"
+assert_contains "$install_docker_body" "tune_docker_daemon" "deploy configures Docker daemon"
+assert_contains "$install_docker_body" "--live-restore" "deploy sets live-restore"
+# deploy preserves fuse-overlayfs if already active (set by firstboot), but does not force it unconditionally
+assert_contains "$install_docker_body" "fuse-overlayfs" "deploy preserves fuse-overlayfs when already active"
 assert_not_contains "$install_docker_body" "apt-get install -y fuse-overlayfs" "deploy does not install fuse-overlayfs eagerly"
 
 echo ""

--- a/tests/test_setup_docker_driver.sh
+++ b/tests/test_setup_docker_driver.sh
@@ -42,13 +42,13 @@ assert_contains "$setup_docker_body" ' on / type overlay' "setup_docker detects 
 setup_docker_code=$(echo "$setup_docker_body" | grep -v '^\s*#')
 assert_not_contains "$setup_docker_code" 'ENABLE_READONLY' "setup_docker code does not use ENABLE_READONLY flag"
 
-# _configure_readonly() creates daemon.json but does NOT force fuse-overlayfs
-# (boot-time reconciliation handles the driver based on actual mount state)
-assert_contains "$readonly_body" 'tune_docker_daemon --live-restore' "readonly config creates daemon.json with live-restore"
-assert_not_contains "$readonly_body" '--fuse-overlayfs' "readonly config does NOT force fuse-overlayfs at install time"
+# _configure_readonly() creates daemon.json; preserves fuse-overlayfs if already
+# active (firstboot pre-configures it), docker-driver-reconcile.sh is safety net
+assert_contains "$readonly_body" 'tune_docker_daemon' "readonly config creates daemon.json"
+assert_contains "$readonly_body" '--live-restore' "readonly config sets live-restore"
+assert_contains "$readonly_body" 'fuse-overlayfs' "readonly config handles fuse-overlayfs detection"
 assert_not_contains "$readonly_body" 'rm -rf /var/lib/docker' "readonly config does not wipe Docker storage"
 assert_contains "$readonly_body" 'fuse-overlayfs --version' "readonly config verifies fuse-overlayfs binary"
-assert_contains "$readonly_body" 'boot time' "readonly config defers driver to boot-time reconciliation"
 assert_contains "$readonly_body" 'FAILED' "readonly config shows failure message when overlayfs fails"
 
 echo ""


### PR DESCRIPTION
## Summary

- **firstboot.sh**: Switch Docker to fuse-overlayfs before any image pulls when `ENABLE_READONLY=true`, so images are stored with the correct driver on the SD card and survive the overlayroot transition
- **deploy.sh + setup.sh**: Preserve fuse-overlayfs if already configured (was being reverted by `tune_docker_daemon --live-restore` which pops `storage-driver`)
- **boot-tune.sh**: Fix tmpfs mount point detection — `grep '^/overlay'` never matched Raspberry Pi OS mount at `/media/root-rw`, killing the entire boot-tune script silently

### Root cause

On `both` mode with readonly: first boot pulls images with overlay2 (writable ext4). After reboot, overlayroot activates, `docker-driver-reconcile.sh` switches to fuse-overlayfs — Docker can't see overlay2 images, re-pulls 1.5G into tmpfs, fills to 95%, client images fail with "no space left on device".

### Design context

PR #245 (`4bbdd20`) deliberately gated fuse-overlayfs on actual mount state (not `ENABLE_READONLY`) to avoid 20-40% FUSE IO overhead on writable systems. That logic remains correct for `setup-docker.sh`. This PR adds a targeted pre-configuration step in `firstboot.sh` only — it's not "intent-based in general", it's "preparing the next boot mode". `docker-driver-reconcile.sh` stays as boot-time safety net.

## Test plan

- [ ] 17/17 Docker tests pass locally (deploy gating, setup driver, daemon.json mutation)
- [ ] shellcheck clean (all 6 modified files)
- [ ] Reflash `both` mode on Pi → verify after reboot:
  - overlayroot active
  - Docker driver=fuse-overlayfs
  - no server image re-pull (images in lower layer)
  - client containers start
  - tmpfs usage < 50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)