### PR TITLE
fix(install): TUI install on tty3 + chvt 8 for fb-display + mask getty@tty1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Install TUI overlapped fb-display on the HDMI console** — both the `firstboot.sh` install progress (rendered via fbcon on `/dev/tty1`) and the fb-display container (raw pixels on `/dev/fb0`) were fighting for the same framebuffer surface. The overlap was visible at the end of the client install (firstboot calls `systemctl start snapclient.service` BEFORE the reboot, so fb-display starts while the install TUI is still drawing) and again post-reboot, where the default `getty@tty1.service` login prompt would redraw on top of fb-display. Three coordinated fixes: (1) `progress.sh` and `unified-log.sh` now write to `$PROGRESS_TTY` (default `/dev/tty1` for backward-compat with standalone runs); (2) `firstboot.sh` exports `PROGRESS_TTY=/dev/tty3` + `chvt 3` at start so the install TUI gets its own VT, then `chvt 8` (a blank VT outside `logind`'s autovt range) right before starting `snapclient.service` so the kernel `fbcon` driver clears the framebuffer for fb-display to draw on without contention; (3) client `setup.sh` now masks `getty@tty1.service` when `HAS_DISPLAY=true` — console login remains accessible via Alt+F2 (logind autovt template auto-spawns agetty on tty2 on demand)
+
 ## [0.6.6] — 2026-05-08
 
 ### Fixed

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1096,6 +1096,19 @@ if systemctl is-enabled x11-autostart.service &>/dev/null; then
     systemctl disable x11-autostart.service
     echo "  Disabled previous X11 autostart service"
 fi
+
+# Free /dev/tty1 (and through it /dev/fb0) so fb-display owns the
+# framebuffer post-reboot. Default Raspberry Pi OS enables agetty on tty1,
+# whose login prompt would draw on top of fb-display via fbcon. Console
+# login remains accessible via Alt+F2 (logind autovt template auto-spawns
+# agetty on tty2 on demand). Idempotent: mask is a no-op when already set.
+if [[ "$HAS_DISPLAY" == true ]]; then
+    if systemctl list-unit-files getty@.service &>/dev/null; then
+        systemctl stop getty@tty1.service 2>/dev/null || true
+        systemctl mask getty@tty1.service 2>/dev/null || true
+        echo "  Masked getty@tty1.service (login prompt) — fb-display owns /dev/fb0; use Alt+F2 for console"
+    fi
+fi
 echo ""
 
 # ============================================

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Progress display library for snapMULTI auto-install.
 #
-# Provides a full-screen TUI on /dev/tty1 (HDMI console) with:
+# Provides a full-screen TUI on $PROGRESS_TTY (default /dev/tty1) with:
 #   - ASCII progress bar with weighted percentages
 #   - Step checklist ([x] done, [>] current, [ ] pending)
 #   - Animated spinner for long-running operations
@@ -27,6 +27,12 @@ PROGRESS_ANIM_PID=""
 # Title displayed in the TUI header (can be overridden before progress_init)
 PROGRESS_TITLE="${PROGRESS_TITLE:-snapMULTI Auto-Install}"
 
+# Target TTY for the TUI. firstboot.sh sets this to /dev/tty3 so that
+# fb-display can own /dev/tty1 (and through it /dev/fb0) post-install
+# without the install log overlapping the cover-art renderer.
+# Standalone callers and legacy callers still default to /dev/tty1.
+PROGRESS_TTY="${PROGRESS_TTY:-/dev/tty1}"
+
 # Default steps — fallback for standalone testing only.
 # Callers (firstboot.sh) always set STEP_NAMES/STEP_WEIGHTS before sourcing.
 if [[ ${#STEP_NAMES[@]} -eq 0 ]]; then
@@ -50,15 +56,15 @@ progress_init() {
     # On HD screens the default 8x16 font yields 240 columns — far too small.
     # Uni3-TerminusBold28x14 gives ~137 cols x 38 rows on 1080p, enough
     # for the 74-char wide TUI layout.
-    if [[ -c /dev/tty1 ]]; then
+    if [[ -c "$PROGRESS_TTY" ]]; then
         local fb_width
         fb_width=$(cut -d, -f1 /sys/class/graphics/fb0/virtual_size 2>/dev/null || echo 0)
         if (( fb_width > 1000 )); then
             # Use large font if available (not all Pi OS images include it)
             if ls /usr/share/consolefonts/Uni3-TerminusBold28x14* &>/dev/null; then
-                setfont Uni3-TerminusBold28x14 -C /dev/tty1 2>/dev/null || true
+                setfont Uni3-TerminusBold28x14 -C "$PROGRESS_TTY" 2>/dev/null || true
             elif ls /usr/share/consolefonts/Lat15-TerminusBold24x12* &>/dev/null; then
-                setfont Lat15-TerminusBold24x12 -C /dev/tty1 2>/dev/null || true
+                setfont Lat15-TerminusBold24x12 -C "$PROGRESS_TTY" 2>/dev/null || true
             fi
         fi
     fi
@@ -75,10 +81,10 @@ _box_width=96
 _inner_width=94
 
 _detect_tty_size() {
-    if [[ -c /dev/tty1 ]]; then
-        # Try stty first (works when called from tty1 directly)
-        _tty_cols=$(stty -F /dev/tty1 size 2>/dev/null | awk '{print $2}') || _tty_cols=0
-        _tty_rows=$(stty -F /dev/tty1 size 2>/dev/null | awk '{print $1}') || _tty_rows=0
+    if [[ -c "$PROGRESS_TTY" ]]; then
+        # Try stty first (works when called from the target tty directly)
+        _tty_cols=$(stty -F "$PROGRESS_TTY" size 2>/dev/null | awk '{print $2}') || _tty_cols=0
+        _tty_rows=$(stty -F "$PROGRESS_TTY" size 2>/dev/null | awk '{print $1}') || _tty_rows=0
 
         # Fallback: compute from framebuffer size and console font metrics.
         # stty returns empty when called via SSH or cloud-init (no controlling tty).
@@ -126,10 +132,10 @@ render_progress() {
     # Defense in depth — every "render" caller should already short-circuit
     # under PROGRESS_MANAGED, but if any future caller forgets, this guard
     # prevents a child process (e.g. setup.sh in --both mode) from drawing
-    # over the parent's TUI on /dev/tty1.
+    # over the parent's TUI.
     [[ -n "${PROGRESS_MANAGED:-}" ]] && return
 
-    [[ -c /dev/tty1 ]] || return
+    [[ -c "$PROGRESS_TTY" ]] || return
 
     # Clamp pct to 0-100
     (( pct < 0 )) && pct=0
@@ -193,7 +199,7 @@ render_progress() {
             printf '  | %-*s |\n' "$_inner_width" ""
         done
         printf '  +%s+\n' "$hline"
-    } > /dev/tty1
+    } > "$PROGRESS_TTY"
 }
 
 log_progress() {
@@ -325,7 +331,7 @@ progress_complete() {
     now_mono=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0)
     local elapsed=$(( now_mono - PROGRESS_START_MONO ))
 
-    [[ -c /dev/tty1 ]] || return
+    [[ -c "$PROGRESS_TTY" ]] || return
 
     local bar_width=$(( _box_width - 12 ))
     (( bar_width < 20 )) && bar_width=20
@@ -395,5 +401,5 @@ progress_complete() {
         printf '  +%s+\n' "$hline"
         printf '\n'
         printf '  \033[1;32m  snapMULTI ready\033[0m\n'
-    } > /dev/tty1
+    } > "$PROGRESS_TTY"
 }

--- a/scripts/common/unified-log.sh
+++ b/scripts/common/unified-log.sh
@@ -6,7 +6,7 @@
 #   - Log levels (INFO, WARN, ERROR, OK)
 #   - Source identification (which module produced the line)
 #   - Dual output: install log file + TUI progress feed
-#   - Console output for errors/warnings on /dev/tty1
+#   - Console output for errors/warnings on $PROGRESS_TTY (default /dev/tty1)
 #
 # Replaces both logging.sh and log_and_tty() from firstboot.sh.
 #
@@ -20,6 +20,10 @@
 # Log file destinations (can be overridden before sourcing)
 UNIFIED_LOG="${UNIFIED_LOG:-/var/log/snapmulti-install.log}"
 LOG_SOURCE="${LOG_SOURCE:-unknown}"
+
+# Console TTY for ERROR/WARN visibility. firstboot.sh sets this to /dev/tty3
+# so the install log doesn't overlap fb-display rendering on /dev/tty1 / fb0.
+PROGRESS_TTY="${PROGRESS_TTY:-/dev/tty1}"
 
 # Ensure log file exists and is writable
 if [[ ! -f "$UNIFIED_LOG" ]]; then
@@ -48,8 +52,8 @@ log_msg() {
 
     # Show errors and warnings on HDMI console
     case "$level" in
-        ERROR) echo "[ERROR] [$source] $msg" > /dev/tty1 2>/dev/null || true ;;
-        WARN)  echo "[WARN]  [$source] $msg" > /dev/tty1 2>/dev/null || true ;;
+        ERROR) echo "[ERROR] [$source] $msg" > "$PROGRESS_TTY" 2>/dev/null || true ;;
+        WARN)  echo "[WARN]  [$source] $msg" > "$PROGRESS_TTY" 2>/dev/null || true ;;
     esac
 }
 
