### PR TITLE
fix: cap TUI log area to 8 lines to prevent header scrolloff

### DIFF
--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -138,6 +138,7 @@ render_progress() {
     local fixed_rows=$(( total + 8 ))
     local log_rows=$(( _tty_rows - fixed_rows ))
     (( log_rows < 4 )) && log_rows=4
+    (( log_rows > 8 )) && log_rows=8
 
     # Get last N lines of log for output area
     local log_lines=""


### PR DESCRIPTION
## Summary

- Cap `log_rows` to max 8 in `progress.sh` `render_progress()`

### Problem

On 800x600 framebuffer (37 rows) with 8 install steps, the log area expanded to 21 lines. The header, progress bar, and step checklist were pushed to a small portion at the top, and only the last lines before "elapsed" were visible.

### Fix

One line: `(( log_rows > 8 )) && log_rows=8`. The file header already documented "last 8 lines" as the intended design — the cap was simply missing.

## Test plan

- [ ] Reflash both mode — verify header, progress bar, and all 8 steps visible with log area below

🤖 Generated with [Claude Code](https://claude.com/claude-code)