### PR TITLE
fix(firstboot): banner lists every user-facing URL

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -1301,6 +1301,7 @@ case "$INSTALL_TYPE" in
         fi
         _tty "  Library:   http://${LOCAL_HOSTNAME}.local:8180"
         _tty "  Status:    http://${LOCAL_HOSTNAME}.local:8083  (system health page)"
+        _tty "  Stream in: tcp://${LOCAL_HOSTNAME}.local:4953  (push audio from Android/Termux/ffmpeg)"
         ;;
     client)
         _tty "  Player will auto-discover your server"

--- a/tests/test_firstboot_reboot.sh
+++ b/tests/test_firstboot_reboot.sh
@@ -73,6 +73,20 @@ assert 'grep -qF "Snapweb:   http://\${LOCAL_HOSTNAME}.local:1780" "$FIRSTBOOT"'
 assert '! grep -qF "Speakers:  http://" "$FIRSTBOOT"' \
        'completion banner no longer labels Snapweb as Speakers'
 
+# Every user-facing URL the project publishes must appear in the banner.
+# Snapweb 1780, myMPD 8180, Status 8083, and the TCP audio input 4953
+# (documented in config/snapserver.conf:69 and docs/USAGE.md) are all
+# end-user endpoints. The Snapcast streaming/RPC ports (1704/1705) and
+# the metadata WS (8082) are intentionally omitted — internal protocol.
+assert 'grep -qF "Library:   http://\${LOCAL_HOSTNAME}.local:8180" "$FIRSTBOOT"' \
+       'completion banner names myMPD library URL'
+
+assert 'grep -qF "Status:    http://\${LOCAL_HOSTNAME}.local:8083" "$FIRSTBOOT"' \
+       'completion banner names Status page URL'
+
+assert 'grep -qF "Stream in: tcp://\${LOCAL_HOSTNAME}.local:4953" "$FIRSTBOOT"' \
+       'completion banner names TCP audio input URL (Android/Termux/ffmpeg)'
+
 echo
 echo "=== firstboot.sh — installed systemd unit permissions ==="
 


### PR DESCRIPTION
## Summary

Audit of the install completion banner against the URLs published by the project (`docker-compose.yml` host-network bindings + `config/snapserver.conf` listen ports + `docs/USAGE.md` Control Interfaces table). Found one user-facing endpoint missing.

## Audit

| URL | Source | Banner before | Banner after |
|-----|--------|---------------|--------------|
| Snapweb \`:1780\` | USAGE.md, snapserver.conf | ✅ | ✅ |
| myMPD \`:8180\` | USAGE.md | ✅ "Library" | ✅ |
| Status \`:8083\` | metadata-service.py (root → /status redirect) | ✅ | ✅ |
| **TCP audio in \`:4953\`** | **snapserver.conf:69, USAGE.md "Streaming from Android"** | **❌ missing** | **✅ added** |

Internal ports intentionally omitted from the banner (Snapcast streaming 1704, RPC 1705, metadata WS 8082) — consumed by other containers/clients, not by the end user.

## Validation

Done locally:
- \`tests/test_firstboot_reboot.sh\` — 14/14 PASS (+3 assertions covering Library / Status / Stream-in)
- \`shellcheck -S warning scripts/firstboot.sh\` clean
- \`bash -n scripts/firstboot.sh\` clean

Deferred to release-gate:
- Live banner check on next reflash

## CHANGELOG note

No \`CHANGELOG.md\` change in this commit to avoid a conflict with the v0.7.5 \`[Unreleased]\` entries from PR #400. Will be folded into the release tag commit.