### PR TITLE
fix(display): recognise DSI/DPI/DisplayPort panels, not only HDMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`has_display()` now recognises DSI / DPI / DisplayPort panels, not only HDMI** — `client/common/scripts/display.sh` previously globbed `card*-HDMI-*/status`. Pi 4 always exposes 2 HDMI connector status files even when nothing is plugged in; if BOTH HDMI ports were disconnected and the user had a DSI panel (e.g. official 7" Touch Display, Pi-Top, custom DSI ribbon), the function found `found_status=true` (HDMI disconnected entries exist) and returned headless — disabling fb-display / audio-visualizer despite a working screen. Fixed: scan all `card*/status` files, parse the connector type from the parent directory name, honour `HDMI-* / DSI-* / DPI-* / DP-* / eDP-*` and explicitly skip `*Writeback*` (which is a virtual render target, not a physical screen). 6 scenarios validated via standalone harness (HDMI+writeback, DSI-only, all-headless, DPI-only, writeback-only, Pi 5 DP).
+
 ### Added
 - **`device-smoke.sh`: five new health checks** — distilled from the live troubleshooting on 2026-05-07 where each of these conditions had a real-world manifestation in the same hour:
   - **NTP time sync** — `timedatectl show -p NTPSynchronized` must be `yes`. Snapcast's TimeProvider is NTP-immune but log timestamps and metadata-service rely on a sane wall clock; Pi Zero 2W's RTC sits at epoch 0 until NTP completes, masking boot-time bugs in any component using absolute timestamps

--- a/client/common/scripts/display.sh
+++ b/client/common/scripts/display.sh
@@ -2,23 +2,48 @@
 set -euo pipefail
 # Display detection library — sourced by firstboot.sh, setup.sh, and display-detect.sh
 #
-# Checks whether an HDMI display is physically connected to the Pi.
-# On Pi 4+ with vc4-kms-v3d, /dev/fb0 always exists even without HDMI.
-# We must check DRM status files to distinguish connected from disconnected.
+# Checks whether ANY display (HDMI, DSI panel, DPI parallel, DisplayPort)
+# is physically connected to the Pi. On Pi 4+ with vc4-kms-v3d, /dev/fb0
+# always exists even without a monitor — we must check DRM status files.
+#
+# Connector types we honour:
+#   HDMI-*       — standard HDMI (Pi 1-5)
+#   DSI-*        — MIPI DSI panels (e.g. official 7" Touch Display, Pi-Top)
+#   DPI-*        — parallel DPI panels (some DAC+DSP boards expose video this way)
+#   DP-*         — DisplayPort (Pi 5)
+#   eDP-*        — embedded DisplayPort (Compute Module carriers)
+#
+# Connectors we EXCLUDE:
+#   *Writeback*  — virtual render target, never represents an actual screen
 
 has_display() {
     [[ -c /dev/fb0 ]] || return 1
 
-    local found_status=false
-    for card in /sys/class/drm/card*-HDMI-*/status; do
-        [[ -f "$card" ]] || continue
-        found_status=true
-        grep -q "^connected" "$card" && return 0
+    local found_real=false       # at least one supported real-display connector
+    local found_any_drm=false    # at least one DRM status file (incl. writeback)
+    local card status_path
+    for status_path in /sys/class/drm/card*/status; do
+        [[ -f "$status_path" ]] || continue
+        found_any_drm=true
+        card=$(basename "$(dirname "$status_path")")
+        # Skip writeback connectors (virtual render target, never a screen)
+        [[ "$card" =~ [Ww]riteback ]] && continue
+        # Honour only real-display connector types
+        case "$card" in
+            *-HDMI-*|*-DSI-*|*-DPI-*|*-DP-*|*-eDP-*)
+                found_real=true
+                grep -q "^connected" "$status_path" && return 0
+                ;;
+        esac
     done
 
-    # DRM status files exist but none say "connected" → headless
-    # Explicit check for clarity — avoids executing $found_status as a command
-    if [[ "$found_status" == "true" ]]; then
+    # At least one real-display connector exists but none is connected → headless
+    if [[ "$found_real" == "true" ]]; then
+        return 1
+    fi
+
+    # DRM exposes only non-display connectors (e.g. writeback only) → headless
+    if [[ "$found_any_drm" == "true" ]]; then
         return 1
     fi
 


### PR DESCRIPTION
## Summary

`client/common/scripts/display.sh::has_display()` only globbed `card*-HDMI-*/status`. On a Pi 4 with a DSI panel attached (e.g. the official 7\" Touch Display) but both HDMI ports disconnected, the function found `found_status=true` (HDMI status files exist showing \"disconnected\") and returned **headless** — disabling the framebuffer profile / fb-display / audio-visualizer despite a working screen.

## Fix

Scan all `card*/status` paths, parse the connector type from the parent dir basename, honour the real-display connector families and explicitly exclude `*Writeback*` (virtual render target, never a physical screen).

Connectors honoured: `HDMI-*`, `DSI-*`, `DPI-*`, `DP-*`, `eDP-*`.

## Validation

**Done locally**: `bash -n` + `shellcheck` clean.

**Standalone harness (6 scenarios)** — all pass:

```
✓  HDMI connected + Writeback (current snapvideo)
✓  DSI panel connected + both HDMI disconnected (THE BUG)
✓  Truly headless (HDMI only, disconnected)
✓  DPI parallel panel only
✓  Writeback-only (corner case)
✓  DisplayPort (Pi 5)
```

**Live verification on snapvideo** — actual DRM tree:
```
card0-HDMI-A-1: connected     ← detected as display ✓
card0-HDMI-A-2: disconnected
card0-Writeback-1: unknown    ← excluded ✓
```

**Deferred to release-gate** (per ADR-005, requires real Pi reflash):
- on a Pi 4 with the official 7\" DSI Touch Display attached and HDMI disconnected: confirm framebuffer profile activates, fb-display container starts, and audio-visualizer is healthy
- on a Pi 5 with a DisplayPort monitor: same verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)