### PR TITLE
fix(install): apply quiet-boot cmdline flags BEFORE setup_readonly_fs

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -917,6 +917,49 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
     fi
 fi
 
+# ── Quiet boot for fb-display ────────────────────────────────────
+# Without this, the post-install reboot leaves systemd / kernel
+# `[ OK ] Started X.service ...` lines streaming on tty1 (drawn via
+# fbcon on /dev/fb0) right while fb-display starts writing raw
+# pixels there. The two outputs interleave on the framebuffer for
+# 30–60 s until multi-user.target settles. Boot quietly: only
+# WARN/ERROR messages remain visible (sufficient for emergency
+# diagnostics), and fb-display has the framebuffer to itself.
+#
+# Applies to client / both installs where a display is present.
+# Server-only installs (no fb-display) keep verbose boot for SSH-less
+# debugging on a head-attached server.
+#
+# CRITICAL ORDERING: this block MUST run BEFORE setup_readonly_fs.
+# raspi-config's `do_overlayfs 0` remounts /boot/firmware read-only
+# during the configuration step (verified live on snapvideo: the log
+# showed `cmdline: failed to add 'quiet'` × 4 with /boot/firmware
+# already in `mount | grep ro`). After that point sed -i can no
+# longer rewrite cmdline.txt and the flags never land.
+#
+# Flag rationale:
+#   quiet                       — kernel skips KERN_INFO / KERN_NOTICE
+#   loglevel=3                  — only WARN+ from kernel reach console
+#   systemd.show_status=false   — systemd ≥ 257 prints
+#                                 `[ OK ] Started X.service` even
+#                                 under `quiet`; this suppresses it
+#   vt.global_cursor_default=0  — hide cursor blink behind fb-display
+#   logo.nologo                 — hide raspberry-pi boot logo
+if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
+    if [[ -c /dev/fb0 ]] && [[ -n "${CMDLINE_FILE:-}" ]] && [[ -f "$CMDLINE_FILE" ]]; then
+        # Idempotent: only append flags that aren't already there.
+        for flag in "quiet" "loglevel=3" "systemd.show_status=false" "vt.global_cursor_default=0" "logo.nologo"; do
+            if ! grep -qE "(^| )${flag//./\\.}( |\$)" "$CMDLINE_FILE"; then
+                if sed -i "1s/\$/ ${flag}/" "$CMDLINE_FILE" 2>/dev/null; then
+                    log_info "cmdline: added '${flag}' (quiet boot for fb-display)"
+                else
+                    log_warn "cmdline: failed to add '${flag}' (is /boot/firmware mounted ro?)"
+                fi
+            fi
+        done
+    fi
+fi
+
 # Read-only filesystem
 if [[ "${ENABLE_READONLY}" == "true" ]]; then
     log_info "Configuring read-only filesystem..."
@@ -932,31 +975,6 @@ if [[ "${ENABLE_READONLY}" == "true" ]]; then
     log_info "Read-only filesystem configured"
 else
     log_info "Read-only filesystem: skipped (ENABLE_READONLY=false)"
-fi
-
-# ── Quiet boot for fb-display ────────────────────────────────────
-# Without this, the post-install reboot leaves systemd / kernel
-# `[ OK ] Started X.service ...` lines streaming on tty1 (drawn via
-# fbcon on /dev/fb0) right while fb-display starts writing raw
-# pixels there. The two outputs interleave on the framebuffer for
-# 30–60 s until multi-user.target settles. Boot quietly: only
-# WARN/ERROR messages remain visible (sufficient for emergency
-# diagnostics), and fb-display has the framebuffer to itself.
-#
-# Applies to client / both installs where a display is present.
-# Server-only installs (no fb-display) keep verbose boot for SSH-less
-# debugging on a head-attached server.
-if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
-    if [[ -c /dev/fb0 ]] && [[ -n "${CMDLINE_FILE:-}" ]] && [[ -f "$CMDLINE_FILE" ]]; then
-        # Idempotent: only append flags that aren't already there.
-        for flag in "quiet" "loglevel=3" "vt.global_cursor_default=0" "logo.nologo"; do
-            if ! grep -qE "(^| )${flag//./\\.}( |\$)" "$CMDLINE_FILE"; then
-                sed -i "1s/\$/ ${flag}/" "$CMDLINE_FILE" 2>/dev/null \
-                    && log_info "cmdline: added '${flag}' (quiet boot for fb-display)" \
-                    || log_warn "cmdline: failed to add '${flag}'"
-            fi
-        done
-    fi
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/tests/test_install_tty_fb_overlap.sh
+++ b/tests/test_install_tty_fb_overlap.sh
@@ -124,7 +124,7 @@ assert 'echo "$quiet_block" | grep -qE "INSTALL_TYPE.*client.*both"' \
 assert 'echo "$quiet_block" | grep -qE "\\[\\[ -c /dev/fb0 \\]\\]"' \
        'quiet boot block gated on /dev/fb0 presence'
 
