### PR TITLE
docs: micro-fixes for community polish

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -72,7 +72,7 @@ Lo script chiede: **Audio Player** (solo altoparlante) / **Music Server** (Spoti
 
 ### 4. Avvia il Pi
 
-Espelli l'SD, inseriscila nel Pi, accendi. Aspetta ~10 minuti. L'installer al primo boot gira senza SSH, mostra l'avanzamento su HDMI se hai uno schermo collegato. Fatto.
+Espelli l'SD, inseriscila nel Pi, accendi. Aspetta circa 10-15 minuti. L'installer al primo boot gira senza SSH, mostra l'avanzamento su HDMI se hai uno schermo collegato. Fatto.
 
 > **Procedura dettagliata** con screenshot e troubleshooting: [docs/INSTALL.it.md](docs/INSTALL.it.md).
 > **Matrice di compatibilità** (modelli Pi, DAC HAT, setup di rete): [docs/HARDWARE.it.md](docs/HARDWARE.it.md).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The script asks: **Audio Player** (speaker only) / **Music Server** (Spotify+Air
 
 ### 4. Boot the Pi
 
-Eject SD, insert in the Pi, power on. Wait ~10 minutes. The first-boot installer runs without SSH, shows progress on HDMI if you have a screen attached. Done.
+Eject SD, insert in the Pi, power on. Wait about 10-15 minutes. The first-boot installer runs without SSH, shows progress on HDMI if you have a screen attached. Done.
 
 > **Detailed walk-through** with screenshots and troubleshooting: [docs/INSTALL.md](docs/INSTALL.md).
 > **Compatibility matrix** (which Pi models, DAC HATs, network setups): [docs/HARDWARE.md](docs/HARDWARE.md).

--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -40,7 +40,7 @@ Se la tua libreria è su un NAS (Synology, QNAP, server Linux generico, condivis
 | Protocollo | Quando | Note |
 |------------|--------|------|
 | NFS | NAS Linux / Synology / QNAP, allow-list per IP | `prepare-sd.sh` scrive una coppia `.mount`/`.automount` systemd; nessuna password |
-| SMB / CIFS | Condivisione Windows, Synology / QNAP con username + password | Le credenziali finiscono in `install.conf` sulla partizione FAT32 durante `prepare-sd.sh` e `firstboot.sh`, poi vengono cancellate e persistite in `/etc/snapmulti-smb-credentials` (root-only, su ext4) |
+| SMB / CIFS | Condivisione Windows, Synology / QNAP con username + password | `prepare-sd.sh` scrive temporaneamente le credenziali in `install.conf` sulla partizione FAT32. Al primo boot, `firstboot.sh` le copia in `/etc/snapmulti-smb-credentials` con permessi root-only e poi le rimuove da `install.conf` |
 | USB | Disco collegato al Pi | Auto-montato da `udisks2`; scegli l'UUID della partizione nel menu |
 | Locale | File copiati in `/audio` sul Pi | Default per chi inizia |
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -40,7 +40,7 @@ If your library lives on a NAS (Synology, QNAP, generic Linux server, Windows sh
 | Protocol | When | Notes |
 |----------|------|-------|
 | NFS | Linux / Synology / QNAP NAS, allow-list by IP | `prepare-sd.sh` writes a systemd `.mount`/`.automount` pair; no password |
-| SMB / CIFS | Windows share, Synology / QNAP with username + password | Credentials are written into `install.conf` on the FAT32 boot partition during `prepare-sd.sh` and `firstboot.sh`, then scrubbed and persisted in `/etc/snapmulti-smb-credentials` (root-only, on ext4) |
+| SMB / CIFS | Windows share, Synology / QNAP with username + password | `prepare-sd.sh` writes the credentials temporarily into `install.conf` on the FAT32 boot partition. On first boot, `firstboot.sh` copies them to `/etc/snapmulti-smb-credentials` with root-only permissions and then removes them from `install.conf` |
 | USB | Drive plugged into the Pi | Auto-mounted by `udisks2`; pick the partition UUID in the menu |
 | Local | Files copied into `/audio` on the Pi | Default for first-time users |
 

--- a/docs/TROUBLESHOOTING.it.md
+++ b/docs/TROUBLESHOOTING.it.md
@@ -125,12 +125,21 @@ Output JSON per script / dashboard: `sudo bash /opt/snapmulti/scripts/device-smo
 **Causa probabile.** Path share NAS errato (snapMULTI rifiuta path con spazi — il default Synology `Music Share` va rinominato `Music_Share`), credenziali SMB sbagliate, export NFS non autorizzato per l'IP del Pi, o `.automount` systemd che non si è abilitato.
 
 **Cosa provare.**
-1. Sul server: identifica il nome della mount unit (systemd-escapa il path) e controlla il suo stato. I mount point predefiniti sono `/media/nfs-music` o `/media/smb-music`:
+1. Sul server: identifica il nome della mount unit (systemd-escapa il path) e controlla il suo stato. I mount point predefiniti sono `/media/nfs-music` per NFS o `/media/smb-music` per SMB — sostituisci con quello che corrisponde al tuo install:
    ```bash
+   # Install NFS:
    systemctl status "$(systemd-escape -p --suffix=automount /media/nfs-music)"
    systemctl status "$(systemd-escape -p --suffix=mount /media/nfs-music)"
+   # Install SMB:
+   systemctl status "$(systemd-escape -p --suffix=automount /media/smb-music)"
+   systemctl status "$(systemd-escape -p --suffix=mount /media/smb-music)"
    ```
-2. Prova un mount manuale con lo stesso path: `sudo mount -t nfs <nas>:<share> /mnt/test` o `sudo mount -t cifs ...`. Il messaggio d'errore è più informativo di quello di systemd.
+2. Prova un mount manuale con lo stesso path contro una directory temporanea. Il messaggio d'errore è più informativo di quello di systemd:
+   ```bash
+   sudo mkdir -p /mnt/test
+   sudo mount -t nfs <nas>:<share> /mnt/test       # NFS
+   sudo mount -t cifs //<nas>/<share> /mnt/test    # SMB (aggiungi -o username=...,password=...)
+   ```
 3. Verifica che il path non abbia **spazi** lato NAS. Rinomina `Music Share` → `Music_Share`.
 4. Per SMB, le credenziali persistenti vivono in `/etc/snapmulti-smb-credentials` (root-only, su ext4). Vengono scritte anche dentro `install.conf` sulla partizione FAT32 di boot durante `prepare-sd.sh` e `firstboot.sh`, poi rimosse una volta che `mount-music` le ha copiate in `/etc/snapmulti-smb-credentials`.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -125,12 +125,21 @@ JSON for scripts / dashboards: `sudo bash /opt/snapmulti/scripts/device-smoke.sh
 **Likely cause.** NAS share path mismatch (snapMULTI rejects paths with spaces — Synology's default `Music Share` must be renamed `Music_Share`), wrong username / password for SMB, NFS export not allowed for the Pi's IP, or the systemd `.automount` failed to enable.
 
 **Try this.**
-1. On the server: identify the mount unit name (systemd-escapes the mount path) and check its state. Default mount points are `/media/nfs-music` or `/media/smb-music`:
+1. On the server: identify the mount unit name (systemd-escapes the mount path) and check its state. Default mount points are `/media/nfs-music` for NFS or `/media/smb-music` for SMB — substitute the one that matches your install:
    ```bash
+   # NFS install:
    systemctl status "$(systemd-escape -p --suffix=automount /media/nfs-music)"
    systemctl status "$(systemd-escape -p --suffix=mount /media/nfs-music)"
+   # SMB install:
+   systemctl status "$(systemd-escape -p --suffix=automount /media/smb-music)"
+   systemctl status "$(systemd-escape -p --suffix=mount /media/smb-music)"
    ```
-2. Try a manual mount with the same path: `sudo mount -t nfs <nas>:<share> /mnt/test` or `sudo mount -t cifs ...`. The error message is more informative than the systemd one.
+2. Try a manual mount with the same path against a throwaway target. The error message is more informative than the systemd one:
+   ```bash
+   sudo mkdir -p /mnt/test
+   sudo mount -t nfs <nas>:<share> /mnt/test       # NFS
+   sudo mount -t cifs //<nas>/<share> /mnt/test    # SMB (add -o username=...,password=...)
+   ```
 3. Check the path has **no spaces** on the NAS side. Rename `Music Share` → `Music_Share`.
 4. For SMB, the persistent credentials live in `/etc/snapmulti-smb-credentials` (root-only, on ext4). They are also written into `install.conf` on the FAT32 boot partition during `prepare-sd.sh` and `firstboot.sh`, then scrubbed once `mount-music` has copied them to `/etc/snapmulti-smb-credentials`.
 


### PR DESCRIPTION
## Summary

Three small docs-only consistency fixes on top of PR #398. No runtime, scripts, tests, or architecture touched.

- **README.md / .it.md** — first-boot wait time aligned with `INSTALL.md`. README said `Wait ~10 minutes` / `Aspetta ~10 minuti`, INSTALL said `10-15 min`. Reader gets the same number in both docs now.
- **TROUBLESHOOTING.md / .it.md** — NAS section: the `systemctl status \"\$(systemd-escape ...)\"` example only showed `/media/nfs-music`. Now it shows both `/media/nfs-music` (NFS install) and `/media/smb-music` (SMB install) side-by-side so users don't have to guess. Manual-mount example now does `sudo mkdir -p /mnt/test` before the `mount` call.
- **ADVANCED.md / .it.md** — SMB credentials table cell rewritten into a clear two-step lifecycle: `prepare-sd.sh` writes them temporarily to `install.conf` on FAT32, then `firstboot.sh` copies them to `/etc/snapmulti-smb-credentials` with root-only permissions and removes them from `install.conf`. Replaces the previous fused sentence that was harder to parse.

Reflash-first policy preserved — no references to non-existent scripts or manual-recovery-as-default. EN / IT kept in sync.

## Validation

Done locally:
- `rg -n \"Wait ~10|Aspetta ~10|rename the folder|setup_music_source\\.sh|/etc/credentials\\.smb|never on the FAT32|no terminal required\" README.md README.it.md docs` → zero matches