@@ -68,5 +72,5 @@ step()  { log_info "==> $*"; }
 # Backward compatibility with firstboot.sh log_and_tty()
 log_and_tty() {
     log_info "$*"
-    echo "$*" > /dev/tty1 2>/dev/null || true
+    echo "$*" > "$PROGRESS_TTY" 2>/dev/null || true
 }

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -127,6 +127,18 @@ CLIENT_DIR="/opt/snapclient"
 LOG_SOURCE="firstboot"
 export UNIFIED_LOG="/var/log/snapmulti-install.log"
 
+# Move the install TUI to /dev/tty3 so /dev/tty1 (and /dev/fb0 through it)
+# can be claimed by fb-display without overlap. We chvt to tty3 so the
+# install progress remains visible on the HDMI console; right before
+# starting fb-display we switch to tty8 (a blank, autovt-free VT) so the
+# kernel fbcon driver clears the framebuffer for fb-display to draw on.
+# Standalone runs (no tty3 available) silently fall back via the test below.
+if [[ -c /dev/tty3 ]] && command -v chvt &>/dev/null; then
+    export PROGRESS_TTY=/dev/tty3
+    chvt 3 2>/dev/null || true
+    setterm -blank 0 -powersave off >/dev/tty3 2>/dev/null || true
+fi
+
 # Source unified logger
 COMMON="$SNAP_BOOT/common"
 [[ ! -d "$COMMON" ]] && COMMON="$SCRIPT_DIR/common"
