### PR TITLE
fix(progress): respect PROGRESS_MANAGED in progress() and progress_init()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **TUI flicker during `--both` install: client install screen briefly overdrew the unified TUI** — `progress()` and `progress_init()` in `scripts/common/progress.sh` were missing the `PROGRESS_MANAGED` short-circuit that `milestone()`, `start_progress_animation()`, and `progress_complete()` already had. When `firstboot.sh` invoked `setup.sh --auto` with `PROGRESS_MANAGED=1`, the child's 10 `progress N "..."` calls each rendered the stand-alone `Snapclient Auto-Install` TUI to `/dev/tty1` (with `STEP_NAMES`/`PROGRESS_TITLE` from setup.sh), then firstboot's spinner thread re-rendered the unified TUI ~1 s later, producing a visible flash of "old client install screen" multiple times during the client phase. Reproduced live on snapvideo. Fix: gate `progress_init` (setfont + log truncate), `progress` (render call), and add a defense-in-depth guard in `render_progress` itself, all on `PROGRESS_MANAGED`. The child's logs still flow into the parent via the pipe filter — only the screen-drawing is suppressed
+
 ## [0.6.5] — 2026-05-08
 
 ### Fixed

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -39,6 +39,12 @@ fi
 PROGRESS_LOG="/tmp/snapmulti-progress.log"
 
 progress_init() {
+    # When the parent process owns /dev/tty1 (firstboot calling setup.sh
+    # via PROGRESS_MANAGED=1), don't touch the screen or the parent's log
+    # file: setfont triggers a console redraw and the truncate would wipe
+    # the parent's running progress log.
+    [[ -n "${PROGRESS_MANAGED:-}" ]] && return
+
     : > "$PROGRESS_LOG"
 
     # On HD screens the default 8x16 font yields 240 columns — far too small.
@@ -116,6 +122,12 @@ _detect_tty_size() {
 render_progress() {
     local step=$1 pct=$2 elapsed=$3 spinner=${4:-}
     local total=${#STEP_NAMES[@]}
+
+    # Defense in depth — every "render" caller should already short-circuit
+    # under PROGRESS_MANAGED, but if any future caller forgets, this guard
+    # prevents a child process (e.g. setup.sh in --both mode) from drawing
+    # over the parent's TUI on /dev/tty1.
+    [[ -n "${PROGRESS_MANAGED:-}" ]] && return
 
     [[ -c /dev/tty1 ]] || return
 
@@ -268,6 +280,17 @@ stop_progress_animation() {
 progress() {
     local step=$1 msg="$2"
     local total=${#STEP_NAMES[@]}
+
+    # Always log: the parent's pipe filter (firstboot -> setup.sh) maps the
+    # stdout "=== Step ... ===" line into its own log entry, and the child's
+    # own PROGRESS_LOG append (in log_progress) is harmless.
+    if [[ -n "${PROGRESS_MANAGED:-}" ]]; then
+        local now_mono elapsed
+        now_mono=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0)
+        elapsed=$(( now_mono - PROGRESS_START_MONO ))
+        echo "=== Step $step/$total: $msg ($((elapsed/60))m$((elapsed%60))s) ==="
+        return
+    fi
 
     stop_progress_animation
 


### PR DESCRIPTION
## Summary

Fixes the TUI flicker you observed during the v0.6.5 reflash on snapvideo: the "old client install screen" briefly appearing several times during the client phase of a `--both` install.

## Root cause

In `--both` mode `firstboot.sh` runs `bash scripts/setup.sh --auto` with `PROGRESS_MANAGED=1` exported, expecting the child to skip `/dev/tty1` rendering. Most `progress.sh` helpers honoured that contract — `milestone()`, `start_progress_animation()`, `progress_complete()` — but two did not:

| Function | Bug |
|----------|-----|
| `progress()` | Called `render_progress` unconditionally. Each of setup.sh's 10 `progress N "..."` calls flashed the standalone `"Snapclient Auto-Install"` TUI on tty1 (with the client's `STEP_NAMES`), before firstboot's spinner repainted ~1 s later. **This is the "vecchia schermata client" you saw** |
| `progress_init()` | Ran `setfont` + truncated `PROGRESS_LOG` unconditionally. `setfont` triggers a console redraw; the truncate would wipe the parent's running progress log if both used the same path |

## Fix

Three guards mirroring the pattern already used by `milestone()` and friends:

```bash
# progress_init() — top of function
[[ -n "${PROGRESS_MANAGED:-}" ]] && return

# progress() — log only, skip rendering
if [[ -n "${PROGRESS_MANAGED:-}" ]]; then
    echo "=== Step $step/$total: $msg ($((elapsed/60))m$((elapsed%60))s) ==="
    return
fi

# render_progress() — defense in depth
[[ -n "${PROGRESS_MANAGED:-}" ]] && return
```

The `progress()` change still emits the `=== Step ===` line so firstboot's pipe filter (`bash scripts/setup.sh ... 2>&1 | while read ...`) continues to log every step into the unified install log.

## Validation

- [x] `bash -n scripts/common/progress.sh` passes
- [x] `shellcheck` clean (one pre-existing SC1003 INFO on the spinner array — not introduced by this PR)
- [x] Pre-push gates green

To validate end-to-end: re-run `prepare-sd.sh` with this on `main`, reflash, install `--both`. The unified TUI should stay continuous through the entire server→client transition with no flashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)