### PR TITLE
fix(smoke): allowlist man-db.service (overlayroot EAGAIN race)

### DIFF
--- a/scripts/smoke/check_boot_health.sh
+++ b/scripts/smoke/check_boot_health.sh
@@ -83,6 +83,13 @@ check_boot_health() {
         # when firstboot.sh succeeded. snapmulti's own checkpoint files
         # are the real source of truth for install completion.
         "cloud-init-main.service"
+        # Debian's daily man-page index regeneration races with the
+        # fuse-overlayfs upper layer on /var/cache/man — `mandb` aborts
+        # with "Resource temporarily unavailable" (EAGAIN) on overlayroot.
+        # Caught on pi4nohat 2026-05-10: the per-locale subdir creation
+        # (/var/cache/man/pt_BR/<PID>) races with fuse-overlayfs file
+        # ops. Not snapMULTI-related and we don't ship man pages anyway.
+        "man-db.service"
     )
 
     local sys_state


### PR DESCRIPTION
## Summary

Adds `man-db.service` to the `check_boot_health.sh` allowlist alongside the existing `rpi-resize-swap-file.service` and `cloud-init-main.service` entries.

## Why

Debian's daily `man-db.timer` triggers `mandb --quiet` which writes per-locale subdirs under `/var/cache/man/`. On fuse-overlayfs the subdir creation races with the upper-layer file ops and aborts with EAGAIN — a kernel-level retryable error, not a real fault. The service stays in `failed (Result: exit-code)` until the next firing.

Caught on **pi4nohat** (Pi 4 2GB, no HAT, internal BCM2835 audio) on 2026-05-10:
```
× man-db.service - Daily man-db regeneration
   mandb: can't create index cache /var/cache/man/pt_BR/40723: Resource temporarily unavailable
```

Same RO-FS-incompatibility family as the existing allowlist entries.

## Validation

**Done locally:**
- Verified fix on pi4nohat: deployed patched module to `/tmp/smoke-test/smoke/`, re-ran smoke
- **Before**: `[ERROR] systemd state degraded — 1 unexpected failed unit(s): man-db.service`
- **After**: `[OK] systemd is-system-running: degraded (only expected failures: 2 unit(s) on the readonly-FS allowlist)`
- shellcheck PASS (`shellcheck -x -S warning scripts/smoke/check_boot_health.sh`)

**Deferred to release-gate:**
- N/A — smoke-only change, no runtime/install impact. Will land in v0.7.2 device-smoke validation.

## Context

Found during fleet validation after PR #338 merge: ran smoke on the 6th device (pi4nohat) which surfaced this Debian stock-service quirk. The other 5 devices either don't trigger the EAGAIN race deterministically or `man-db.timer` hasn't fired yet on them.