### PR TITLE
fix: bump verify floor to 180s and gate MPD db restore on network source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Consolidated apt operations during firstboot** — Docker apt repo now added before `install-deps.sh`'s `apt-get update`, so a single update covers Debian + Docker sources. `fuse-overlayfs` moved into `install-deps.sh` (gated on `ENABLE_READONLY=true`). Result: 2 `apt-get update` → 1, 3 `apt-get install` → 2. Saves ~15s on Pi 4 firstboot. Failure isolation preserved (Debian and Docker installs remain separate transactions)
+- **MPD database backup gated on network source** — `prepare-sd.sh` and `firstboot.sh` now restore `mpd/data/mpd.db` only when `MUSIC_SOURCE=nfs` or `smb`. For local USB/disk sources the db is skipped: scan is fast on local storage, and the db's path pointers may not match the new host's library (see [#278](https://github.com/lollonet/snapMULTI/issues/278))
 
 ### Fixed
+- **MPD verify timeout still too tight on Pi 4 2GB** — bumped `verify_services` floor from 120s to 180s. Observed on moniaserver `--both` install: MPD needed 130-150s for listener bind during firstboot (cold caches + image pull I/O contention). Network mounts (NFS/SMB) honor extended `MPD_START_PERIOD` as before; floor only affects local mounts where `MPD_START_PERIOD=30s` default
 - **MPD verify timeout too tight during firstboot** — `deploy.sh verify_services` previously gave up after 60s when `MPD_START_PERIOD=30s` (local mounts), but Pi 4 2GB during firstboot needs 90-120s for MPD's listener bind due to cold caches and post-pull I/O contention. Floor verify timeout at 120s, decoupled from MPD's healthcheck `start_period` (which is for Docker, not deploy). Network mounts (NFS/SMB) still get the extended 300s+ window
 - **I2C HAT detection false positive on bare Pi 4/5** ([#276](https://github.com/lollonet/snapMULTI/pull/276)) — scan restricted to bus 1 (GPIO header); HDMI internal buses (20/21 on Pi 4, 11/12 on Pi 5) had devices at PCM5122 addresses causing wrong HiFiBerry detection, ALSA crash, and install failure
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -812,13 +812,14 @@ verify_services() {
     # Verify timeout is decoupled from MPD_START_PERIOD: the healthcheck
     # (TCP ping on 6600) does not wait for library scan, but Pi 4/Zero during
     # firstboot has cold caches + post-pull I/O contention that can delay MPD's
-    # listener bind beyond 60s. Floor at 120s for local mounts; honor extended
+    # listener bind beyond 120s (observed on moniaserver Pi 4 2GB --both:
+    # 130-150s needed). Floor at 180s for local mounts; honor extended
     # MPD_START_PERIOD for network mounts (NFS/SMB).
     local start_period
     start_period=$(grep '^MPD_START_PERIOD=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d 's')
     start_period=${start_period:-30}
     local wait_seconds=15
-    local floor_seconds=120
+    local floor_seconds=180
     local effective=$(( start_period > floor_seconds ? start_period : floor_seconds ))
     local max_attempts=$(( (effective / wait_seconds) + 2 ))
 

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -317,10 +317,22 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
         cp "$SNAP_BOOT/server/docker-driver-reconcile.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/ro-mode.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/.version" "$SERVER_DIR/" 2>/dev/null || true
+        # Restore the MPD database backup only when the music source is on a
+        # network mount (NFS/SMB) where a full rescan would take hours.
+        # For local sources (USB/local disk) the db may be stale or contain
+        # path pointers from a different host's library — skip and let MPD
+        # build a fresh db on first scan (fast on local storage). See #278.
         if [[ -f "$SNAP_BOOT/server/mpd/data/mpd.db" ]]; then
-            mkdir -p "$SERVER_DIR/mpd/data"
-            cp "$SNAP_BOOT/server/mpd/data/mpd.db" "$SERVER_DIR/mpd/data/"
-            log_info "Restored MPD database backup"
+            case "${MUSIC_SOURCE:-}" in
+                nfs|smb)
+                    mkdir -p "$SERVER_DIR/mpd/data"
+                    cp "$SNAP_BOOT/server/mpd/data/mpd.db" "$SERVER_DIR/mpd/data/"
+                    log_info "Restored MPD database backup ($MUSIC_SOURCE source)"
+                    ;;
+                *)
+                    log_info "Skipping MPD db restore (source=${MUSIC_SOURCE:-unset}, not network)"
+                    ;;
+            esac
         fi
     fi
     cp -r "$SNAP_BOOT/common" "$SERVER_DIR/scripts/" 2>/dev/null || true

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -404,13 +404,19 @@ function Copy-ServerFiles {
         Copy-Item $roMode -Destination $serverDest
     }
 
-    # Optional: pre-built MPD database (avoids full NFS rescan on deploy)
+    # Optional: pre-built MPD database. Only ship it when the target's music
+    # source is a network mount — for local USB/disk the db's path pointers
+    # likely don't match the new host's library. See #278.
     $mpdDb = Join-Path $ProjectDir 'mpd\data\mpd.db'
     if (Test-Path $mpdDb) {
-        $mpdDataDest = Join-Path $serverDest 'mpd\data'
-        New-Item -ItemType Directory -Path $mpdDataDest -Force | Out-Null
-        Copy-Item $mpdDb -Destination $mpdDataDest
-        Write-Host '  Including pre-built MPD database (fast incremental scan)'
+        if ($MusicSource -eq 'nfs' -or $MusicSource -eq 'smb') {
+            $mpdDataDest = Join-Path $serverDest 'mpd\data'
+            New-Item -ItemType Directory -Path $mpdDataDest -Force | Out-Null
+            Copy-Item $mpdDb -Destination $mpdDataDest
+            Write-Host "  Including pre-built MPD database (fast incremental scan, $MusicSource source)"
+        } else {
+            Write-Host "  Skipping MPD db copy (source=$MusicSource, fresh scan on first boot)"
+        }
     }
 }
 

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -340,11 +340,20 @@ copy_server_files() {
     cp "$PROJECT_DIR/docker-compose.yml" "$dest/"
     cp "$PROJECT_DIR/.env.example" "$dest/" 2>/dev/null || true
 
-    # Optional: pre-built MPD database (avoids full NFS rescan on deploy)
+    # Optional: pre-built MPD database. Only ship it when the target's music
+    # source is a network mount — for local USB/disk the db's path pointers
+    # likely don't match the new host's library. See #278.
     if [[ -f "$PROJECT_DIR/mpd/data/mpd.db" ]]; then
-        mkdir -p "$dest/mpd/data"
-        cp "$PROJECT_DIR/mpd/data/mpd.db" "$dest/mpd/data/"
-        echo "  Including pre-built MPD database (fast incremental scan)"
+        case "${MUSIC_SOURCE:-}" in
+            nfs|smb)
+                mkdir -p "$dest/mpd/data"
+                cp "$PROJECT_DIR/mpd/data/mpd.db" "$dest/mpd/data/"
+                echo "  Including pre-built MPD database (fast incremental scan, $MUSIC_SOURCE source)"
+                ;;
+            *)
+                echo "  Skipping MPD db copy (source=${MUSIC_SOURCE:-unset}, fresh scan on first boot)"
+                ;;
+        esac
     fi
 }
 


### PR DESCRIPTION
## Summary

Two fixes uncovered while monitoring moniaserver `--both` install on 2026-04-27:

1. **Verify floor 120s → 180s** — PR #279's 120s floor was insufficient on Pi 4 2GB during firstboot (MPD needed 130-150s for listener bind)
2. **MPD db restore gated on network MUSIC_SOURCE** — closes #278: stop restoring stale db on local-disk targets

## Why

### Verify floor bump
moniaserver smoke test sequence:
```
[20:19:25] Verifying services
[20:19:26] Attempt 1/10: 7/7 running, 2/7 healthy
[20:19:41] Attempt 2/10: 5/7 healthy
[20:19:57] Attempt 3/10: 5/7 healthy
[20:20:12] Attempt 4/10: 6/7 healthy   ← old PR (60s) would have failed here
[20:20:28] Attempt 5/10: 6/7 healthy
[20:20:43] Attempt 6/10: 6/7 healthy
[20:20:59] Attempt 7/10: 6/7 healthy
[20:21:14] Attempt 8/10: 6/7 healthy
[20:21:30] Attempt 9/10: 6/7 healthy
[20:21:45] Attempt 10/10: 6/7 healthy  ← #279 (120s) failed here
[20:21:46] Server deployment failed

# ~30s later: all 7 containers reported healthy
```

MPD needed roughly 130-150s. Floor at 180s (12 × 15s = 180s) gives ~30s headroom over the observed delay. Network mount path (NFS/SMB) is unchanged — `MPD_START_PERIOD=300s+` still honored.

### MPD db gating (#278)
`prepare-sd.sh` and `firstboot.sh` previously restored `mpd/data/mpd.db` unconditionally. For local USB/disk sources, the restored db can contain NFS-rooted paths from a different host's library (the user's main install machine), causing stale listings until full rescan.

Local scan is fast (seconds, not hours). Network rescan is slow — the db restore is a real win there. Gate on `MUSIC_SOURCE=nfs|smb`.

## Files changed

| File | Change |
|---|---|
| `scripts/deploy.sh` | Floor 120 → 180 in `verify_services` |
| `scripts/firstboot.sh` | Gate `mpd.db` restore on `MUSIC_SOURCE=nfs|smb` |
| `scripts/prepare-sd.sh` | Gate `mpd.db` copy on `MUSIC_SOURCE=nfs|smb` |
| `scripts/prepare-sd.ps1` | Same gate (PowerShell sync) |
| `CHANGELOG.md` | Both entries under Unreleased |

## Test plan

- [ ] Reflash moniaserver `--both` (local disk), confirm verify completes within 180s and client setup runs
- [ ] Reflash a NFS-source Pi (snapvideo), confirm db is still restored and `start_period=300s` honored
- [ ] Verify install log shows "Skipping MPD db restore (source=local…)" on local-disk targets
- [ ] Issue #278 can be closed once this is merged (or kept open for the more elaborate signature-tagging approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)