@@ -227,9 +239,17 @@ cleanup_on_failure() {
             echo "=== END DIAGNOSTIC DUMP ==="
         } >> "$UNIFIED_LOG" 2>/dev/null || true
 
-        echo "" > /dev/tty1 2>/dev/null || true
-        echo "  --- Installation FAILED (module: $CURRENT_MODULE) ---" > /dev/tty1 2>/dev/null || true
-        echo "  Check log: $UNIFIED_LOG" > /dev/tty1 2>/dev/null || true
+        # Failure messages must be visible regardless of which VT is
+        # active. fb-display may have started already (post snapclient),
+        # in which case PROGRESS_TTY is no longer the visible VT — so
+        # write to both PROGRESS_TTY and /dev/tty1 as a belt+braces.
+        for _vt in "$PROGRESS_TTY" /dev/tty1; do
+            [[ -c "$_vt" ]] || continue
+            echo "" > "$_vt" 2>/dev/null || true
+            echo "  --- Installation FAILED (module: $CURRENT_MODULE) ---" > "$_vt" 2>/dev/null || true
+            echo "  Check log: $UNIFIED_LOG" > "$_vt" 2>/dev/null || true
+        done
+        chvt 1 2>/dev/null || true
 
         # Atomic FAILED_MARKER write: same pattern as checkpoint_done.
         # touch leaves a zero-byte file; if power loss strikes between
@@ -750,7 +770,17 @@ if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
     next_step "Verifying client..."
     start_progress_animation "$CURRENT_STEP" "$(cumulative_pct "$CURRENT_STEP")" "$(current_weight)" 2>/dev/null || true
 
