### PR TITLE
docs(community): architecture diagram + alternatives comparison in README

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -20,6 +20,49 @@ Riproduci musica in sincronia in ogni stanza. Streaming da Spotify, AirPlay, la 
   <em>Display HDMI: copertina, analizzatore di spettro, metadati brano — rendering diretto su framebuffer, nessun desktop</em>
 </p>
 
+## Come funziona
+
+```text
+   Spotify   AirPlay   Tidal   myMPD web UI   qualsiasi app TCP audio
+      │         │        │           │                │
+      └─────────┴────────┴───────────┴────────────────┘
+                              │
+                              ▼
+                    ┌───────────────────┐
+                    │  Server (Pi / NUC)│  miscela le sorgenti, codifica
+                    │  snapserver       │  una volta, distribuisce uno stream
+                    └───────────────────┘
+                              │  Snapcast su LAN (TCP/UDP)
+                              ▼
+              ┌───────────┬───────────┬──────────────┐
+              │  Pi #1    │  Pi #2    │  Pi #N       │  ognuno esegue snapclient
+              │  Soggiorno│  Cucina   │  Camera      │  + un DAC HAT o USB DAC
+              └───────────┴───────────┴──────────────┘
+                              │
+                              ▼
+                          🔊 Altoparlanti
+```
+
+Tutti i client suonano in lock-step (~5 ms di drift tra stanze). Aggiungi un client flashando un'altra SD e inserendola in qualsiasi Pi — niente IP da configurare, niente pairing, mDNS trova il server da solo. Server e un client possono girare sullo stesso Pi (modalità `both`).
+
+## Perché snapMULTI
+
+| | snapMULTI | Sonos | Volumio | MoOde |
+|---|---|---|---|---|
+| **Costo per stanza** | ~60 € (Pi 4 + DAC HAT) | 200 €+ (One SL) | ~60 € hardware + abbonamento Volumio Plus per multi-stanza | ~60 € hardware |
+| **Open source** | ✅ GPL-3.0 | ❌ proprietario | Parziale (multi-stanza è a pagamento) | ✅ |
+| **Sync multi-stanza** | ✅ Snapcast (~5 ms) | ✅ proprietario | ✅ (con Plus) | ❌ singolo dispositivo |
+| **Senza cloud** | ✅ tutto locale | ❌ richiede cloud Sonos | Parziale | ✅ |
+| **Telemetria** | ❌ nessuna, nessuna prevista | ✅ raccolta di default | Parziale | ❌ |
+| **Spotify Connect** | ✅ Premium | ✅ | ✅ (Plus) | ✅ |
+| **AirPlay** | ✅ AirPlay 1 | ✅ AirPlay 2 | ✅ (Plus) | ✅ |
+| **Tidal Connect** | ✅ (solo ARM, opt-in) | ✅ | ✅ (Plus) | ✅ |
+| **Display HDMI copertina** | ✅ fb-display integrato | ❌ | ❌ | ❌ |
+| **Setup** | flash SD → boot → fatto (~10 min) | setup app | wizard (~30 min) | wizard |
+| **Hardware proprietario** | nessuno — porti il tuo Pi | richiesto | nessuno | nessuno |
+
+Scegli snapMULTI se vuoi **multi-stanza + Pi-DIY + zero cloud + zero abbonamento** in un solo pacchetto. Scegli Sonos se vuoi plug-and-play e non ti dispiace il prezzo e il vincolo cloud. Scegli Volumio Plus se hai già il loro hardware e l'abbonamento multi-stanza ti sta bene.
+
 ## Sorgenti
 
 | Sorgente | Come |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,49 @@ Play music in sync across every room. Stream from Spotify, AirPlay, your music l
   <em>HDMI display: cover art, spectrum analyzer, track metadata — rendered directly to framebuffer, no desktop needed</em>
 </p>
 
