### PR TITLE
fix: bake SNAPMULTI_VERSION into metadata image at build time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,8 +89,8 @@ PGID=1000
 # EXTERNAL_HOST: hostname/IP for artwork URLs sent to clients (auto-detected via FQDN).
 # Set explicitly if artwork doesn't appear on clients (auto-detection may return localhost).
 #EXTERNAL_HOST=
-# SNAPMULTI_VERSION: set automatically by deploy.sh from git tags or .version file
-#SNAPMULTI_VERSION=0.3.6
+# Note: SNAPMULTI_VERSION is no longer set here — it's baked into the
+# metadata image at build time (see Dockerfile.metadata).
 #METADATA_MEM_LIMIT=128M
 #METADATA_MEM_RESERVE=64M
 #METADATA_CPU_LIMIT=0.5

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -145,6 +145,8 @@ jobs:
           file: Dockerfile.metadata
           platforms: ${{ matrix.platform }}
           push: true
+          build-args: |
+            SNAPMULTI_VERSION=${{ steps.version.outputs.tag && format('v{0}', steps.version.outputs.tag) || steps.version.outputs.label }}
           tags: |
             lollonet/snapmulti-metadata:${{ steps.version.outputs.label }}-${{ matrix.suffix }}
             ${{ steps.version.outputs.tag && format('lollonet/snapmulti-metadata:{0}-{1}', steps.version.outputs.tag, matrix.suffix) || '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,13 +71,6 @@ jobs:
             sudo cp /tmp/snapmulti-deploy/docker-compose.yml /opt/snapmulti/docker-compose.yml
             rm -rf /tmp/snapmulti-deploy
 
-            echo "Updating SNAPMULTI_VERSION in .env..."
-            if grep -q '^SNAPMULTI_VERSION=' .env 2>/dev/null; then
-              sudo sed -i "s|^SNAPMULTI_VERSION=.*|SNAPMULTI_VERSION=${DEPLOY_VERSION}|" .env
-            else
-              echo "SNAPMULTI_VERSION=${DEPLOY_VERSION}" | sudo tee -a .env > /dev/null
-            fi
-
             echo "Logging in to Docker Hub..."
             if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
               echo "ERROR: DOCKERHUB_USERNAME or DOCKERHUB_TOKEN secret is empty."
@@ -148,10 +141,10 @@ jobs:
                 sudo rsync -aX --ignore-existing /var/lib/docker/fuse-overlayfs/ \
                     "$BAKE_DIR/var/lib/docker/fuse-overlayfs/"
 
-                # Verify version was actually written
-                BAKED=$(grep '^SNAPMULTI_VERSION=' "$BAKE_DIR/opt/snapmulti/.env" 2>/dev/null | cut -d= -f2)
-                if [[ "$BAKED" != "${DEPLOY_VERSION}" ]]; then
-                    echo "ERROR: Bake verification failed -- expected ${DEPLOY_VERSION}, got ${BAKED}"
+                # Sanity-check that the bake actually persisted the .env (rsync failure
+                # would already have exited via set -e, but guard against an empty file).
+                if [[ ! -s "$BAKE_DIR/opt/snapmulti/.env" ]]; then
+                    echo "ERROR: Bake verification failed -- baked .env is empty or missing"
                     exit 1
                 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`SNAPMULTI_VERSION` baked into the metadata image at build time** — previously the version reported by `/health` and `/version` came from an env var written by `deploy.sh` into `.env` at install time. After a `docker compose pull`, the new image ran with the *old* `.env` value, so the running code reported a stale version (observed on snapvideo: pulled v0.6.4 image, `/health` still reported `v0.6.3`). Now `Dockerfile.metadata` declares `ARG SNAPMULTI_VERSION=dev`, the workflow passes `--build-arg SNAPMULTI_VERSION=v$TAG` (or `dev`/`manual` for `workflow_dispatch`), and the value is baked as both `ENV SNAPMULTI_VERSION=` and `LABEL org.opencontainers.image.version=`. `docker-compose.yml` no longer overrides the env var, `deploy.sh` no longer writes to `.env`, `deploy.yml` no longer rewrites it on the target host, and `.env.example` documents the new flow. Result: image and reported version are tightly coupled, no drift after `docker pull` is possible.
+
 ## [0.6.4] — 2026-05-08
 
 ### Added

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -23,6 +23,14 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# Bake the snapMULTI version into the image so /health and /version report
+# what's actually running, never a stale value from a previously-rendered
+# .env file. Build args are populated by .github/workflows/build-push.yml
+# (tagged release: vX.Y.Z; workflow_dispatch: dev/manual).
+ARG SNAPMULTI_VERSION=dev
+ENV SNAPMULTI_VERSION=${SNAPMULTI_VERSION}
+LABEL org.opencontainers.image.version=${SNAPMULTI_VERSION}
+
 USER 1000
 
 CMD ["python3", "/app/metadata-service.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,7 +249,9 @@ services:
     environment:
       - TZ=${TZ:-Europe/Berlin}
       - EXTERNAL_HOST=${EXTERNAL_HOST:-}
-      - SNAPMULTI_VERSION=${SNAPMULTI_VERSION:-unknown}
+      # SNAPMULTI_VERSION is baked into the image at build time (see
+      # Dockerfile.metadata + build-push.yml --build-arg), so /health and
+      # /version always report the actually-running code's version.
     volumes:
       - ./artwork:/app/artwork
     healthcheck:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -954,21 +954,6 @@ _detect_version() {
     echo "$version"
 }
 
-# Write SNAPMULTI_VERSION to .env (called early so metadata container gets it).
-# Does NOT write .version file — that's done by write_version after verify.
-write_version_to_env() {
-    local version
-    version=$(_detect_version)
-    if [[ -n "$version" ]] && [[ -f "$ENV_FILE" ]]; then
-        if grep -q '^SNAPMULTI_VERSION=' "$ENV_FILE" 2>/dev/null; then
-            sed -i "s|^SNAPMULTI_VERSION=.*|SNAPMULTI_VERSION=$version|" "$ENV_FILE"
-        else
-            echo "SNAPMULTI_VERSION=$version" >> "$ENV_FILE"
-        fi
-        info "Version: $version"
-    fi
-}
-
 # Record deployed version to .version file (called after successful verify).
 write_version() {
     local version
@@ -1052,7 +1037,6 @@ main() {
     info "Using profile: $profile"
 
     setup_env "$profile"
-    write_version_to_env
     validate_config
     pull_images
     start_services


### PR DESCRIPTION
## Summary

Previously `/health` and `/version` reported a value read from `SNAPMULTI_VERSION` in `.env`, written once by `deploy.sh` at install time. After `docker compose pull`, the new image ran with the **old** `.env` value, so the running code reported a stale version.

Reproduced live on snapvideo today during the v0.6.4 release-gate: pulled v0.6.4 image, `/health` kept reporting `v0.6.3` until `.env` was manually updated.

## Approach

Couple the version to the image, not to a side-channel env var.

| File | Change |
|------|--------|
| `Dockerfile.metadata` | `ARG SNAPMULTI_VERSION=dev` → `ENV` + OCI `LABEL` |
| `.github/workflows/build-push.yml` | Pass `--build-arg SNAPMULTI_VERSION=v$TAG` (or `dev`/`manual` for `workflow_dispatch`) |
| `docker-compose.yml` | Drop the `SNAPMULTI_VERSION` env var override |
| `scripts/deploy.sh` | Remove `write_version_to_env()` and its caller |
| `.github/workflows/deploy.yml` | Stop rewriting `SNAPMULTI_VERSION` on the target host; replace bake verification |
| `.env.example` | Drop `SNAPMULTI_VERSION` line, point readers to the Dockerfile |

The Python code in `metadata-service.py` (`os.environ.get("SNAPMULTI_VERSION", "unknown")`) is unchanged — it still reads the env var, only now the env var comes from `ENV` baked into the image, not `.env`.

After this lands and a new tag fires `build-push.yml`, `docker pull` brings the version with it. Existing devices stay at their current version until the next pull, which is correct.

## Validation

Done locally:
- [x] `docker compose config -q` passes
- [x] `bash -n scripts/deploy.sh` passes
- [x] `shellcheck scripts/deploy.sh` clean (only pre-existing SC1091 source warnings)
- [x] YAML parse for both workflow files
- [x] No remaining `SNAPMULTI_VERSION` references outside the new locations

Deferred to release-gate:
- `:latest` rebuild from the next tag carries `SNAPMULTI_VERSION=vX.Y.Z`
- A device that has done `docker pull metadata` after that tag reports the new version on `/health` and `/version`
- `docker inspect lollonet/snapmulti-metadata:latest --format '{{index .Config.Labels "org.opencontainers.image.version"}}'` returns the right tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)