### PR TITLE
fix(deploy): server mem-drift force-recreate (symmetric to PR #393)

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -252,6 +252,27 @@ if ! declare -F detect_hat &>/dev/null; then
     exit 1
 fi
 
+# Source single-owner systemd snippet helper (scripts/common/systemd-snippets.sh).
+# The helper lives in the server tree because deploy.sh owns the same
+# snippets; setup.sh walks a candidate list to find it across the four
+# layouts in which setup.sh can run: dev tree, baked install dir,
+# firstboot SD-card mount, and rare standalone re-run from /opt.
+# Hard-fail on miss — silently generating units without the helpers
+# would produce service files missing critical ExecStartPre lines.
+for _snippets_candidate in \
+    "$SCRIPT_DIR/systemd-snippets.sh" \
+    "$SCRIPT_DIR/common/systemd-snippets.sh" \
+    "$SCRIPT_DIR/../../../scripts/common/systemd-snippets.sh" \
+    "$COMMON_DIR/../scripts/common/systemd-snippets.sh" \
+    "/boot/firmware/common/systemd-snippets.sh"; do
+    # shellcheck source=../../../scripts/common/systemd-snippets.sh
+    [[ -f "$_snippets_candidate" ]] && source "$_snippets_candidate" && break
+done
+if ! declare -F compose_stop_5s_execstop &>/dev/null; then
+    echo "FATAL: systemd-snippets.sh not found in any candidate path" >&2
+    exit 1
+fi
+
 # Ensure HAT detection tools are present BEFORE we call detect_hat. On
 # minimal Pi OS images neither alsa-utils (aplay), i2c-tools (i2cdetect),
 # nor kmod (modprobe) are installed by default; without them, detect_hat
@@ -1268,13 +1289,13 @@ RequiresMountsFor=${INSTALL_DIR}
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=${INSTALL_DIR}
-ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do docker info >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'
+$(docker_info_ready_execstartpre)
 # Wait for avahi-daemon readiness before snapclient-discover and \`docker
 # compose up\`. snapclient-discover queries _snapcast._tcp via avahi-browse;
 # snapclient's libavahi-client also needs avahi ready to react to server
 # restarts. Non-fatal: 30 s max wait, then proceed (avahi may be missing
 # in unusual setups).
-ExecStartPre=/bin/bash -c 'for i in \$(seq 1 30); do systemctl is-active --quiet avahi-daemon.service && [[ -S /run/avahi-daemon/socket ]] && break; sleep 1; done; sleep 2'
+$(avahi_daemon_ready_execstartpre)
 ExecStartPre=-/usr/local/bin/snapclient-discover
 # Detect-and-recreate on mem_limit drift: the snapclient container is
 # created during firstboot.sh BEFORE the final reboot that activates
@@ -1289,7 +1310,7 @@ ExecStartPre=-/usr/local/bin/snapclient-discover
 # byte count once recreated, and empty when the container does not
 # yet exist (fresh reflash) — all three cases lead to the correct
 # decision (recreate only when memory == 0).
-ExecStartPre=-/bin/bash -c 'mem=\$(/usr/bin/docker inspect snapclient --format "{{.HostConfig.Memory}}" 2>/dev/null || true); if [[ "\$\$mem" == "0" ]]; then cd ${INSTALL_DIR} && /usr/bin/docker compose up -d --force-recreate; fi'
+$(mem_drift_recreate_execstartpre snapclient "${INSTALL_DIR}")
 ExecStart=/usr/bin/docker compose up -d
 # Non-destructive stop: see scripts/deploy.sh for full rationale. In
 # short, \`compose stop\` halts the snapclient container processes
@@ -1297,7 +1318,7 @@ ExecStart=/usr/bin/docker compose up -d
 # \`systemctl restart\` is a fast \`start\` not a recreate. Operators
 # call \`docker compose down\` manually from \${INSTALL_DIR} when a
 # destructive teardown is actually needed.
-ExecStop=/usr/bin/docker compose stop -t 5
+$(compose_stop_5s_execstop)
 TimeoutStartSec=180
 Restart=on-failure
 RestartSec=10

--- a/scripts/common/systemd-snippets.sh
+++ b/scripts/common/systemd-snippets.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# systemd-snippets.sh — single owner of ExecStartPre/Post/Stop snippets
+# shared between snapmulti-server.service (scripts/deploy.sh:1034) and
+# snapclient.service (client/common/scripts/setup.sh:1243).
+#
+# Before this consolidation, four identical (modulo container name +
+# project-dir variable) snippets were inlined twice each — one in the
+# server unit, one in the client unit — and any drift between them
+# would have surfaced only at runtime on the device. Cluster surfaced
+# by code-architecture-auditor after PR #402; bundled with #402 per
+# "narrative-coherent fixes go in one PR" rule.
+#
+# Contract:
+#   - Every helper prints exactly one unit-file line to stdout, no
+#     trailing newline. Consumed via `$(helper)` substitution inside an
+#     unquoted heredoc (the trailing newline that `$()` already strips
+#     would otherwise need explicit handling).
+#   - Output text is literal: bash's heredoc substitution drops the
+#     command-substitution result in as plain characters and does NOT
+#     re-process `$(...)` or `$VAR` inside it. So the snippet helpers
+#     embed `$(seq …)` and `$$mem` literally — systemd then interprets
+#     them at unit-execution time.
+#   - Helpers take no environment dependencies. The only parameter is
+#     for the mem-drift helper, which is parameterized on container
+#     name and compose project dir.
+#
+# Sourced by:
+#   scripts/deploy.sh                          (server unit generator)
+#   client/common/scripts/setup.sh             (client unit generator)
+#
+# Path resolution from setup.sh is fallback-based (firstboot, dev tree,
+# baked install) — see setup.sh for the candidate list. deploy.sh has a
+# single predictable path.
+
+# Source guard: re-sourcing is harmless (function redefinitions only),
+# but skip the work on repeat to keep the load-time profile flat.
+[[ -n "${_SNAPMULTI_SYSTEMD_SNIPPETS_LOADED:-}" ]] && return 0
+_SNAPMULTI_SYSTEMD_SNIPPETS_LOADED=1
+
+# ExecStartPre that waits for `docker info` to succeed (≤ 120 s).
+# Used by both server and client to gate compose-up on a healthy
+# Docker daemon. Hard-fail (exit 1) is intentional: with no daemon
+# there is nothing to start.
+docker_info_ready_execstartpre() {
+    printf 'ExecStartPre=/bin/bash -c %s' \
+        "'for i in \$(seq 1 60); do docker info >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'"
+}
+
+# ExecStartPre that waits for avahi-daemon readiness (≤ 30 s + 2 s
+# settle). Mitigates the snapcast 0.35 mDNS reconnect bug: if
+# libavahi-client connects before avahi is fully up it falls back to
+# PTR-only multicast and strict zeroconf clients (Python zeroconf,
+# dns-sd, snapclient ≥ 0.36) fail to discover. Non-fatal: falls through
+# silently when avahi is absent.
+avahi_daemon_ready_execstartpre() {
+    printf 'ExecStartPre=/bin/bash -c %s' \
+        "'for i in \$(seq 1 30); do systemctl is-active --quiet avahi-daemon.service && [[ -S /run/avahi-daemon/socket ]] && break; sleep 1; done; sleep 2'"
+}
+
+# ExecStartPre that detects HostConfig.Memory=0 drift (created before
+# cgroup memory v2 was active) and force-recreates the compose stack.
+# Args:
+#   $1 — container name (snapserver | snapclient)
+#   $2 — compose project directory (interpolated at generation time)
+# Empty inspect output (fresh reflash, no container yet) returns "",
+# which is neither "0" nor a byte count, so the recreate is skipped.
+# The `=-` (ignore-failure) prefix is intentional: a flaky probe must
+# not block ExecStart.
+mem_drift_recreate_execstartpre() {
+    local container="${1:?container name required}"
+    local project_dir="${2:?compose project dir required}"
+    printf 'ExecStartPre=-/bin/bash -c %s' \
+        "'mem=\$(/usr/bin/docker inspect ${container} --format \"{{.HostConfig.Memory}}\" 2>/dev/null || true); if [[ \"\$\$mem\" == \"0\" ]]; then cd ${project_dir} && /usr/bin/docker compose up -d --force-recreate; fi'"
+}
+
+# ExecStop using `compose stop -t 5`, NOT `compose down`. Non-destructive:
+# halts container processes (5 s grace) but leaves container objects
+# and the compose network in place, so a subsequent `systemctl start`
+# re-enters ExecStart=`compose up -d` and `start`s the existing
+# containers — no rebuild, no network teardown, no image re-pull. A
+# `systemctl restart` therefore costs 2-5 s of audio silence instead
+# of the 30-40 s a full `compose down` would cost.
+compose_stop_5s_execstop() {
+    printf 'ExecStop=/usr/bin/docker compose stop -t 5'
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1067,6 +1067,21 @@ ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do docker info >/dev/null 2>&1
 # \`sleep 2\` lets avahi publish its first announce. Non-fatal on
 # unusual setups (no avahi installed) — falls through after 30 s.
 ExecStartPre=/bin/bash -c 'for i in \$(seq 1 30); do systemctl is-active --quiet avahi-daemon.service && [[ -S /run/avahi-daemon/socket ]] && break; sleep 1; done; sleep 2'
+# Detect-and-recreate on mem_limit drift, symmetric to snapclient.service
+# (PR #393). The first compose up during firstboot runs BEFORE the final
+# reboot that activates cgroup memory v2 (cmdline_ensure_memory_cgroup
+# patches cmdline.txt but takes effect only after reboot). So even though
+# deploy.sh:921 invokes \`docker compose up -d --force-recreate\`, the
+# resulting containers are created without cgroup memory v2 →
+# HostConfig.Memory=0. The next \`systemctl start\` (after reboot) runs
+# plain \`compose up -d\`, which is idempotent on existing containers and
+# keeps the limit-less ones. We probe snapserver (representative of the
+# stack — they're all created together) and force-recreate the whole
+# compose project exactly once when drift is detected. Empty inspect
+# output (fresh reflash, no container yet) returns "", neither "0" nor a
+# byte count, so the recreate is skipped — ExecStart will create the
+# containers fresh with proper limits.
+ExecStartPre=-/bin/bash -c 'mem=\$(/usr/bin/docker inspect snapserver --format "{{.HostConfig.Memory}}" 2>/dev/null || true); if [[ "\$\$mem" == "0" ]]; then cd ${PROJECT_ROOT} && /usr/bin/docker compose up -d --force-recreate; fi'
 ExecStart=/usr/bin/docker compose up -d
 # Self-heal mDNS publish race: 12 s after compose up, query the local
 # avahi cache for \`_snapcast._tcp\`. If the PTR record is present but

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,6 +34,8 @@ source "$SCRIPT_DIR/common/system-tune.sh"
 source "$SCRIPT_DIR/common/resource-detect.sh"
 # shellcheck source=common/pull-images.sh
 source "$SCRIPT_DIR/common/pull-images.sh"
+# shellcheck source=common/systemd-snippets.sh
+source "$SCRIPT_DIR/common/systemd-snippets.sh"
 
 # Global: set by preflight_checks based on architecture
 IS_ARM=false
@@ -1057,7 +1059,7 @@ RequiresMountsFor=${PROJECT_ROOT} ${PROJECT_ROOT}/audio${music_mount_clause}
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=${PROJECT_ROOT}
-ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do docker info >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'
+$(docker_info_ready_execstartpre)
 # Wait for avahi-daemon to be fully ready before \`docker compose up\`.
 # Without this, snapserver's libavahi-client connect race-loses against
 # avahi-daemon initialisation and falls back to PTR-only UDP 5353
@@ -1066,7 +1068,7 @@ ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do docker info >/dev/null 2>&1
 # state; the socket existence proves the dbus listener is up; the final
 # \`sleep 2\` lets avahi publish its first announce. Non-fatal on
 # unusual setups (no avahi installed) — falls through after 30 s.
-ExecStartPre=/bin/bash -c 'for i in \$(seq 1 30); do systemctl is-active --quiet avahi-daemon.service && [[ -S /run/avahi-daemon/socket ]] && break; sleep 1; done; sleep 2'
+$(avahi_daemon_ready_execstartpre)
 # Detect-and-recreate on mem_limit drift, symmetric to snapclient.service
 # (PR #393). The first compose up during firstboot runs BEFORE the final
 # reboot that activates cgroup memory v2 (cmdline_ensure_memory_cgroup
@@ -1081,7 +1083,7 @@ ExecStartPre=/bin/bash -c 'for i in \$(seq 1 30); do systemctl is-active --quiet
 # output (fresh reflash, no container yet) returns "", neither "0" nor a
 # byte count, so the recreate is skipped — ExecStart will create the
 # containers fresh with proper limits.
-ExecStartPre=-/bin/bash -c 'mem=\$(/usr/bin/docker inspect snapserver --format "{{.HostConfig.Memory}}" 2>/dev/null || true); if [[ "\$\$mem" == "0" ]]; then cd ${PROJECT_ROOT} && /usr/bin/docker compose up -d --force-recreate; fi'
+$(mem_drift_recreate_execstartpre snapserver "${PROJECT_ROOT}")
 ExecStart=/usr/bin/docker compose up -d
 # Self-heal mDNS publish race: 12 s after compose up, query the local
 # avahi cache for \`_snapcast._tcp\`. If the PTR record is present but
@@ -1115,7 +1117,7 @@ ExecStartPost=-/bin/bash -c '\\
 # of the 30-40 s a full \`compose down\` would cost. If the operator
 # needs a destructive teardown (image upgrade, volume rebuild) they
 # call \`docker compose down\` manually from \${PROJECT_ROOT}.
-ExecStop=/usr/bin/docker compose stop -t 5
+$(compose_stop_5s_execstop)
 TimeoutStartSec=180
 Restart=on-failure
 RestartSec=10

--- a/tests/test_avahi_readiness.sh
+++ b/tests/test_avahi_readiness.sh
@@ -26,6 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_SH="$SCRIPT_DIR/../scripts/deploy.sh"
 SETUP_SH="$SCRIPT_DIR/../client/common/scripts/setup.sh"
 SYSTEM_TUNE_SH="$SCRIPT_DIR/../scripts/common/system-tune.sh"
+SNIPPETS_SH="$SCRIPT_DIR/../scripts/common/systemd-snippets.sh"
 
 pass=0
 fail=0
@@ -41,10 +42,46 @@ assert() {
     fi
 }
 
+# Render the snapmulti-server unit body: extract the heredoc, source the
+# systemd-snippets helper, set the variables the heredoc references, then
+# eval the heredoc body so $(helper) substitutions resolve. This makes
+# the test assert on the FINAL unit content (what systemd sees) rather
+# than the source-file text — assertions stay valid across refactors
+# that move snippet generation behind helpers.
+# shellcheck source=../scripts/common/systemd-snippets.sh
+source "$SNIPPETS_SH"
+
+render_unit() {
+    local script="$1" marker="$2"
+    local body
+    body=$(awk -v m="$marker" '
+        # Match both `cat > X <<EOF` and `cat > X << EOF` (server uses no-space,
+        # client uses space) — tolerate either.
+        $0 ~ ("cat > " m " *<< *EOF") {flag=1; next}
+        flag && /^EOF$/ {flag=0; exit}
+        flag {print}
+    ' "$script")
+    # Variables referenced inside the heredoc — set with install-time
+    # defaults. shellcheck can't see through eval, so the SC2034 disables
+    # below acknowledge that these locals are consumed by the heredoc
+    # expansion. _after_units is only used by the client unit,
+    # music_mount_clause only by the server unit.
+    # shellcheck disable=SC2034
+    local PROJECT_ROOT=/opt/snapmulti
+    # shellcheck disable=SC2034
+    local INSTALL_DIR=/opt/snapclient
+    # shellcheck disable=SC2034
+    local music_mount_clause=""
+    # shellcheck disable=SC2034
+    local _after_units="docker.service network-online.target avahi-daemon.service"
+    eval "cat <<EOF
+$body
+EOF"
+}
+
 echo "=== snapmulti-server.service — avahi readiness ExecStartPre ==="
 
-# Extract the snapmulti-server unit file body from the heredoc.
-server_unit=$(awk '/cat > \/etc\/systemd\/system\/snapmulti-server\.service/,/^EOF$/' "$DEPLOY_SH")
+server_unit=$(render_unit "$DEPLOY_SH" "/etc/systemd/system/snapmulti-server.service")
 
 assert 'echo "$server_unit" | grep -qE "ExecStartPre=.*systemctl is-active --quiet avahi-daemon"' \
        'snapmulti-server has ExecStartPre gating on avahi-daemon is-active'
@@ -135,7 +172,7 @@ assert 'echo "$server_unit" | grep -qE "^ExecStop=.*compose stop -t 5"' \
 echo
 echo "=== snapclient.service — avahi readiness ExecStartPre ==="
 
-client_unit=$(awk '/cat > \/etc\/systemd\/system\/snapclient\.service/,/^EOF$/' "$SETUP_SH")
+client_unit=$(render_unit "$SETUP_SH" "/etc/systemd/system/snapclient.service")
 
 assert 'echo "$client_unit" | grep -qE "ExecStartPre=.*systemctl is-active --quiet avahi-daemon"' \
        'snapclient has ExecStartPre gating on avahi-daemon is-active'

--- a/tests/test_avahi_readiness.sh
+++ b/tests/test_avahi_readiness.sh
@@ -99,6 +99,18 @@ assert '! echo "$server_unit" | grep -qF "\\+" && ! echo "$server_unit" | grep -
 assert 'echo "$server_unit" | grep -qE "ExecStartPost=-"' \
        'ExecStartPost is non-fatal (leading -)'
 
+# mem_limit drift recreate guard — symmetric to snapclient.service (PR #393).
+# Live evidence on pi4hatsrvusb post-reflash: 7 server containers had
+# HostConfig.Memory=0 because the first compose up ran before cgroup v2
+# was active. The guard probes snapserver and force-recreates the stack
+# when limit==0. Must be non-fatal (leading -) so a missing/transient
+# docker inspect does not hold the unit in failed state.
+assert 'echo "$server_unit" | grep -qE "ExecStartPre=-.*docker inspect snapserver.*HostConfig.Memory"' \
+       'server has mem-drift force-recreate ExecStartPre (symmetric to snapclient)'
+
+assert 'echo "$server_unit" | grep -qE "ExecStartPre=-.*if \[\[ .*mem.* == .0..*compose up -d --force-recreate"' \
+       'server mem-drift guard force-recreates when HostConfig.Memory=0'
+
 # PartOf=avahi-daemon.service has been removed: it gave Avahi full
 # lifecycle control over the audio stack, so a routine avahi restart
 # took the whole stack down. Server-side recovery from the snapcast

--- a/tests/test_deploy_systemd_service.sh
+++ b/tests/test_deploy_systemd_service.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_SH="$SCRIPT_DIR/../scripts/deploy.sh"
+SNIPPETS_SH="$SCRIPT_DIR/../scripts/common/systemd-snippets.sh"
 
 pass=0
 fail=0
@@ -18,15 +19,34 @@ assert_contains() {
     fi
 }
 
+# Source-text checks (function wiring, idempotency markers).
 service_body="$(sed -n '/^install_systemd_service()/,/^}/p' "$DEPLOY_SH")"
+
+# Rendered unit-file checks (the actual content systemd will read).
+# Mirrors the render_unit pattern in test_avahi_readiness.sh — sources
+# systemd-snippets.sh so $(helper) substitutions inside the heredoc
+# resolve to the final unit-file lines.
+# shellcheck source=../scripts/common/systemd-snippets.sh
+source "$SNIPPETS_SH"
+heredoc_body=$(awk '
+    $0 ~ ("cat > /etc/systemd/system/snapmulti-server.service *<< *EOF") {flag=1; next}
+    flag && /^EOF$/ {flag=0; exit}
+    flag {print}
+' "$DEPLOY_SH")
+PROJECT_ROOT=/opt/snapmulti
+# shellcheck disable=SC2034  # consumed inside eval'd heredoc below
+music_mount_clause=""
+service_unit=$(eval "cat <<EOF
+$heredoc_body
+EOF")
 
 echo "Testing deploy systemd service..."
 
 assert_contains "$service_body" 'snapmulti-server.service' "service file is created"
-assert_contains "$service_body" 'ExecStart=/usr/bin/docker compose up -d' "service starts compose stack"
-assert_contains "$service_body" 'ExecStop=/usr/bin/docker compose stop -t 5' "service stops compose stack non-destructively"
-assert_contains "$service_body" 'WorkingDirectory=${PROJECT_ROOT}' "service runs from project root"
-assert_contains "$service_body" 'WantedBy=multi-user.target' "service is enabled at boot"
+assert_contains "$service_unit" 'ExecStart=/usr/bin/docker compose up -d' "service starts compose stack"
+assert_contains "$service_unit" 'ExecStop=/usr/bin/docker compose stop -t 5' "service stops compose stack non-destructively"
+assert_contains "$service_unit" "WorkingDirectory=$PROJECT_ROOT" "service runs from project root"
+assert_contains "$service_unit" 'WantedBy=multi-user.target' "service is enabled at boot"
 assert_contains "$service_body" 'systemctl enable snapmulti-server.service' "service is enabled"
 
 echo ""

--- a/tests/test_systemd_snippets.sh
+++ b/tests/test_systemd_snippets.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Functional + static checks for scripts/common/systemd-snippets.sh.
+#
+# Each helper emits exactly one systemd unit-file line. The output is
+# consumed via $(helper) inside an unquoted heredoc, so:
+#   - bash strips the trailing newline from $() — helpers MUST NOT emit
+#     a trailing newline (otherwise the next heredoc line shifts down).
+#   - the substituted text is plain characters: bash does NOT re-process
+#     $(...) or $VAR inside the substituted result. So `$(seq …)` and
+#     `$$mem` must appear literally in helper output, NOT in their
+#     bash-evaluated forms.
+#
+# We assert byte-for-byte equality against the strings that previously
+# lived inlined in deploy.sh (snapmulti-server.service) and setup.sh
+# (snapclient.service), to lock the helper outputs to the pre-refactor
+# behaviour.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNIPPETS="$SCRIPT_DIR/../scripts/common/systemd-snippets.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "=== Static checks ==="
+assert_eq "$(test -f "$SNIPPETS" && echo yes)" "yes" "systemd-snippets.sh exists"
+assert_eq "$(bash -n "$SNIPPETS" 2>&1 && echo OK)" "OK" "bash -n clean"
+if command -v shellcheck >/dev/null 2>&1; then
+    assert_eq "$(shellcheck -S warning "$SNIPPETS" >/dev/null 2>&1 && echo OK)" "OK" "shellcheck -S warning clean"
+fi
+for fn in docker_info_ready_execstartpre avahi_daemon_ready_execstartpre \
+          mem_drift_recreate_execstartpre compose_stop_5s_execstop; do
+    assert_eq "$(grep -cE "^${fn}\\(\\) \\{" "$SNIPPETS")" "1" "function $fn defined"
+done
+
+echo
+echo "=== Source guard ==="
+# Source twice — second source must be a no-op (idempotent load).
+( # shellcheck disable=SC1090
+  source "$SNIPPETS"
+  loaded_first="$_SNAPMULTI_SYSTEMD_SNIPPETS_LOADED"
+  # shellcheck disable=SC1090
+  source "$SNIPPETS"
+  loaded_second="$_SNAPMULTI_SYSTEMD_SNIPPETS_LOADED"
+  echo "  first=$loaded_first second=$loaded_second"
+  [[ "$loaded_first" == "1" && "$loaded_second" == "1" ]]
+) && { echo "  PASS: source guard works"; pass=$((pass + 1)); } || { echo "  FAIL: source guard"; fail=$((fail + 1)); }
+
+# Reset guard for the rest of the test (we want to source fresh).
+unset _SNAPMULTI_SYSTEMD_SNIPPETS_LOADED
+# shellcheck source=../scripts/common/systemd-snippets.sh
+source "$SNIPPETS"
+
+echo
+echo "=== docker_info_ready_execstartpre ==="
+expected_docker="ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do docker info >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'"
+actual_docker=$(docker_info_ready_execstartpre)
+assert_eq "$actual_docker" "$expected_docker" "docker info wait line matches pre-refactor"
+# No trailing newline (the function must NOT emit one; verify length).
+actual_with_marker=$(printf '%s|END' "$(docker_info_ready_execstartpre)")
+assert_eq "${actual_with_marker: -4}" "|END" "docker_info has no trailing newline"
+
+echo
+echo "=== avahi_daemon_ready_execstartpre ==="
+expected_avahi="ExecStartPre=/bin/bash -c 'for i in \$(seq 1 30); do systemctl is-active --quiet avahi-daemon.service && [[ -S /run/avahi-daemon/socket ]] && break; sleep 1; done; sleep 2'"
+actual_avahi=$(avahi_daemon_ready_execstartpre)
+assert_eq "$actual_avahi" "$expected_avahi" "avahi readiness line matches pre-refactor"
+
+echo
+echo "=== mem_drift_recreate_execstartpre snapserver /opt/snapmulti ==="
+expected_mem_srv='ExecStartPre=-/bin/bash -c '\''mem=$(/usr/bin/docker inspect snapserver --format "{{.HostConfig.Memory}}" 2>/dev/null || true); if [[ "$$mem" == "0" ]]; then cd /opt/snapmulti && /usr/bin/docker compose up -d --force-recreate; fi'\'
+actual_mem_srv=$(mem_drift_recreate_execstartpre snapserver /opt/snapmulti)
+assert_eq "$actual_mem_srv" "$expected_mem_srv" "server mem-drift line matches deploy.sh pre-refactor"
+
+echo
+echo "=== mem_drift_recreate_execstartpre snapclient /opt/snapclient ==="
+expected_mem_cli='ExecStartPre=-/bin/bash -c '\''mem=$(/usr/bin/docker inspect snapclient --format "{{.HostConfig.Memory}}" 2>/dev/null || true); if [[ "$$mem" == "0" ]]; then cd /opt/snapclient && /usr/bin/docker compose up -d --force-recreate; fi'\'
+actual_mem_cli=$(mem_drift_recreate_execstartpre snapclient /opt/snapclient)
+assert_eq "$actual_mem_cli" "$expected_mem_cli" "client mem-drift line matches setup.sh pre-refactor"
+
+echo
+echo "=== mem_drift_recreate_execstartpre parametrization ==="
+# Container name parametrized — alternate value must flow through.
+custom=$(mem_drift_recreate_execstartpre someother /tmp/foo)
+case "$custom" in
+    *'docker inspect someother --format'*) container_ok=1 ;;
+    *) container_ok=0 ;;
+esac
+assert_eq "$container_ok" "1" "container name reflected in output"
+case "$custom" in
+    *'cd /tmp/foo &&'*) dir_ok=1 ;;
+    *) dir_ok=0 ;;
+esac
+assert_eq "$dir_ok" "1" "project dir reflected in output"
+
+# Missing args must hard-fail (parameter substitution :? guard).
+if ( mem_drift_recreate_execstartpre 2>/dev/null ); then
+    echo "  FAIL: mem_drift_recreate_execstartpre should reject missing container"
+    fail=$((fail + 1))
+else
+    echo "  PASS: mem_drift_recreate_execstartpre rejects missing container"
+    pass=$((pass + 1))
+fi
+if ( mem_drift_recreate_execstartpre snapserver 2>/dev/null ); then
+    echo "  FAIL: mem_drift_recreate_execstartpre should reject missing dir"
+    fail=$((fail + 1))
+else
+    echo "  PASS: mem_drift_recreate_execstartpre rejects missing dir"
+    pass=$((pass + 1))
+fi
+
+echo
+echo "=== compose_stop_5s_execstop ==="
+expected_stop="ExecStop=/usr/bin/docker compose stop -t 5"
+actual_stop=$(compose_stop_5s_execstop)
+assert_eq "$actual_stop" "$expected_stop" "compose stop line matches pre-refactor"
+
+echo
+echo "=== Heredoc integration (smoke) ==="
+# Confirm that consuming via $() inside a heredoc yields the expected
+# output without surprises. The mem-drift case is the gnarliest because
+# of the $$ escaping for systemd → bash.
+PROJECT_ROOT=/opt/snapmulti
+generated=$(cat <<EOF
+$(docker_info_ready_execstartpre)
+$(mem_drift_recreate_execstartpre snapserver "${PROJECT_ROOT}")
+$(compose_stop_5s_execstop)
+EOF
+)
+case "$generated" in
+    *'for i in $(seq 1 60)'*) heredoc_seq_ok=1 ;;
+    *) heredoc_seq_ok=0 ;;
+esac
+assert_eq "$heredoc_seq_ok" "1" "heredoc preserves literal \$(seq …)"
+case "$generated" in
+    *'"$$mem" == "0"'*) heredoc_dollar_ok=1 ;;
+    *) heredoc_dollar_ok=0 ;;
+esac
+assert_eq "$heredoc_dollar_ok" "1" "heredoc preserves literal \$\$mem (systemd escape)"
+
+echo
+echo "Results: $pass passed, $fail failed"
+exit $(( fail > 0 ? 1 : 0 ))