-    # Start client via systemd — the lifecycle owner post-install (ADR-005)
+    # Start client via systemd — the lifecycle owner post-install (ADR-005).
+    # Switch to a blank VT first so fb-display has /dev/fb0 to itself.
+    # The kernel fbcon driver clears the framebuffer on chvt; fb-display
+    # then writes raw pixels without the install TUI fighting for the
+    # same surface. VT 8 is outside logind's autovt range (NAutoVTs=6
+    # by default) so nothing else fights for it. setterm prevents the
+    # 10-minute screen blanker from kicking in mid-render.
+    if [[ -c /dev/fb0 ]] && command -v chvt &>/dev/null; then
+        chvt 8 2>/dev/null || true
+        setterm -blank 0 -powersave off -cursor off >/dev/tty8 2>/dev/null || true
+    fi
     log_info "Starting client via systemd..."
     systemctl start snapclient.service || log_warn "systemctl start snapclient failed"
 
@@ -907,9 +937,13 @@ progress_complete 2>/dev/null || true
 LOCAL_HOSTNAME=$(hostname 2>/dev/null || echo "snapmulti")
 IP_ADDR=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '/src/{for(i=1;i<=NF;i++) if($i=="src"){print $(i+1); exit}}') || true
 
-# Show completion banner on both log and HDMI console
-# (log_info only writes to log + PROGRESS_LOG, not tty1 — use direct echo)
-_tty() { echo "$*" > /dev/tty1 2>/dev/null || true; log_info "$*"; }
+# Show completion banner on both log and HDMI console.
+# log_info only writes to the install log + PROGRESS_LOG, not the visible
+# console — use a direct echo to the install TUI tty. For server-only this
+# is /dev/tty1 (and the user sees it directly); for client/both we already
+# switched to /dev/tty8 so fb-display can render — the banner survives in
+# the log, and fb-display itself shows the install is finished.
+_tty() { echo "$*" > "$PROGRESS_TTY" 2>/dev/null || true; log_info "$*"; }
 
 _elapsed="$((SECONDS / 60))m$((SECONDS % 60))s"
 log_info "Installation completed in $_elapsed"

