### PR TITLE
fix: floor MPD verify timeout at 120s during firstboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **MPD verify timeout too tight during firstboot** — `deploy.sh verify_services` previously gave up after 60s when `MPD_START_PERIOD=30s` (local mounts), but Pi 4 2GB during firstboot needs 90-120s for MPD's listener bind due to cold caches and post-pull I/O contention. Floor verify timeout at 120s, decoupled from MPD's healthcheck `start_period` (which is for Docker, not deploy). Network mounts (NFS/SMB) still get the extended 300s+ window
 - **I2C HAT detection false positive on bare Pi 4/5** ([#276](https://github.com/lollonet/snapMULTI/pull/276)) — scan restricted to bus 1 (GPIO header); HDMI internal buses (20/21 on Pi 4, 11/12 on Pi 5) had devices at PCM5122 addresses causing wrong HiFiBerry detection, ALSA crash, and install failure
 
 ## [0.6.3] — 2026-04-24

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -809,15 +809,20 @@ start_services() {
 verify_services() {
     step "Verifying services"
 
-    # Use MPD_START_PERIOD from .env (default 30s) to set verification timeout.
-    # NFS mounts may need 300s for MPD to become healthy.
+    # Verify timeout is decoupled from MPD_START_PERIOD: the healthcheck
+    # (TCP ping on 6600) does not wait for library scan, but Pi 4/Zero during
+    # firstboot has cold caches + post-pull I/O contention that can delay MPD's
+    # listener bind beyond 60s. Floor at 120s for local mounts; honor extended
+    # MPD_START_PERIOD for network mounts (NFS/SMB).
     local start_period
     start_period=$(grep '^MPD_START_PERIOD=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d 's')
     start_period=${start_period:-30}
     local wait_seconds=15
-    local max_attempts=$(( (start_period / wait_seconds) + 2 ))
+    local floor_seconds=120
+    local effective=$(( start_period > floor_seconds ? start_period : floor_seconds ))
+    local max_attempts=$(( (effective / wait_seconds) + 2 ))
 
-    info "Checking services (up to ${start_period}s, ${wait_seconds}s interval)..."
+    info "Checking services (up to ${effective}s, ${wait_seconds}s interval)..."
 
     # shellcheck source=common/verify-compose.sh
     source "$SCRIPT_DIR/common/verify-compose.sh"


### PR DESCRIPTION
## Summary

- `deploy.sh verify_services` derived its timeout from `MPD_START_PERIOD` (default 30s for local mounts), capping verify at 60s — too tight for Pi 4/Zero during firstboot
- Floor verify timeout at 120s, decoupled from Docker's `start_period`
- Network mounts (NFS/SMB) still get the extended 300s+ window

## Why

The MPD healthcheck (TCP ping on 6600) does not wait for library scan — MPD answers `OK` as soon as the listener binds. But during firstboot on Pi 4 2GB, cold filesystem caches + post-pull I/O contention can delay that bind beyond 60s.

When verify fails, `firstboot.sh:485-490` exits — and on `--both` installs that means the client setup block (line 510+) is never reached. moniaserver hit exactly this on 2026-04-27: server containers came up healthy after install, but `firstboot.sh` had already exited, so `/opt/snapclient/.env`, `snapclient.service`, and `snapclient-discover.timer` were never created.

Verify timeout and Docker's `start_period` are different concerns:
- **`start_period`** (Docker): grace window where failed healthchecks don't count
- **verify timeout** (deploy.sh): how long to wait before declaring install failed

This PR decouples them: floor at 120s for local mounts (covers firstboot I/O contention without dragging install duration), honor the full 300s+ window for network mounts.

## Test plan

- [ ] Reflash moniaserver with `--both` from main + this branch, confirm both server and client install completes
- [ ] Verify existing NFS install on snapvideo still works (300s path)
- [ ] Smoke test on raspy (amd64, faster I/O) — 120s floor should be ample headroom
- [ ] Related issue #278 (db backup leak across install types) tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)