### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-10
+
+Community-launch release. Folds 14 PRs (#321–#335) on top of v0.6.6:
+boot-pipeline hardening (lazy automount for NFS/SMB, non-blocking reboot,
+single mount-authority via systemd .mount units), metadata-plugin bug
+hunt (3 latent races + 1 thread-safety + 1 fuzzy-match collision),
+Tidal progress-bar fix, install-flow alignment (Windows parity, docker/
+copy, cmdline ordering), community-launch artifacts (CONTRIBUTING.md +
+.it.md, CODE_OF_CONDUCT.md, THIRD-PARTY-NOTICES.md, hardware table,
+architecture diagram), and one round of doc-vs-code reconciliation
+(SECURITY.md SMB credentials line, USAGE.md polling interval, port
+SSOT). Reflash recommended over in-place upgrade (DEC-003).
+
 ### Added
 - **Pre-flight port-conflict check covers 5 more host-bound ports** — `deploy.sh:start_services` previously only probed 1704 / 1705 / 1780 / 6600 / 8082 / 8083 / 8180. With `network_mode: host` for the whole stack, a foreign daemon already listening on a snapMULTI port surfaces as a mysterious container crash at compose-up. The check now also covers 2019 (tidal-connect TCP control), 4953 (snapserver TCP input source), 5000 (shairport-sync RTSP), 5858 (`meta_shairport` cover-art HTTP), and 24879 (go-librespot WebSocket API — localhost only but listed for completeness). Mirrors exactly the port list documented in `docs/USAGE.md` "Port conflicts". Comment block in the loop header points future readers at the same SSOT
 - **`CONTRIBUTING.md` test commands** — both English and Italian versions now include `bash tests/run-all-tests.sh` (the BATS-style bash suite, 34 files, 500+ assertions) and `pytest tests/ -v` (Python plugin tests under `tests/conftest.py` + `tests/test_meta_*.py`) in the local pre-commit checklist. Aligns the contributor onboarding with the test pipeline that actually runs in CI. `ruff` was deliberately NOT added — there is no `pyproject.toml` / `ruff.toml` configuring rules, so a bare `ruff check .` would surface arbitrary defaults rather than the project's chosen style. A separate PR is needed to land a ruff config first


### PR DESCRIPTION
## Summary

Community-launch release. Folds 14 PRs (#321–#335) on top of v0.6.6.

This PR contains a single-file change to `CHANGELOG.md`: rename `[Unreleased]` → `[0.7.0] — 2026-05-10`, add a fresh empty `[Unreleased]` block on top, and a release-summary paragraph. All other changes were merged in their respective PRs.

## What's in v0.7.0

### Boot-pipeline hardening
- NFS/SMB mounts now lazy via systemd `.automount` — server boots regardless of NAS state (#334)
- `firstboot.sh` final reboot is non-blocking (`systemctl reboot --no-block`) — no deadlock under `cloud-final.service` (#334)
- Single mount-authority via `.mount` units — no `/etc/fstab` fallback, overlayroot-immune (#325)
- Avahi readiness wait + mDNS self-heal for first-boot SRV/TXT (#316)

### Metadata-plugin bug hunt
- Thread-safety lock around OrderedDict cache mutations (#333)
- Sala/Sala-Grande collision-safe resolver (exact match + `snapclient-` prefix, no fuzzy regex) (#333)
- MusicBrainz rate limiter releases lock before `time.sleep()` (#333)
- `ws_clients` set race vs `_broadcast_server_info` (#329)
- Non-blocking stdin partial-UTF-8 chunk handling (#329)
- Orphan `</item>` overflow (10 MB) (#329)
- 100% CPU busy-loop on closed stdin (#330)
- Tidal progress bar parser fixed (TUI panel `x` char) (#332)

### Install-flow alignment
- Windows `prepare-sd.ps1` parity: `docker/` copy + advanced install.conf keys (#323)
- Cmdline ordering for client/both installs (#322)
- `docker/` directory copy to `/opt/snapmulti/` for metadata bind-mount (#321)
- `deploy.sh` skips `install_dependencies` when firstboot already provisioned (#324)

### Community artifacts
- `CONTRIBUTING.md` + `.it.md` (#326, #328)
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) (#326)
- `THIRD-PARTY-NOTICES.md` (full GPL attribution + Tidal redistribution disclosure) (#326, #334)
- Hardware table revamp (Recommended/Server-only/Not-supported) (#326)
- Architecture diagram + comparison vs Sonos/Volumio/MoOde (#327)
- README value-prop opening + port SSOT pointer (#326, #328)

### Doc-vs-code reconciliation
- `SECURITY.md` SMB credentials line (no longer `/etc/fstab`) (#334)
- `USAGE.md` polling interval (every 3s with PR #95 attribution) (#335)
- Port conflict SSOT: 12 ports across `deploy.sh`, `USAGE.md` inline, `USAGE.md` table (#335)
- `CONTRIBUTING.md` test commands include `bash tests/run-all-tests.sh` + `pytest tests/ -v` (#335)

## Validation

Done locally:
- [x] CHANGELOG.md structure validated (`grep '^## \['` shows correct ordering)
- [x] Pre-push hook full pass (shellcheck + hadolint + compose syntax)
- [x] All 14 component PRs are already merged with green CI

Deferred to release-gate:
- [ ] Tag `v0.7.0` after this PR merges → triggers `build-push.yml`
- [ ] Build matrix amd64 (`snapcast-runner`) + arm64 (`ARM64`) → push `lollonet/snapmulti-{server,airplay,mpd,metadata,tidal}:0.7.0` + `:latest`
- [ ] Reflash `snapvideo` with `IMAGE_TAG=0.7.0` (or `:latest` after build) — verify lazy automount + non-blocking reboot end-to-end
- [ ] `gh release create v0.7.0` with release notes

## Reflash recommended

Per DEC-003 (reflash-first), users on v0.6.x should reflash to v0.7.0 rather than attempt in-place upgrade. The `.mount → .automount` migration in `mount-music.sh` is idempotent (disable old `.mount` symlink before enabling `.automount`), so technically in-place would work — but reflash is the supported path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)