### PR TITLE
fix: reset SECONDS after NTP sync to avoid corrupted install time

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -291,6 +291,10 @@ start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(
 # shellcheck source=common/wait-network.sh
 source "$COMMON/wait-network.sh"
 wait_for_network
+# Reset SECONDS after NTP sync — Bash SECONDS uses wall clock (not monotonic),
+# so an NTP time jump (Pi boots at epoch 0, sync to 2026) corrupts the counter.
+# Installation time is measured from here, excluding network wait.
+SECONDS=0
 milestone "$CURRENT_STEP" "Network ready" 2 2>/dev/null || true
 
 # ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Reset `SECONDS=0` in `firstboot.sh` immediately after `wait_for_network` returns

### Problem

Bash `SECONDS` uses wall clock (`gettimeofday`), not `CLOCK_MONOTONIC`. Pi without RTC battery boots at epoch 0 (Jan 1970). NTP sync in `wait_for_network` jumps the clock forward ~56 years. `SECONDS` then reports millions of minutes as install duration.

### Fix

`SECONDS=0` after NTP sync. Install time measures from network-ready to completion — excludes network wait (not useful install metric) and avoids the NTP time jump corruption.

## Test plan

- [ ] Shellcheck clean
- [ ] Reflash Pi — verify install time shows reasonable value (e.g. `8m30s` not `29630000m`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)