--- a/tests/test_install_tty_fb_overlap.sh
+++ b/tests/test_install_tty_fb_overlap.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # assert() conditions are intentionally
+#                              passed as single-quoted strings and eval'd
+#                              with the file paths in scope.
+# Static checks for the install TUI / fb-display overlap fix.
+#
+# Three coordinated changes:
+#   1. progress.sh + unified-log.sh use $PROGRESS_TTY (default /dev/tty1),
+#      not a hardcoded path — so firstboot.sh can redirect the install
+#      TUI to /dev/tty3 without touching the libraries.
+#   2. firstboot.sh:
+#        - exports PROGRESS_TTY=/dev/tty3 + chvt 3 at start,
+#        - chvt 8 (blank VT outside logind autovt range) right before
+#          systemctl start snapclient.service so fb-display owns /dev/fb0.
+#   3. client setup.sh masks getty@tty1.service when HAS_DISPLAY=true
+#      so the post-reboot login prompt doesn't redraw on top of fb-display.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROGRESS_SH="$SCRIPT_DIR/../scripts/common/progress.sh"
+UNIFIED_LOG_SH="$SCRIPT_DIR/../scripts/common/unified-log.sh"
+FIRSTBOOT="$SCRIPT_DIR/../scripts/firstboot.sh"
+SETUP_SH="$SCRIPT_DIR/../client/common/scripts/setup.sh"
+
+pass=0
+fail=0
+
+assert() {
+    local cond="$1" desc="$2"
+    if eval "$cond"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "=== progress.sh — env-driven PROGRESS_TTY ==="
+
+assert 'grep -qE "^PROGRESS_TTY=\"\\\$\\{PROGRESS_TTY:-/dev/tty1\\}\"" "$PROGRESS_SH"' \
+       'progress.sh declares PROGRESS_TTY with /dev/tty1 default'
+
+# No hardcoded `/dev/tty1` in progress.sh active code (comments and the
+# default value are OK). awk strips inline comments before checking.
+hardcoded=$(awk -F'#' '
+    {code=$1; if (code ~ /\/dev\/tty1/ && code !~ /PROGRESS_TTY:-/) print NR": "$0}
+' "$PROGRESS_SH" || true)
+if [[ -z "$hardcoded" ]]; then
+    echo "  PASS: progress.sh has no hardcoded /dev/tty1 in active code"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: progress.sh still has hardcoded /dev/tty1:"
+    echo "$hardcoded" | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+assert 'grep -qE "render_progress|^[[:space:]]*\\}.*> *\"\\\$PROGRESS_TTY\"" "$PROGRESS_SH"' \
+       'progress.sh writes render output to "$PROGRESS_TTY"'
+
+assert 'grep -qE "stty -F \"\\\$PROGRESS_TTY\"" "$PROGRESS_SH"' \
+       'progress.sh queries stty on "$PROGRESS_TTY"'
+
+assert 'grep -qE "setfont .* -C \"\\\$PROGRESS_TTY\"" "$PROGRESS_SH"' \
+       'progress.sh runs setfont on "$PROGRESS_TTY"'
+
+echo
+echo "=== unified-log.sh — env-driven PROGRESS_TTY ==="
+
+assert 'grep -qE "^PROGRESS_TTY=\"\\\$\\{PROGRESS_TTY:-/dev/tty1\\}\"" "$UNIFIED_LOG_SH"' \
+       'unified-log.sh declares PROGRESS_TTY with /dev/tty1 default'
+
+assert 'grep -qE "ERROR\\] \\[\\\$source\\] \\\$msg\" *> *\"\\\$PROGRESS_TTY\"" "$UNIFIED_LOG_SH"' \
+       'unified-log.sh writes ERROR to "$PROGRESS_TTY"'
+
+assert 'grep -qE "WARN\\] *\\[\\\$source\\] \\\$msg\" *> *\"\\\$PROGRESS_TTY\"" "$UNIFIED_LOG_SH"' \
+       'unified-log.sh writes WARN to "$PROGRESS_TTY"'
+
+assert 'grep -qE "log_and_tty\\(\\)" "$UNIFIED_LOG_SH" && \
+        awk "/^log_and_tty\\(\\)/,/^\\}/" "$UNIFIED_LOG_SH" | grep -qE "> *\"\\\$PROGRESS_TTY\""' \
+       'log_and_tty() targets "$PROGRESS_TTY"'
+
+echo
+echo "=== firstboot.sh — chvt 3 at start, chvt 8 before fb-display ==="
+
+assert 'grep -qE "export PROGRESS_TTY=/dev/tty3" "$FIRSTBOOT"' \
+       'firstboot.sh exports PROGRESS_TTY=/dev/tty3'
+
+assert 'grep -qE "chvt 3" "$FIRSTBOOT"' \
+       'firstboot.sh switches to VT 3 for the install TUI'
+
+# The chvt 8 must precede `systemctl start snapclient.service`.
+chvt8_line=$(grep -nE 'chvt 8' "$FIRSTBOOT" | head -1 | cut -d: -f1)
+snap_start_line=$(grep -nE 'systemctl start snapclient\.service' "$FIRSTBOOT" | head -1 | cut -d: -f1)
+if [[ -n "$chvt8_line" && -n "$snap_start_line" && "$chvt8_line" -lt "$snap_start_line" ]]; then
+    echo "  PASS: chvt 8 (line $chvt8_line) runs BEFORE systemctl start snapclient (line $snap_start_line)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: chvt 8 missing or AFTER snapclient start (chvt8=$chvt8_line, start=$snap_start_line)"
+    fail=$((fail + 1))
+fi
+
+# chvt 8 path must be guarded on /dev/fb0 + chvt presence: scan a small
+# window of lines preceding chvt 8 for the conditional.
+chvt8_ln=$(grep -nE 'chvt 8' "$FIRSTBOOT" | head -1 | cut -d: -f1)
+if [[ -n "$chvt8_ln" ]]; then
+    start_ln=$((chvt8_ln - 5))
+    (( start_ln < 1 )) && start_ln=1
+    guard_window=$(sed -n "${start_ln},${chvt8_ln}p" "$FIRSTBOOT")
+    if echo "$guard_window" | grep -qE 'if \[\[ -c /dev/fb0' \
+       && echo "$guard_window" | grep -q 'command -v chvt'; then
+        echo "  PASS: chvt 8 block guarded on /dev/fb0 + chvt presence"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: chvt 8 missing fb0/chvt guard (window:"
+        echo "$guard_window" | sed 's/^/    /'
+        echo "    )"
+        fail=$((fail + 1))
+    fi
+else
+    echo "  FAIL: chvt 8 not found in firstboot.sh"
+    fail=$((fail + 1))
+fi
+
+# setterm clears blanker/cursor on tty8.
+assert 'grep -qE "setterm.*-blank 0.*tty8|setterm.*tty8.*-blank 0" "$FIRSTBOOT"' \
+       'setterm disables blanker on /dev/tty8'
+
+echo
+echo "=== client setup.sh — mask getty@tty1 when HAS_DISPLAY ==="
+
+assert 'awk "/HAS_DISPLAY.*== true/,/^fi$/" "$SETUP_SH" | grep -qE "systemctl mask getty@tty1\\.service"' \
+       'setup.sh masks getty@tty1.service inside the HAS_DISPLAY block'
+
+assert 'awk "/HAS_DISPLAY.*== true/,/^fi$/" "$SETUP_SH" | grep -qE "systemctl stop getty@tty1\\.service"' \
+       'setup.sh stops getty@tty1.service before mask (to drop running prompt)'
+
+# Must NOT mask getty unconditionally — headless installs need tty1 free
+# of fb-display anyway, but forcibly masking would surprise users.
+mask_outside_block=$(awk '
+    /^if \[\[ "\$HAS_DISPLAY" == true \]\]; then$/ {in_block=1; next}
+    in_block && /^fi$/ {in_block=0; next}
+    !in_block && /systemctl mask getty@tty1/ {print NR": "$0}
+' "$SETUP_SH" || true)
+if [[ -z "$mask_outside_block" ]]; then
+    echo "  PASS: getty@tty1 mask is gated on HAS_DISPLAY (not unconditional)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: stray getty@tty1 mask outside HAS_DISPLAY block:"
+    echo "$mask_outside_block" | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+echo
+echo "=== Bash syntax ==="
+for f in "$PROGRESS_SH" "$UNIFIED_LOG_SH" "$FIRSTBOOT" "$SETUP_SH"; do
+    if bash -n "$f"; then
+        echo "  PASS: bash -n $(basename "$f")"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: bash -n $(basename "$f")"
+        fail=$((fail + 1))
+    fi
+done
+
+echo
+echo "=== Summary ==="
+echo "  Pass: $pass"
+echo "  Fail: $fail"
+
+[[ "$fail" -eq 0 ]]

--- a/tests/test_install_tty_fb_overlap.sh
+++ b/tests/test_install_tty_fb_overlap.sh
@@ -130,18 +130,42 @@ assert 'grep -qE "setterm.*-blank 0.*tty8|setterm.*tty8.*-blank 0" "$FIRSTBOOT"'
 echo
 echo "=== client setup.sh — mask getty@tty1 when HAS_DISPLAY ==="
 
-assert 'awk "/HAS_DISPLAY.*== true/,/^fi$/" "$SETUP_SH" | grep -qE "systemctl mask getty@tty1\\.service"' \
-       'setup.sh masks getty@tty1.service inside the HAS_DISPLAY block'
+# setup.sh has MULTIPLE `if [[ "$HAS_DISPLAY" == true ]]` blocks
+# (audio loopback at line ~590, COMPOSE_PROFILES at line ~990, getty
+# mask at line ~1105). The simple awk-range pattern stops at the FIRST
+# `^fi$` in the file, which is the audio block — the getty mask is never
+# in scope. Use a depth-tracked walk so grep sees content from ANY
+# HAS_DISPLAY block, regardless of nesting.
+hd_blocks=$(awk '
+    /^if \[\[ "\$HAS_DISPLAY" == true \]\]; then$/ {depth=1; print; next}
+    depth>0 && /^[[:space:]]*if / {depth++}
+    depth>0 && /^[[:space:]]*fi$/ {print; depth--; next}
+    depth>0 {print}
+' "$SETUP_SH")
 
-assert 'awk "/HAS_DISPLAY.*== true/,/^fi$/" "$SETUP_SH" | grep -qE "systemctl stop getty@tty1\\.service"' \
-       'setup.sh stops getty@tty1.service before mask (to drop running prompt)'
+if echo "$hd_blocks" | grep -qE 'systemctl mask getty@tty1\.service'; then
+    echo "  PASS: setup.sh masks getty@tty1.service inside a HAS_DISPLAY block"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: setup.sh missing systemctl mask getty@tty1 inside HAS_DISPLAY"
+    fail=$((fail + 1))
+fi
 
-# Must NOT mask getty unconditionally — headless installs need tty1 free
-# of fb-display anyway, but forcibly masking would surprise users.
+if echo "$hd_blocks" | grep -qE 'systemctl stop getty@tty1\.service'; then
+    echo "  PASS: setup.sh stops getty@tty1.service before mask (to drop running prompt)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: setup.sh missing systemctl stop getty@tty1 inside HAS_DISPLAY"
+    fail=$((fail + 1))
+fi
+
+# Must NOT mask getty unconditionally — headless installs need tty1
+# free, and forcibly masking would surprise diagnostics-only runs.
 mask_outside_block=$(awk '
-    /^if \[\[ "\$HAS_DISPLAY" == true \]\]; then$/ {in_block=1; next}
-    in_block && /^fi$/ {in_block=0; next}
-    !in_block && /systemctl mask getty@tty1/ {print NR": "$0}
+    /^if \[\[ "\$HAS_DISPLAY" == true \]\]; then$/ {depth=1; next}
+    depth>0 && /^[[:space:]]*if / {depth++; next}
+    depth>0 && /^[[:space:]]*fi$/ {depth--; next}
+    depth==0 && /systemctl mask getty@tty1/ {print NR": "$0}
 ' "$SETUP_SH" || true)
 if [[ -z "$mask_outside_block" ]]; then
     echo "  PASS: getty@tty1 mask is gated on HAS_DISPLAY (not unconditional)"


### PR DESCRIPTION
## Summary

Resolves the install TUI / fb-display overlap on the HDMI console.

## The bug

Both the install progress TUI (rendered via fbcon on `/dev/tty1`) and the fb-display container (raw pixels on `/dev/fb0`) were fighting for the same framebuffer surface. The overlap was visible:

- **End of client install**: `firstboot.sh:755` calls `systemctl start snapclient.service` BEFORE the final reboot, so fb-display starts drawing while the install TUI is still rendering.
- **After reboot**: `getty@tty1.service` draws the login prompt on top of fb-display.

## The fix (three coordinated changes)

### 1. `progress.sh` + `unified-log.sh` accept `$PROGRESS_TTY`
Default stays `/dev/tty1` — standalone callers and the server-only path keep legacy behavior.

### 2. `firstboot.sh` orchestrates VT switching
- At start: `export PROGRESS_TTY=/dev/tty3 && chvt 3` — install TUI gets its own VT
- Before `systemctl start snapclient.service`: `chvt 8` (blank VT outside `logind`'s autovt range, `NAutoVTs=6`) so the kernel `fbcon` driver clears `/dev/fb0` and fb-display has it to itself.
- Failure path: writes to BOTH `$PROGRESS_TTY` and `/dev/tty1` + `chvt 1`, so failure messages survive even if fb-display already started.

### 3. `setup.sh` masks `getty@tty1.service` when `HAS_DISPLAY=true`
Console login remains accessible via **Alt+F2** — `logind`'s `autovt@.service` template spawns `agetty` on `tty2` on demand. Idempotent.

## Validation

**Done locally:**
- [x] `tests/test_install_tty_fb_overlap.sh` — 21 assertions, all pass
- [x] `bash -n` syntax check on all four modified files
- [x] `shellcheck -e SC1091 -S warning` clean (only style/info on test file)

**Deferred to release-gate:**
- [ ] Reflash on snapvideo (Pi 4 with HDMI display) and observe install TUI on `/dev/tty3` + fb-display on `/dev/fb0` without overlap
- [ ] Confirm `Alt+F2` works for console login post-reboot
- [ ] Headless install (no display): verify backward-compat, no chvt/setterm errors in install log

## Risks

- `chvt` requires `CAP_SYS_TTY_CONFIG` — firstboot runs as root, fine.
- VT 8 was picked because `NAutoVTs=6` (systemd-logind default). If a downstream Pi OS image has `NAutoVTs=8` we'd race with `autovt@tty7/tty8`. Documented in code comment; can switch to VT 12 if it ever bites.
- `setterm` writes are non-fatal (`|| true`), so a missing `console-tools` package can't break the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)