-for flag in quiet loglevel=3 vt.global_cursor_default=0 logo.nologo; do
+for flag in quiet loglevel=3 systemd.show_status=false vt.global_cursor_default=0 logo.nologo; do
     if echo "$quiet_block" | grep -qF "$flag"; then
         echo "  PASS: cmdline flag '$flag' is appended"
         pass=$((pass + 1))
@@ -138,6 +138,22 @@ done
 # existing cmdline so re-run firstboot doesn't duplicate flags.
 assert 'echo "$quiet_block" | grep -qE "if ! grep -qE.*CMDLINE_FILE"' \
        'each cmdline flag append is idempotent (grep guard)'
+
+# CRITICAL ORDERING: the quiet-boot block MUST run BEFORE
+# setup_readonly_fs. raspi-config's `do_overlayfs 0` remounts
+# /boot/firmware read-only mid-install, after which sed -i can no
+# longer touch cmdline.txt. Verified live on snapvideo (the wrong
+# order produced 4× `cmdline: failed to add '...'` warnings and an
+# empty quiet-boot effect post-reboot).
+quiet_line=$(grep -nE "^[[:space:]]*for flag in .*systemd\\.show_status" "$FIRSTBOOT" | head -1 | cut -d: -f1)
+ro_line=$(grep -nE "^[[:space:]]*setup_readonly_fs " "$FIRSTBOOT" | head -1 | cut -d: -f1)
+if [[ -n "$quiet_line" && -n "$ro_line" && "$quiet_line" -lt "$ro_line" ]]; then
+    echo "  PASS: quiet-boot block (line $quiet_line) runs BEFORE setup_readonly_fs (line $ro_line)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: quiet-boot block AFTER setup_readonly_fs (quiet=$quiet_line, ro=$ro_line)"
+    fail=$((fail + 1))
+fi
 
 echo
 echo "=== client setup.sh — mask getty@tty1 when HAS_DISPLAY ==="


### PR DESCRIPTION
## Summary

The PR #318 quiet-boot flags never reached `cmdline.txt` on snapvideo. User-reported overlap of systemd `[ OK ] Started X.service` over fb-display persisted on first boot.

## Root cause (verified live on snapvideo)

```
[WARN] [finalize] cmdline: failed to add 'quiet'
[WARN] [finalize] cmdline: failed to add 'loglevel=3'
[WARN] [finalize] cmdline: failed to add 'vt.global_cursor_default=0'
[WARN] [finalize] cmdline: failed to add 'logo.nologo'
```

`raspi-config nonint do_overlayfs 0` (called from `setup_readonly_fs`) remounts `/boot/firmware` read-only DURING the configuration step, not just at next boot. PR #318's quiet-boot block was placed AFTER `setup_readonly_fs`, so by the time `sed -i` ran on `cmdline.txt`, the partition was already RO and every append failed silently with a WARN.

Verified: `mount | grep firmware` on snapvideo showed `vfat (ro,…)` and the cmdline contained zero of the four flags.

## Fix

1. **Move the quiet-boot block ABOVE `setup_readonly_fs`**. Same code, just earlier — flags land while `/boot/firmware` is still RW, then overlayroot's later cmdline rewrite preserves them (it only prepends `overlayroot=tmpfs`).

2. **Add `systemd.show_status=false`** to the flag list. systemd ≥ 257 (Pi OS Bookworm ships 257.9) prints `[ OK ] Started X.service` even under `quiet` — exactly the lines the user saw overlap fb-display. This flag is the actual fix for systemd's "fancy" boot output.

3. **Better error reporting**: the WARN message now hints at the RO-mount cause so future runs surface the symptom directly.

## Validation

**Done locally:**
- [x] `tests/test_install_tty_fb_overlap.sh` — 30/30 pass (added ordering assertion + systemd.show_status flag)
- [x] `bash -n scripts/firstboot.sh` clean

**Deferred to release-gate (snapvideo reflash):**
- [ ] Install log shows `cmdline: added 'quiet'`, `'loglevel=3'`, `'systemd.show_status=false'`, etc. — no `cmdline: failed to add` warnings
- [ ] `cat /boot/firmware/cmdline.txt` post-install contains the 5 flags
- [ ] Post-reboot HDMI: no `[ OK ] Started X.service` overlap on fb-display

## Risks

- The quiet-boot block now runs BEFORE `setup_readonly_fs`. If somebody adds future code between the two blocks that depends on the readonly fs being configured, we might surface an ordering issue. Currently nothing between them — clean.
- `systemd.show_status=false` silences also `[FAILED]` messages from non-essential services. Only emergency-target failures escape (those go via getty/sulogin path, not the systemd status output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)