### PR DESCRIPTION
## Summary

Live evidence on pi4hatsrvusb post-reflash:

```
[ERROR] Container(s) with HostConfig.Memory=0 (limit drift —
deploy.sh must --force-recreate): metadata, shairport-sync,
tidal-connect, librespot, mympd, snapserver, mpd
```

All 7 server containers had `HostConfig.Memory=0` after fresh install. Same bug pattern that PR #393 fixed on the client side; the server unit never got the symmetric guard.

## Root cause

| Step | What happens | State |
|---|---|---|
| 1 | firstboot.sh invokes deploy.sh, deploy.sh runs `compose up -d --force-recreate` (deploy.sh:921) | OK |
| 2 | cmdline_ensure_memory_cgroup patches cmdline.txt — but cgroup v2 activates only AFTER reboot | Patched, not active |
| 3 | First compose up creates 7 containers WITHOUT cgroup v2 | `HostConfig.Memory=0` for each |
| 4 | firstboot reboots | OK |
| 5 | snapmulti-server.service ExecStart=`compose up -d` runs (idempotent) | Existing containers kept, mem still 0 |
| 6 | check_containers smoke step on first session post-reflash flags drift | ❌ |

## Fix

Mirror of snapclient.service ExecStartPre from PR #393:

```bash
ExecStartPre=-/bin/bash -c 'mem=$(/usr/bin/docker inspect snapserver \
    --format "{{.HostConfig.Memory}}" 2>/dev/null || true); \
    if [[ "$$mem" == "0" ]]; then \
        cd ${PROJECT_ROOT} && /usr/bin/docker compose up -d --force-recreate; \
    fi'
```

Three values matter:
- `"0"` → container exists, limit missing → recreate
- `"<bytes>"` → container exists, limit applied → skip
- `""` → container does not yet exist (fresh reflash) → skip, regular ExecStart will create with proper limits

Non-fatal (leading `-`): a transient `docker inspect` failure won't hold the unit in failed state.

## Validation

Done locally:
- `tests/test_avahi_readiness.sh` — 33/33 PASS (+2 assertions on the new ExecStartPre)
- `tests/test_deploy_systemd_service.sh` — 6/6 PASS
- `tests/test_mount_music_systemd_unit.sh` — PASS
- `bash -n scripts/deploy.sh` — OK
- `shellcheck -S warning scripts/deploy.sh tests/test_avahi_readiness.sh` — clean

Deferred to release-gate:
- Reflash of a server device and verify `docker inspect snapserver --format '{{.HostConfig.Memory}}'` returns a non-zero byte count on first systemd-managed start

## CHANGELOG note

No `CHANGELOG.md` change — folded into the v0.7.5 release-tag commit to avoid conflict with the existing `[Unreleased]` entries on `main`.