### PR TITLE
docs(hardware): update Tested Combinations with 2026-04-27 release-gate batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Consolidated apt operations during firstboot** — Docker apt repo now added before `install-deps.sh`'s `apt-get update`, so a single update covers Debian + Docker sources. `fuse-overlayfs` moved into `install-deps.sh` (gated on `ENABLE_READONLY=true`). Result: 2 `apt-get update` → 1, 3 `apt-get install` → 2. Saves ~15s on Pi 4 firstboot. Failure isolation preserved (Debian and Docker installs remain separate transactions)
+
+### Documentation
+- **`docs/HARDWARE.md` Tested Combinations** updated with the 2026-04-27 release-gate validation: 6 devices reflashed from main, smoke test PASS, audio confirmed at ALSA `hw_ptr` level. Coverage now spans 3 Pi families (Zero 2W, 3 B+, 4 B), 2 DAC chip families (PCM5122 + WM8804/S/PDIF), HiFiBerry + InnoMaker brands, headless and HDMI-display variants, and `--both`/`--client` modes. Italian translation synced
 - **MPD database backup gated on network source** — `prepare-sd.sh` and `firstboot.sh` now restore `mpd/data/mpd.db` only when `MUSIC_SOURCE=nfs` or `smb`. For local USB/disk sources the db is skipped: scan is fast on local storage, and the db's path pointers may not match the new host's library (see [#278](https://github.com/lollonet/snapMULTI/issues/278))
 
 ### Fixed

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -296,17 +296,27 @@ Se un nodo è collegato a un ricevitore AV via cavo ottico, usa HiFiBerry Digi+ 
 
 ## Combinazioni Testate
 
-Queste combinazioni hardware sono state verificate in installazioni reali:
+Queste combinazioni hardware sono state verificate end-to-end (firstboot → smoke test → playback audio) nelle date indicate. Il batch del 2026-04-27 è la validazione release-gate per v0.6.x: 6 device riflashati da `main`, smoke test PASS su ognuno, `hw_ptr` ALSA che avanza durante la riproduzione (audio che raggiunge davvero il DAC, non solo la FIFO).
 
-| Modello Pi | HAT Audio | Modalità | Sorgente Musica | Stato |
-|------------|-----------|----------|----------------|-------|
-| Pi 4 | HiFiBerry DAC+ | Server + Client | NFS, USB | Funzionante |
-| Pi 4 | HiFiBerry Digi+ | Server + Client | NFS, USB | Funzionante |
-| Pi 4 | InnoMaker DAC | Client | — | Funzionante |
-| Pi 4 | Nessuno (HDMI/3.5mm) | Server | NFS, USB | Funzionante |
-| Pi 4 | Nessuno (HDMI) | Client (headless) | — | Funzionante |
-| Pi 3 | InnoMaker DAC | Client (headless) | — | Funzionante |
-| Pi Zero 2 W | InnoMaker DAC | Client (headless) | — | Funzionante |
+| Hostname | Modello Pi | HAT Audio | Chip DAC | Modalità | Display | Sorgente Musica | Validato | Stato |
+|---|---|---|---|---|---|---|---|---|
+| snapvideo | Pi 4 B (8 GB) | HiFiBerry DAC+ | PCM5122 (analogico) | both | HDMI 800×600 (display cover art) | locale | 2026-04-27 | Funzionante |
+| moniaserver | Pi 4 B (2 GB) | HiFiBerry DAC+ Standard | PCM5122 (analogico) | both | headless | USB | 2026-04-27 | Funzionante |
+| snapdigi | Pi 4 B (2 GB) | HiFiBerry Digi+ | WM8804 (S/PDIF) | client | HDMI verso TV LG 50" | n/d | 2026-04-27 | Funzionante |
+| piotto | Pi 4 B (2 GB) | nessuno (bcm2835 onboard) | — | client | headless | n/d | 2026-04-27 | Funzionante |
+| moniaclient | Pi 3 B+ (1 GB) | InnoMaker HIFI DAC HAT | PCM5122 (analogico) | client | headless | n/d | 2026-04-27 | Funzionante |
+| pizero | Pi Zero 2 W (512 MB) | InnoMaker DAC | PCM5122 (analogico) | client | headless | n/d | 2026-04-27 | Funzionante |
+
+**Copertura raggiunta il 2026-04-27**:
+
+- 3 famiglie di Pi: Pi Zero 2 W, Pi 3 B+, Pi 4 B (4 revisioni diverse di Pi 4: 1.1, 1.2, 1.4, 1.5)
+- 2 famiglie di chip DAC: PCM5122 (analogico, 4 schede tra brand HiFiBerry e InnoMaker) e WM8804 (S/PDIF digitale)
+- Più 1 device con `bcm2835` onboard (senza HAT)
+- Entrambi i path mixer: hardware (`hardware:Digital` su PCM5122) e software fallback (S/PDIF + onboard)
+- Entrambe le modalità di install (`--both`, `--client`) e `--server` esercitate nei round precedenti
+- Varianti headless e con display HDMI
+- Filesystem read-only (overlayroot + fuse-overlayfs) attivo su ogni device
+- Auto-detect via I2C bus 1 per PCM5122 EEPROM-less funziona su tutti e quattro i DAC HAT
 
 ## Limitazioni Note
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -296,17 +296,27 @@ If a node connects to an AV receiver via optical cable, use HiFiBerry Digi+ inst
 
 ## Tested Combinations
 
-These hardware combinations have been verified in real deployments:
+These hardware combinations have been verified end-to-end (firstboot → smoke test → audio playback) on the dates indicated. The 2026-04-27 batch was the v0.6.x release-gate validation: 6 devices reflashed from `main`, smoke test PASS on each, ALSA `hw_ptr` advancing during playback (audio actually reaching the DAC, not just the FIFO).
 
-| Pi Model | Audio HAT | Mode | Music Source | Status |
-|----------|-----------|------|-------------|--------|
-| Pi 4 | HiFiBerry DAC+ | Server + Client | NFS, USB | Working |
-| Pi 4 | HiFiBerry Digi+ | Server + Client | NFS, USB | Working |
-| Pi 4 | InnoMaker DAC | Client | — | Working |
-| Pi 4 | None (HDMI/3.5mm) | Server | NFS, USB | Working |
-| Pi 4 | None (HDMI) | Client (headless) | — | Working |
-| Pi 3 | InnoMaker DAC | Client (headless) | — | Working |
-| Pi Zero 2 W | InnoMaker DAC | Client (headless) | — | Working |
+| Hostname | Pi Model | Audio HAT | DAC chip | Mode | Display | Music Source | Validated | Status |
+|---|---|---|---|---|---|---|---|---|
+| snapvideo | Pi 4 B (8 GB) | HiFiBerry DAC+ | PCM5122 (analog) | both | HDMI 800×600 (cover art display) | local | 2026-04-27 | Working |
+| moniaserver | Pi 4 B (2 GB) | HiFiBerry DAC+ Standard | PCM5122 (analog) | both | headless | USB | 2026-04-27 | Working |
+| snapdigi | Pi 4 B (2 GB) | HiFiBerry Digi+ | WM8804 (S/PDIF) | client | HDMI to LG 50" TV | n/a | 2026-04-27 | Working |
+| piotto | Pi 4 B (2 GB) | none (bcm2835 onboard) | — | client | headless | n/a | 2026-04-27 | Working |
+| moniaclient | Pi 3 B+ (1 GB) | InnoMaker HIFI DAC HAT | PCM5122 (analog) | client | headless | n/a | 2026-04-27 | Working |
+| pizero | Pi Zero 2 W (512 MB) | InnoMaker DAC | PCM5122 (analog) | client | headless | n/a | 2026-04-27 | Working |
+
+**Coverage achieved on 2026-04-27**:
+
+- 3 Pi families: Pi Zero 2 W, Pi 3 B+, Pi 4 B (4 different rev numbers on the Pi 4: 1.1, 1.2, 1.4, 1.5)
+- 2 DAC chip families: PCM5122 (analog, 4 boards across HiFiBerry + InnoMaker brands) and WM8804 (S/PDIF digital)
+- Plus 1 device with onboard `bcm2835` (no HAT)
+- Both mixer paths: hardware (`hardware:Digital` on PCM5122) and software fallback (S/PDIF + onboard)
+- Both install modes (`--both`, `--client`) and `--server` exercised in earlier rounds
+- Headless and HDMI-display variants
+- Read-only filesystem (overlayroot + fuse-overlayfs) active on every device
+- Auto-detect via I2C bus 1 EEPROM-less PCM5122 detection works on all four DAC HATs
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

Replace the generic 7-row "Tested Combinations" table in `docs/HARDWARE.md` with the actual 6 devices reflashed and validated end-to-end on 2026-04-27 (firstboot → smoke test PASS → audio confirmed at ALSA `hw_ptr` level).

## New table (excerpt)

| Hostname | Pi Model | HAT | DAC chip | Mode | Display |
|---|---|---|---|---|---|
| snapvideo | Pi 4 B (8 GB) | HiFiBerry DAC+ | PCM5122 | both | HDMI 800×600 |
| moniaserver | Pi 4 B (2 GB) | HiFiBerry DAC+ Std | PCM5122 | both | headless |
| snapdigi | Pi 4 B (2 GB) | HiFiBerry Digi+ | WM8804 (S/PDIF) | client | HDMI to LG 50" TV |
| piotto | Pi 4 B (2 GB) | none (bcm2835) | — | client | headless |
| moniaclient | Pi 3 B+ (1 GB) | InnoMaker HIFI DAC HAT | PCM5122 | client | headless |
| pizero | Pi Zero 2 W (512 MB) | InnoMaker DAC | PCM5122 | client | headless |

## Why

This is the empirical evidence behind ADR-005's release gate ("every tag requires `device-smoke.sh` green on real Pi") and the basis for community launch claims. The previous table was a synthesis of "what should work"; this one is "what was reflashed from main today and verified".

## Coverage achieved

- 3 Pi families (Zero 2W, 3 B+, 4 B with 4 different rev numbers on Pi 4)
- 2 DAC chip families: PCM5122 analog (4 boards across HiFiBerry + InnoMaker brands) + WM8804 S/PDIF (HiFiBerry Digi+)
- 1 device with onboard bcm2835 (no HAT)
- Both mixer paths: hardware (`hardware:Digital` on PCM5122) + software fallback (S/PDIF + onboard)
- Both `--both` and `--client` modes (`--server` exercised in earlier rounds)
- Headless + HDMI-display variants
- Read-only filesystem active on every device
- I2C bus 1 EEPROM-less PCM5122 detection works across HiFiBerry and InnoMaker

## Test plan

- [x] Markdown renders correctly (table formatting, alignment)
- [x] Italian translation `docs/HARDWARE.it.md` synced
- [x] CHANGELOG.md entry under Documentation
- [ ] Optional: link this section from README.md beginner guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)