+## How it works
+
+```text
+   Spotify   AirPlay   Tidal   myMPD web UI   any TCP audio app
+      │         │        │           │                │
+      └─────────┴────────┴───────────┴────────────────┘
+                              │
+                              ▼
+                    ┌───────────────────┐
+                    │  Server (Pi / NUC)│  mixes sources, encodes once,
+                    │  snapserver       │  fans out a single audio stream
+                    └───────────────────┘
+                              │  Snapcast over LAN (TCP/UDP)
+                              ▼
+              ┌───────────┬───────────┬──────────────┐
+              │  Pi #1    │  Pi #2    │  Pi #N       │  each runs snapclient
+              │  Living   │  Kitchen  │  Bedroom     │  + a DAC HAT or USB DAC
+              └───────────┴───────────┴──────────────┘
+                              │
+                              ▼
+                          🔊 Speakers
+```
+
+All clients play in lock-step (~5 ms drift across rooms). Add a client by flashing another SD and inserting it in any Pi — no IP config, no pairing, mDNS auto-discovers the server. Server and one client can run on the same Pi (`both` mode).
+
+## Why snapMULTI
+
+| | snapMULTI | Sonos | Volumio | MoOde |
+|---|---|---|---|---|
+| **Cost per room** | ~€60 (Pi 4 + DAC HAT) | €200+ (One SL) | ~€60 hardware + Volumio Plus subscription for multi-room | ~€60 hardware |
+| **Open source** | ✅ GPL-3.0 | ❌ proprietary | Partial (multi-room is paid) | ✅ |
+| **Multi-room sync** | ✅ Snapcast (~5 ms) | ✅ proprietary | ✅ (with Plus) | ❌ single device |
+| **Cloud-free** | ✅ all local | ❌ Sonos cloud required | Partial | ✅ |
+| **Telemetry** | ❌ none, none planned | ✅ collected by default | Partial | ❌ |
+| **Spotify Connect** | ✅ Premium | ✅ | ✅ (Plus) | ✅ |
+| **AirPlay** | ✅ AirPlay 1 | ✅ AirPlay 2 | ✅ (Plus) | ✅ |
+| **Tidal Connect** | ✅ (ARM only, opt-in) | ✅ | ✅ (Plus) | ✅ |
+| **HDMI cover-art display** | ✅ built-in fb-display | ❌ | ❌ | ❌ |
+| **Setup** | flash SD → boot → done (~10 min) | app setup | wizard (~30 min) | wizard |
+| **First-party hardware** | none — bring your own Pi | required | none | none |
+
+Pick snapMULTI when you want **multi-room + Pi-DIY + zero cloud + zero subscription** in one package. Pick Sonos when you want plug-and-play and don't mind the price tag and the cloud lock-in. Pick Volumio Plus when you already own its hardware and the multi-room subscription is OK with you.
+
 ## Sources
 
 | Source | How |


### PR DESCRIPTION
## Summary

Two README enrichments from the council audit P2 list — both pure additions, no behaviour changes.

### 1. How it works — architecture diagram

ASCII topology diagram between the value-prop and the source list. Shows the data flow: sources (Spotify, AirPlay, Tidal, MPD, TCP) → server (Pi/NUC) → Snapcast over LAN → N clients (each with DAC HAT) → speakers. Calls out:
- ~5 ms drift across rooms
- mDNS auto-discovery (no IP config)
- `both` mode where server and one client coexist on the same Pi

### 2. Why snapMULTI — alternatives comparison

Honest comparison vs the three alternatives a Reddit/HN reader is most likely to mention:

| | snapMULTI | Sonos | Volumio | MoOde |
|---|---|---|---|---|
| Cost per room | ~€60 | €200+ | ~€60 + Plus subscription for multi-room | ~€60 |
| Open source | ✅ | ❌ | Partial | ✅ |
| Multi-room | ✅ | ✅ | with Plus | ❌ |
| Cloud-free | ✅ | ❌ | Partial | ✅ |

(table is more complete in the README — Spotify/AirPlay/Tidal coverage, telemetry, HDMI display, setup time, hardware lock-in.)

Followed by a 3-sentence "pick X when..." guide so readers can self-select.

## Italian sync

`README.it.md` updated in the same commit (translation, not a separate PR) per the project's `.it.md` SSOT rule.

## Why now

Closes the remaining "Reddit hooks" identified by the council audit:
- "Why not just use Sonos?" — answered in the table
- "How does it actually work?" — answered in the diagram
- "Where does the audio come from?" — answered by the source-flow arrows

🤖 Generated with [Claude Code](https://claude.com/claude-code)