### PR TITLE
fix(smoke): lower /run warn floor 200→180 MB for Pi 3B+ false-warn

### DIFF
--- a/scripts/smoke/check_system.sh
+++ b/scripts/smoke/check_system.sh
@@ -132,7 +132,12 @@ check_system() {
     if (( total_mb >= 3500 )); then
         floor_warn=1024; floor_fail=800;  expected_class="≥4 GB Pi"
     elif (( total_mb >= 900 )); then
-        floor_warn=200;  floor_fail=150;  expected_class="1-2 GB Pi"
+        # Pi 3B+ 1 GB on a clean reflash gets 191 MB (~20% of 955 MB MemTotal);
+        # boot-tune.sh does not remount /run (only the overlayroot tmpfs) and
+        # systemd-default has been observed adequate for the containerd
+        # self-heal pattern. 180 MB lets the systemd default pass cleanly
+        # while still catching genuine misconfiguration (<150 MB = fail).
+        floor_warn=180;  floor_fail=150;  expected_class="1-2 GB Pi"
     else
         floor_warn=80;   floor_fail=60;   expected_class="<1 GB Pi (Zero/Zero 2W)"
     fi


### PR DESCRIPTION
## Summary

`/run` tmpfs warn floor was 200 MB for the 1-2 GB Pi class. A freshly-reflashed Pi 3B+ sits at ~191 MB (systemd default ~20% of 955 MB MemTotal). boot-tune.sh only remounts the *overlayroot* tmpfs, not `/run`, so every Pi 3B+ smoke run emitted a noisy warning even though the system was healthy.

## Why now

Surfaced by today's fleet smoke (PR #349):

```
pi3hat               client  v0.7.3          PASS    0      1 warning(s)
```

The single warning was: `/run tmpfs size: 191 MB on 955 MB RAM (below 200 MB warn floor for 1-2 GB Pi — containerd may false-ENOSPC under apt install)`. Investigation showed the inline comment **already** acknowledges 191 MB as "within design budget" — the rule and the comment had drifted apart.

## Fix

Lower `floor_warn` from 200 → 180 MB for 1-2 GB Pi class. `floor_fail=150` unchanged — that's the real containerd-trouble threshold.

| RAM class | warn (was) | warn (now) | fail |
|---|---|---|---|
| ≥4 GB | 1024 | 1024 | 800 |
| **1-2 GB** | **200** | **180** | 150 |
| <1 GB (Zero/Zero 2W) | 80 | 80 | 60 |

## Validation

Live-tested on `pi3hat` (Pi 3B+ 1 GB, 191 MB `/run`):

```json
{
  "warns": 0,
  "fails": 0,
  "run_check": [
    {
      "section": "System",
      "status": "pass",
      "msg": "/run tmpfs size: 191 MB on 955 MB RAM (1-2 GB Pi floor ≥180 MB)"
    }
  ]
}
```

- shellcheck-clean (`scripts/smoke/check_system.sh`)
- bash -n syntax pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)