### PR TITLE
fix(prepare-sd): close verify+copy gap for systemd-snippets.sh

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -264,7 +264,8 @@ for _snippets_candidate in \
     "$SCRIPT_DIR/common/systemd-snippets.sh" \
     "$SCRIPT_DIR/../../../scripts/common/systemd-snippets.sh" \
     "$COMMON_DIR/../scripts/common/systemd-snippets.sh" \
-    "/boot/firmware/common/systemd-snippets.sh"; do
+    "/boot/firmware/snapmulti/common/systemd-snippets.sh" \
+    "/boot/snapmulti/common/systemd-snippets.sh"; do
     # shellcheck source=../../../scripts/common/systemd-snippets.sh
     [[ -f "$_snippets_candidate" ]] && source "$_snippets_candidate" && break
 done

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -110,7 +110,8 @@ function Assert-PreparedSdCard {
         'common/install-deps.sh',
         'common/setup-docker.sh',
         'common/wait-network.sh',
-        'common/mount-music.sh'
+        'common/mount-music.sh',
+        'common/systemd-snippets.sh'
     )
     foreach ($file in $requiredBase) {
         $path = Join-Path $Dest $file
@@ -152,6 +153,7 @@ function Assert-PreparedSdCard {
             'client/scripts/display-detect.sh',
             'client/scripts/common/install-deps.sh',
             'client/scripts/common/install-docker.sh',
+            'client/scripts/common/systemd-snippets.sh',
             'client/snapclient.conf'
         )) {
             $path = Join-Path $Dest $file
@@ -501,7 +503,7 @@ function Copy-ClientFiles {
     # Shared modules from server scripts/common/
     $commonDest = Join-Path $scriptsDest 'common'
     New-Item -ItemType Directory -Path $commonDest -Force | Out-Null
-    foreach ($shared in @('install-deps.sh', 'install-docker.sh', 'system-tune.sh', 'unified-log.sh', 'logging.sh', 'sanitize.sh')) {
+    foreach ($shared in @('install-deps.sh', 'install-docker.sh', 'system-tune.sh', 'unified-log.sh', 'logging.sh', 'sanitize.sh', 'systemd-snippets.sh')) {
         $sharedPath = Join-Path $ScriptDir "common\$shared"
         if (Test-Path $sharedPath) {
             Copy-Item $sharedPath -Destination $commonDest

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -424,7 +424,7 @@ copy_client_files() {
     # /opt/snapmulti/... /opt/snapclient/... ; do source "$_cand"; done`
     # idiom in ro-mode.sh / cmdline-manager.sh is resilience for ad-hoc
     # operator invocations, not because the copies disagree.
-    for _shared in install-deps.sh install-docker.sh system-tune.sh unified-log.sh logging.sh sanitize.sh; do
+    for _shared in install-deps.sh install-docker.sh system-tune.sh unified-log.sh logging.sh sanitize.sh systemd-snippets.sh; do
         [[ -f "$SCRIPT_DIR/common/$_shared" ]] && cp "$SCRIPT_DIR/common/$_shared" "$dest/scripts/common/"
     done
     # boot-tune.sh is a server script but client also needs it for boot-time tuning
@@ -741,7 +741,7 @@ VERIFY_ERRORS=0
 # -- snapMULTI files --
 echo ""
 echo "--- snapMULTI files ---"
-for f in install.conf firstboot.sh common/progress.sh common/logging.sh common/unified-log.sh common/sanitize.sh common/system-tune.sh common/install-docker.sh common/install-deps.sh common/setup-docker.sh common/wait-network.sh common/mount-music.sh; do
+for f in install.conf firstboot.sh common/progress.sh common/logging.sh common/unified-log.sh common/sanitize.sh common/system-tune.sh common/install-docker.sh common/install-deps.sh common/setup-docker.sh common/wait-network.sh common/mount-music.sh common/systemd-snippets.sh; do
     if [[ -f "$DEST/$f" ]]; then
         echo "  [OK] snapmulti/$f"
     else
@@ -787,6 +787,7 @@ case "$INSTALL_TYPE" in
                  client/scripts/common/unified-log.sh \
                  client/scripts/common/logging.sh \
                  client/scripts/common/sanitize.sh \
+                 client/scripts/common/systemd-snippets.sh \
                  client/snapclient.conf; do
             if [[ -f "$DEST/$f" ]]; then
                 echo "  [OK] snapmulti/$f"

--- a/tests/test_prepare_sd_required_files.sh
+++ b/tests/test_prepare_sd_required_files.sh
@@ -64,7 +64,12 @@ if [[ -f "$PREPARE_SD_PS1" ]]; then
     assert_contains "$ps1_required_base" "common/systemd-snippets.sh" \
         "ps1 \$requiredBase includes common/systemd-snippets.sh"
 
-    ps1_client_required=$(sed -n '/client\/scripts\/common\/install-deps.sh/,/^[[:space:]]*)$/p' "$PREPARE_SD_PS1")
+    # NB: ps1 client-required array closes with `        )) {` not a bare `)`,
+    # so the closing delimiter has to match the literal `)) {` — `^[[:space:]]*)$`
+    # would never trip and sed would run to EOF, scoping the assert to the entire
+    # tail of the file (assertion still passes because the string is present
+    # above the close, but the range is unintentionally global).
+    ps1_client_required=$(sed -n '/client\/scripts\/common\/install-deps.sh/,/)) {/p' "$PREPARE_SD_PS1")
     assert_contains "$ps1_client_required" "client/scripts/common/systemd-snippets.sh" \
         "ps1 client-required list includes systemd-snippets.sh"
 

--- a/tests/test_prepare_sd_required_files.sh
+++ b/tests/test_prepare_sd_required_files.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PREPARE_SD_SH="$SCRIPT_DIR/../scripts/prepare-sd.sh"
+PREPARE_SD_PS1="$SCRIPT_DIR/../scripts/prepare-sd.ps1"
 
 pass=0
 fail=0
@@ -30,6 +31,47 @@ assert_contains "$verify_block" "common/install-deps.sh" "install-deps.sh is req
 assert_contains "$verify_block" "common/setup-docker.sh" "setup-docker.sh is required"
 assert_contains "$verify_block" "common/wait-network.sh" "wait-network.sh is required"
 assert_contains "$verify_block" "common/mount-music.sh" "mount-music.sh is required"
+# systemd-snippets.sh is sourced by deploy.sh (server) AND by setup.sh
+# (client) to generate the snapmulti-server.service and snapclient.service
+# unit files. If it is missing from the SD card, firstboot.sh's recursive
+# copy from $SNAP_BOOT/common/ to /opt/{snapmulti,snapclient}/scripts/common/
+# would silently drop it and the unit generators would emit incomplete
+# service files. The verify gate must catch this before the operator
+# inserts the card into the Pi.
+assert_contains "$verify_block" "common/systemd-snippets.sh" "systemd-snippets.sh is required (server+client unit generator helper)"
+
+# Client-mode verify list — client/scripts/common/ is a selective copy of
+# the server's scripts/common/. systemd-snippets.sh must be in BOTH places
+# because setup.sh runs from /opt/snapclient/scripts/ post-install and re-
+# runs (live update path) would otherwise fail to find the helper.
+client_verify_block=$(sed -n '/client\/scripts\/common\/install-deps.sh/,/^[[:space:]]*done$/p' "$PREPARE_SD_SH")
+assert_contains "$client_verify_block" "client/scripts/common/systemd-snippets.sh" \
+    "client-mode verify list includes systemd-snippets.sh"
+
+# Bash selective copy loop (copy_client_files) must enumerate systemd-snippets.sh
+# alongside the other shared modules — without it the file is not copied to
+# the client install dir and the previous client verify assertion would have
+# nothing to find.
+copy_block=$(sed -n '/for _shared in/,/done$/p' "$PREPARE_SD_SH" | head -10)
+assert_contains "$copy_block" "systemd-snippets.sh" \
+    "bash selective copy loop includes systemd-snippets.sh"
+
+# PowerShell parity — Windows users go through prepare-sd.ps1, which has
+# its own $requiredBase / client-required arrays and its own selective copy
+# foreach. All three must include systemd-snippets.sh for parity.
+if [[ -f "$PREPARE_SD_PS1" ]]; then
+    ps1_required_base=$(sed -n '/\$requiredBase = @(/,/^[[:space:]]*)$/p' "$PREPARE_SD_PS1")
+    assert_contains "$ps1_required_base" "common/systemd-snippets.sh" \
+        "ps1 \$requiredBase includes common/systemd-snippets.sh"
+
+    ps1_client_required=$(sed -n '/client\/scripts\/common\/install-deps.sh/,/^[[:space:]]*)$/p' "$PREPARE_SD_PS1")
+    assert_contains "$ps1_client_required" "client/scripts/common/systemd-snippets.sh" \
+        "ps1 client-required list includes systemd-snippets.sh"
+
+    ps1_copy_foreach=$(sed -n '/foreach (\$shared in @(/,/))/p' "$PREPARE_SD_PS1")
+    assert_contains "$ps1_copy_foreach" "systemd-snippets.sh" \
+        "ps1 selective copy foreach includes systemd-snippets.sh"
+fi
 
 echo ""
 if [[ "$fail" -gt 0 ]]; then


### PR DESCRIPTION
## Sintesi

Post-merge audit su PR #402 (introduzione `scripts/common/systemd-snippets.sh`) ha sollevato due gap correlati nelle gate di staging SD card.

### P2 — verify gate cieco
`prepare-sd.sh` e `prepare-sd.ps1` mantengono **tre liste esplicite ciascuno** (top-level `common/` verify, `client/scripts/common/` verify, selective copy enumeration). `systemd-snippets.sh` non era in nessuna delle sei.

**Runtime ship today**: la `cp -r common $DEST/` top-level (bash:571 / ps1:676) è ricorsiva e `firstboot.sh:561` ri-copia tutto `$SNAP_BOOT/common/` in `/opt/snapclient/scripts/common/`, quindi setup.sh trova l'helper. Ma il verify gate non noterebbe una regressione futura: se uno dei due `prepare-sd` smette di shippare l'helper (refactor, rename), la verify passa green e l'operatore inserisce una card che fallisce al firstboot.

### P3 — fallback path errato in setup.sh
Candidate `/boot/firmware/common/systemd-snippets.sh` — il path reale sotto `firstboot.sh`'s `SNAP_BOOT=/boot/firmware/snapmulti` è `/boot/firmware/snapmulti/common/`. Inerte oggi perché i candidati precedenti matchano prima, ma documentation rot.

## Modifiche

- `prepare-sd.sh:427` selective copy loop ship systemd-snippets.sh
- `prepare-sd.sh:744` top-level verify list lo include
- `prepare-sd.sh:786` client-mode verify list lo include
- `prepare-sd.ps1`: stesse tre updates (`$requiredBase`, client-required, selective copy foreach)
- `setup.sh:265` candidate list corretta a `/boot/firmware/snapmulti/common/systemd-snippets.sh` + `/boot/snapmulti/common/` per legacy /boot layout (pre-Bookworm)
- `test_prepare_sd_required_files.sh` esteso da 8 a 14 assertion (tutte e tre le liste bash + tutte e tre le liste ps1)

## Validation

**Done locally:**
- [x] `bash tests/test_prepare_sd_required_files.sh` → 14/14 PASS
- [x] Suite intera (`tests/test_*.sh` modulo i due skip CI) → 49/49 PASS
- [x] `shellcheck -S warning -x` clean su prepare-sd.sh, setup.sh, test
- [x] `bash -n` su tutti i file modificati
- [x] Verify reciproca: ogni claim sollevata ha 1 assert specifica nel test

**Deferred to release-gate:**
- Reflash canary su client device (pi3hat o pizero) per confermare path firstboot
- Reflash su server-with-display (snapvideo) — la copia top-level è invariata, regressione attesa: 0

## Background

Audit/findings forniti come parte della review post-PR-#402. Single bundled PR per narrative coherence (entrambe le claim derivano dall'introduzione di systemd-snippets.sh, file overlap su setup.sh / prepare-sd / tests).

No CHANGELOG entry — parallel-branch rule, accumulato per release-tag commit v0.7.5.