### PR TITLE
fix(ci): snapclient binary lives in src/bin/, not src/build/client/

### DIFF
--- a/scripts/ci/build-snapclient-deb.sh
+++ b/scripts/ci/build-snapclient-deb.sh
@@ -60,7 +60,7 @@ mkdir -p "$PKG_ROOT/usr/bin" "$PKG_ROOT/DEBIAN" \
          "$PKG_ROOT/lib/systemd/system" "$PKG_ROOT/etc/default" \
          "$PKG_ROOT/usr/share/doc/snapclient"
 
-install -m 755 src/build/client/snapclient "$PKG_ROOT/usr/bin/snapclient"
+install -m 755 src/bin/snapclient "$PKG_ROOT/usr/bin/snapclient"
 
 cat > "$PKG_ROOT/DEBIAN/control" <<EOF
 Package: snapclient


### PR DESCRIPTION
## Summary
- `scripts/ci/build-snapclient-deb.sh` was installing the binary from the wrong path: `src/build/client/snapclient`. snapcast's CMakeLists sets `RUNTIME_OUTPUT_DIRECTORY` to `<source>/bin`, so the actual location is `src/bin/snapclient`.
- All 4 matrix builds for tag `snapclient-deb/v0.35.0-snapmulti1` (run 25748571618) failed at the packaging step with `install: cannot stat 'src/build/client/snapclient': No such file or directory`. The compilation itself completed cleanly (`[100%] Built target snapclient`).
- One-line path fix.

## Validation
- Done locally: shellcheck + `bash -n` on the modified script.
- Deferred to release-gate: re-tagging `snapclient-deb/v0.35.0-snapmulti1` (will need to delete the failed tag first) once this lands on main, then watching the workflow produce 4 `.deb` files + a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)