### PR TITLE
feat(prepare-sd): audio output menu with manual HAT/built-in override

### DIFF
--- a/client/common/scripts/audio-hat-detect.sh
+++ b/client/common/scripts/audio-hat-detect.sh
@@ -269,3 +269,62 @@ resolve_hat_config_name() {
         *)                  echo "$name" ;;
     esac
 }
+
+# detect_internal_card_name MODE → echoes the real ALSA card name for the
+# built-in audio output. MODE is `hdmi` or `jack`.
+#
+# Why this exists: the `internal-audio.conf` profile hard-codes
+# HAT_CARD_NAME="Headphones" which is correct for Pi 3/4 with kernel ≤ 6.1
+# but wrong elsewhere. Recent kernels (Bookworm / Trixie, kernel 6.6+) name
+# HDMI outputs `vc4-hdmi-0` / `vc4-hdmi-1`, and Pi 5 has no analog jack at
+# all. `aplay -L` is the source of truth at runtime — this helper queries
+# it and returns the first matching card name, with a graceful fallback
+# chain.
+#
+# Returns:
+#   stdout: the resolved card name (e.g. "Headphones", "vc4-hdmi-0").
+#   exit 0: name resolved.
+#   exit 1: no match found OR aplay unavailable (caller falls back).
+#
+# Resolution order:
+#   hdmi → vc4-hdmi-0 | vc4-hdmi-1 | vc4hdmi0 | vc4hdmi1 | HDMI
+#   jack → Headphones    (Pi 3/4 only — Pi 5 must use hdmi)
+#
+# We probe `aplay -L` (PCM names, what ALSA actually exposes) rather than
+# `aplay -l` (verbose card list) because snapclient uses the PCM name form
+# `hw:CARD=NAME,DEV=0` which matches the -L output directly.
+detect_internal_card_name() {
+    local mode="${1:?detect_internal_card_name: mode required (hdmi|jack)}"
+    local aplay_bin
+    aplay_bin=$(command -v aplay 2>/dev/null) || return 1
+    local aplay_out
+    aplay_out=$("$aplay_bin" -L 2>/dev/null) || return 1
+    local candidate
+    case "$mode" in
+        hdmi)
+            # First-match wins. vc4-hdmi-0 covers Pi 4/5 with the modern KMS
+            # driver; vc4hdmi0 is the alternate spelling seen on some forks.
+            # Bare "HDMI" is the legacy bcm2835 name still present on older
+            # kernels and a useful last-resort fallback.
+            for candidate in vc4-hdmi-0 vc4-hdmi-1 vc4hdmi0 vc4hdmi1 HDMI; do
+                if grep -qE "^${candidate}$" <<<"$aplay_out"; then
+                    printf '%s\n' "$candidate"
+                    return 0
+                fi
+            done
+            ;;
+        jack)
+            # Headphones is the only canonical name. Pi 5 doesn't expose
+            # this card; the caller is expected to detect the empty output
+            # and fall back to hdmi (or warn the operator).
+            if grep -qE '^Headphones$' <<<"$aplay_out"; then
+                printf 'Headphones\n'
+                return 0
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    return 1
+}

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -97,6 +97,10 @@ if [ "$AUTO_MODE" = true ]; then
     fi
     # Defaults for auto mode (can be overridden by config file)
     AUDIO_HAT="${AUDIO_HAT:-auto}"
+    # Built-in audio output selector — only consulted when AUDIO_HAT is
+    # internal-audio (i.e. user explicitly chose "no HAT" in prepare-sd).
+    # Empty for any other AUDIO_HAT value.
+    AUDIO_INTERNAL_OUTPUT="${AUDIO_INTERNAL_OUTPUT:-}"
     DISPLAY_RESOLUTION="${DISPLAY_RESOLUTION:-}"
     BAND_MODE="${BAND_MODE:-third-octave}"
     SNAPSERVER_HOST="${SNAPSERVER_HOST:-}"
@@ -358,6 +362,34 @@ if [[ "${HAT_CONFIG:-}" == "usb-audio" ]]; then
     if [[ -n "${USB_CARD_ID:-}" ]]; then
         echo "Overriding HAT_CARD_NAME=$HAT_CARD_NAME with USB_CARD_ID=$USB_CARD_ID"
         HAT_CARD_NAME="$USB_CARD_ID"
+    fi
+fi
+
+# Override HAT_CARD_NAME with the real ALSA card name when the user picked
+# "No HAT — use Pi built-in audio" in prepare-sd's audio menu. The static
+# `Headphones` in internal-audio.conf is correct only for Pi 3/4 on older
+# kernels; Bookworm/Trixie expose HDMI as `vc4-hdmi-0`/`vc4-hdmi-1` and Pi
+# 5 has no analog jack at all. detect_internal_card_name walks `aplay -L`
+# and returns the first real match. AUDIO_INTERNAL_OUTPUT comes from
+# install.conf (set when AUDIO_HAT=internal-audio).
+if [[ "${HAT_CONFIG:-}" == "internal-audio" ]] && [[ -n "${AUDIO_INTERNAL_OUTPUT:-}" ]]; then
+    if declare -F detect_internal_card_name &>/dev/null; then
+        _internal_card=$(detect_internal_card_name "$AUDIO_INTERNAL_OUTPUT" 2>/dev/null || true)
+        # Fallback chain: if jack was requested but not present (Pi 5),
+        # automatically retry as hdmi rather than leave the operator with
+        # an unbound card and a non-starting snapclient. The retry is
+        # logged so the diagnostic bundle reflects what actually happened.
+        if [[ -z "$_internal_card" && "$AUDIO_INTERNAL_OUTPUT" == "jack" ]]; then
+            echo "[WARN] AUDIO_INTERNAL_OUTPUT=jack requested but no Headphones card found (likely Pi 5). Falling back to HDMI."
+            _internal_card=$(detect_internal_card_name hdmi 2>/dev/null || true)
+        fi
+        if [[ -n "$_internal_card" ]]; then
+            echo "Overriding HAT_CARD_NAME=$HAT_CARD_NAME with detected built-in card: $_internal_card (mode=$AUDIO_INTERNAL_OUTPUT)"
+            HAT_CARD_NAME="$_internal_card"
+        else
+            echo "[WARN] detect_internal_card_name returned empty for mode=$AUDIO_INTERNAL_OUTPUT — keeping default HAT_CARD_NAME=$HAT_CARD_NAME"
+        fi
+        unset _internal_card
     fi
 fi
 

--- a/client/tests/test_internal_card_detect.sh
+++ b/client/tests/test_internal_card_detect.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Functional tests for detect_internal_card_name in audio-hat-detect.sh.
+#
+# Strategy: source audio-hat-detect.sh, then shadow `aplay` with a function
+# that returns canned `aplay -L` output (Pi 3/4/5 variants — sourced from
+# Raspberry Pi official documentation and the Bookworm release notes).
+# Then assert that the helper returns the right card name for each (mode,
+# Pi) combination, and the right fall-back behaviour on Pi 5.
+#
+# The fixtures below are STATIC SNAPSHOTS of real `aplay -L` output —
+# they're not synthesised. If upstream renames a card, this test breaks
+# and tells us which fixture needs updating.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIO_HAT_DETECT="$SCRIPT_DIR/../common/scripts/audio-hat-detect.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got '$actual', expected '$expected')"
+        fail=$((fail + 1))
+    fi
+}
+
+# ── Fixtures ─────────────────────────────────────────────────────
+# Pi 3/4 on legacy kernel — bcm2835_alsa with combined HDMI+Headphones.
+# Headphones lives on its own card; HDMI is the bare "HDMI" alias.
+# Disables below acknowledge that shellcheck can't see the indirect
+# reference inside shadow_aplay's stub script (the variable is consumed
+# via `eval export <name>` and then read by a separate bash process).
+# shellcheck disable=SC2034
+FIXTURE_PI4_LEGACY=$(cat <<'EOF'
+null
+    Discard all samples (playback) or generate zero samples (capture)
+default
+sysdefault:CARD=Headphones
+    bcm2835 Headphones, bcm2835 Headphones
+Headphones
+    bcm2835 Headphones, bcm2835 Headphones
+    Default Audio Device
+HDMI
+    bcm2835 HDMI 1, bcm2835 HDMI 1
+    Default Audio Device
+EOF
+)
+
+# Pi 4 on Bookworm — KMS driver renames HDMI to vc4-hdmi-0 / vc4-hdmi-1.
+# Headphones still present (analog jack hardware unchanged on Pi 4).
+# shellcheck disable=SC2034
+FIXTURE_PI4_BOOKWORM=$(cat <<'EOF'
+null
+    Discard all samples (playback) or generate zero samples (capture)
+default
+sysdefault:CARD=vc4hdmi0
+    vc4-hdmi-0, MAI PCM vc4-hdmi-0-0
+    Default Audio Device
+vc4-hdmi-0
+    vc4-hdmi-0, MAI PCM vc4-hdmi-0-0
+    Direct hardware device without any conversions
+vc4-hdmi-1
+    vc4-hdmi-1, MAI PCM vc4-hdmi-1-0
+    Direct hardware device without any conversions
+Headphones
+    bcm2835 Headphones, bcm2835 Headphones
+    Default Audio Device
+EOF
+)
+
+# Pi 5 on Bookworm — analog jack hardware REMOVED, only HDMI outputs.
+# No Headphones card. helper must return empty for mode=jack so the
+# setup.sh fallback chain promotes to hdmi.
+# shellcheck disable=SC2034
+FIXTURE_PI5_BOOKWORM=$(cat <<'EOF'
+null
+    Discard all samples (playback) or generate zero samples (capture)
+default
+sysdefault:CARD=vc4hdmi0
+    vc4-hdmi-0, MAI PCM vc4-hdmi-0-0
+    Default Audio Device
+vc4-hdmi-0
+    vc4-hdmi-0, MAI PCM vc4-hdmi-0-0
+    Direct hardware device without any conversions
+vc4-hdmi-1
+    vc4-hdmi-1, MAI PCM vc4-hdmi-1-0
+    Direct hardware device without any conversions
+EOF
+)
+
+# ── Source the helper ────────────────────────────────────────────
+# We need only the function; sourcing the whole file is safe because the
+# top-level is just function definitions + a guarded interactive prompt
+# (run only when sourced from setup.sh's manual HAT-selection path,
+# which we don't trip here).
+# shellcheck source=../common/scripts/audio-hat-detect.sh
+source "$AUDIO_HAT_DETECT"
+
+if ! declare -F detect_internal_card_name >/dev/null; then
+    echo "  FAIL: detect_internal_card_name not defined after sourcing $AUDIO_HAT_DETECT"
+    exit 1
+fi
+
+# Helper: install an aplay() shell function that emits one of the fixtures.
+# detect_internal_card_name resolves aplay via `command -v` and then calls
+# the resulting path directly. We shadow the resolution by exporting a
+# function named `aplay` AND putting a stub at the top of PATH.
+shadow_aplay() {
+    local fixture_var="$1"
+    local stub_dir
+    stub_dir=$(mktemp -d /tmp/aplay-stub-XXXXXX)
+    cat > "$stub_dir/aplay" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+    -L) printf '%s\n' "\${${fixture_var}}" ;;
+    *) exit 1 ;;
+esac
+STUB
+    chmod +x "$stub_dir/aplay"
+    PATH="$stub_dir:$PATH"
+    export PATH
+    # Export the named fixture so the stub script (separate process) sees it.
+    # shellcheck disable=SC2086,SC2163  # intentional: indirect export by name
+    eval "export $fixture_var"
+    _APLAY_STUB_DIR="$stub_dir"
+}
+
+unshadow_aplay() {
+    [[ -n "${_APLAY_STUB_DIR:-}" ]] && rm -rf "$_APLAY_STUB_DIR"
+    unset _APLAY_STUB_DIR
+    PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/tmp/aplay-stub-' | tr '\n' ':' | sed 's/:$//')
+    export PATH
+}
+
+echo "=== Pi 4 legacy kernel (bcm2835_alsa) ==="
+shadow_aplay FIXTURE_PI4_LEGACY
+assert_eq "$(detect_internal_card_name hdmi)" "HDMI" "Pi 4 legacy: hdmi → bare 'HDMI' card"
+assert_eq "$(detect_internal_card_name jack)" "Headphones" "Pi 4 legacy: jack → 'Headphones'"
+unshadow_aplay
+
+echo
+echo "=== Pi 4 Bookworm (KMS vc4-hdmi-X) ==="
+shadow_aplay FIXTURE_PI4_BOOKWORM
+assert_eq "$(detect_internal_card_name hdmi)" "vc4-hdmi-0" "Pi 4 Bookworm: hdmi → 'vc4-hdmi-0' (first match)"
+assert_eq "$(detect_internal_card_name jack)" "Headphones" "Pi 4 Bookworm: jack → 'Headphones' (analog still present)"
+unshadow_aplay
+
+echo
+echo "=== Pi 5 Bookworm (no analog jack) ==="
+shadow_aplay FIXTURE_PI5_BOOKWORM
+assert_eq "$(detect_internal_card_name hdmi)" "vc4-hdmi-0" "Pi 5: hdmi → 'vc4-hdmi-0'"
+# Critical: jack must FAIL on Pi 5 — helper returns empty + exit 1, so the
+# setup.sh caller can detect this and fall back to hdmi. We capture stdout
+# and exit code separately.
+jack_out=$(detect_internal_card_name jack 2>/dev/null || true)
+assert_eq "$jack_out" "" "Pi 5: jack → empty (no Headphones card)"
+if detect_internal_card_name jack 2>/dev/null; then
+    echo "  FAIL: Pi 5 jack should exit non-zero"
+    fail=$((fail + 1))
+else
+    echo "  PASS: Pi 5 jack returns non-zero exit (signals fallback)"
+    pass=$((pass + 1))
+fi
+unshadow_aplay
+
+echo
+echo "=== Defensive: invalid mode ==="
+shadow_aplay FIXTURE_PI4_BOOKWORM
+if detect_internal_card_name garbage 2>/dev/null; then
+    echo "  FAIL: invalid mode should exit non-zero"
+    fail=$((fail + 1))
+else
+    echo "  PASS: invalid mode rejected"
+    pass=$((pass + 1))
+fi
+# Missing arg — `${1:?...}` should trigger
+if (detect_internal_card_name 2>/dev/null); then
+    echo "  FAIL: missing arg should exit non-zero"
+    fail=$((fail + 1))
+else
+    echo "  PASS: missing arg rejected"
+    pass=$((pass + 1))
+fi
+unshadow_aplay
+
+echo
+echo "=== Defensive: aplay unavailable ==="
+# Force the function to fail by stripping PATH so `command -v aplay` returns
+# nothing. Subshell so we don't break later cleanup.
+result=$(PATH=/nonexistent detect_internal_card_name hdmi 2>/dev/null || true)
+assert_eq "$result" "" "aplay missing → empty output"
+if (PATH=/nonexistent detect_internal_card_name hdmi 2>/dev/null); then
+    echo "  FAIL: aplay missing should exit non-zero"
+    fail=$((fail + 1))
+else
+    echo "  PASS: aplay missing returns non-zero (signals fallback to caller)"
+    pass=$((pass + 1))
+fi
+
+echo
+echo "Results: $pass passed, $fail failed"
+exit $(( fail > 0 ? 1 : 0 ))

--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -35,7 +35,7 @@ Il nuovo speaker compare in Snapweb (`http://<server>.local:1780`) entro ~30 sec
 
 ## Libreria musicale in rete
 
-Se la tua libreria è su un NAS (Synology, QNAP, server Linux generico, condivisione Windows), il Menu 2 di `prepare-sd.sh` chiede il path della share durante l'installazione. Scegli il protocollo che corrisponde al tuo NAS:
+Se la tua libreria è su un NAS (Synology, QNAP, server Linux generico, condivisione Windows), il Menu 3 di `prepare-sd.sh` chiede il path della share durante l'installazione. Scegli il protocollo che corrisponde al tuo NAS:
 
 | Protocollo | Quando | Note |
 |------------|--------|------|

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -35,7 +35,7 @@ The new speaker appears in Snapweb (`http://<server>.local:1780`) within ~30 sec
 
 ## Music library on the network
 
-If your library lives on a NAS (Synology, QNAP, generic Linux server, Windows share), `prepare-sd.sh` Menu 2 asks for the share path during install. Pick the protocol that matches your NAS:
+If your library lives on a NAS (Synology, QNAP, generic Linux server, Windows share), `prepare-sd.sh` Menu 3 asks for the share path during install. Pick the protocol that matches your NAS:
 
 | Protocol | When | Notes |
 |----------|------|-------|

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -123,10 +123,12 @@ Dettagli:
 | **DAC HAT I2S** (HiFiBerry DAC+, DAC2 Pro) | Eccellente | Migliore qualità analogica, uscita RCA, si collega direttamente al GPIO del Pi |
 | **HAT S/PDIF I2S** (HiFiBerry Digi+) | Eccellente | Uscita digitale ottica/coassiale verso ricevitore AV o DAC esterno; nessuna conversione analogica sul Pi |
 | **DAC USB** | Molto buona | Ampia gamma di opzioni; funziona con Pi Zero (nessun header GPIO necessario) |
-| **HDMI** | Buona | Usa il tuo TV/ricevitore AV come dispositivo di uscita |
-| **Jack 3.5mm** (Pi 3/4) | Adeguata | Rumore di fondo percepibile su alcuni modelli; va bene per ascolto casual |
+| **HDMI** | Buona | Usa il tuo TV/ricevitore AV come dispositivo di uscita. Il nome della card ALSA varia per kernel: `vc4-hdmi-0` (Bookworm/Trixie KMS), `HDMI` (legacy). Risolto automaticamente al primo boot via `aplay -L` |
+| **Jack 3.5mm** (Pi 3/4) | Adeguata | Rumore di fondo percepibile su alcuni modelli; va bene per ascolto casual. **Il Pi 5 non ha jack analogico** — scegliere "jack" nel menu installer ricade automaticamente su HDMI |
 
 > **Suggerimento:** Usa un HAT I2S per la migliore qualità. [HiFiBerry DAC+ Zero](https://www.hifiberry.com/shop/boards/dacplus-zero/) per i nodi client, [HiFiBerry DAC2 Pro](https://www.hifiberry.com/shop/boards/dac2-pro/) o [HiFiBerry Digi+](https://www.hifiberry.com/shop/boards/hifiberry-digi/) per nodi collegati a ricevitori AV.
+
+> **Override manuale:** `prepare-sd.sh` offre un menu *Uscita audio* (auto-detect, scegliere un HAT dalla lista, oppure scegliere HDMI/jack integrato). L'auto-detect è la scelta giusta per oltre il 90% delle installazioni — usa i percorsi manuali solo se l'auto-detect è già fallito una volta. Vedi [INSTALL.it.md — Menu 2 — Uscita audio](INSTALL.it.md#menu-2--uscita-audio-solo-audio-player-e-serverplayer).
 
 ### Metodo di Installazione Client
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -123,10 +123,12 @@ Detail:
 | **I2S DAC HAT** (HiFiBerry DAC+, DAC2 Pro) | Excellent | Best analog quality, RCA output, connects directly to Pi GPIO |
 | **I2S S/PDIF HAT** (HiFiBerry Digi+) | Excellent | Digital optical/coaxial out to AV receiver or external DAC; no analog conversion on the Pi |
 | **USB DAC** | Very good | Wide range of options; works with Pi Zero (no GPIO header needed) |
-| **HDMI** | Good | Use your TV/AV receiver as output device |
-| **3.5mm jack** (Pi 3/4) | Adequate | Noticeable noise floor on some boards; fine for casual listening |
+| **HDMI** | Good | Use your TV/AV receiver as output device. ALSA card name varies by kernel: `vc4-hdmi-0` (Bookworm/Trixie KMS), `HDMI` (legacy). Resolved automatically at first boot via `aplay -L` |
+| **3.5mm jack** (Pi 3/4) | Adequate | Noticeable noise floor on some boards; fine for casual listening. **Pi 5 has no analog jack** — picking "jack" in the install menu auto-falls back to HDMI |
 
 > **Tip:** Use an I2S HAT for the best quality. [HiFiBerry DAC+ Zero](https://www.hifiberry.com/shop/boards/dacplus-zero/) for client nodes, [HiFiBerry DAC2 Pro](https://www.hifiberry.com/shop/boards/dac2-pro/) or [HiFiBerry Digi+](https://www.hifiberry.com/shop/boards/hifiberry-digi/) for nodes connected to AV receivers.
+
+> **Manual override:** `prepare-sd.sh` offers an *Audio output* menu (auto-detect, pick a HAT from the list, or pick built-in HDMI/jack). Auto-detect is right for >90% of installs — use the manual paths only if auto-detect failed previously. See [INSTALL.md — Menu 2 — Audio output](INSTALL.md#menu-2--audio-output-audio-player-and-serverplayer-only).
 
 ### Client Install Method
 

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -216,7 +216,37 @@ Se il rilevamento automatico fallisce:
 
 ---
 
-### Menu 2 — Dov'è la tua musica? *(Solo Music Server e Server+Player)*
+### Menu 2 — Uscita audio *(Solo Audio Player e Server+Player)*
+
+```
+  +---------------------------------------------+
+  |        Audio output                          |
+  |                                              |
+  |  1) Auto-detect (recommended)                |
+  |     Detects HAT via EEPROM/I2C, falls back   |
+  |     to USB DAC or built-in audio             |
+  |                                              |
+  |  2) I have an audio HAT (choose from list)   |
+  |                                              |
+  |  3) No HAT -- use Pi built-in audio          |
+  |     HDMI (TV/monitor) or 3.5mm jack          |
+  |                                              |
+  +---------------------------------------------+
+```
+
+| Opzione | Quando sceglierla |
+|---------|-------------------|
+| **1 — Auto-detect** | Scelta corretta per >90% delle installazioni. Il Pi sonda l'EEPROM del HAT al primo boot, scansiona il bus I2C per chip DAC noti, e ricade su USB DAC e poi audio integrato. Sceglila a meno che l'auto-detect non sia già fallito una volta |
+| **2 — Ho un HAT audio** | Salta l'auto-detect e scegli il profilo esatto da una lista di 15 HAT supportati (HiFiBerry, IQaudio, JustBoom, Allo, InnoMaker, Waveshare). Utile quando il tuo HAT non ha EEPROM o il chip è condiviso tra profili |
+| **3 — Senza HAT — audio integrato** | Audio integrato Pi 3/4/5. Poi scegli HDMI (TV/monitor) o jack 3.5mm. **Il Pi 5 non ha jack analogico** — scegli HDMI o lascia fare all'auto-detect |
+
+Se scegli **3**, un sotto-menu ti chiede l'uscita:
+- **HDMI** — funziona su Pi 3, Pi 4, Pi 5. Il nome reale della card ALSA (`vc4-hdmi-0`, `HDMI`, dipende dal kernel) viene risolto al primo boot via `aplay -L`
+- **Jack 3.5mm (Headphones)** — funziona solo su Pi 3 e Pi 4. Il Pi 5 non ha jack analogico; se scegli questa opzione su Pi 5, l'installer logga un warning e ricade automaticamente su HDMI
+
+---
+
+### Menu 3 — Dov'è la tua musica? *(Solo Music Server e Server+Player)*
 
 ```
   +---------------------------------------------+

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -214,7 +214,37 @@ If auto-detection fails:
 
 ---
 
-### Menu 2 — Where is your music? *(Music Server and Server+Player only)*
+### Menu 2 — Audio output *(Audio Player and Server+Player only)*
+
+```
+  +---------------------------------------------+
+  |        Audio output                          |
+  |                                              |
+  |  1) Auto-detect (recommended)                |
+  |     Detects HAT via EEPROM/I2C, falls back   |
+  |     to USB DAC or built-in audio             |
+  |                                              |
+  |  2) I have an audio HAT (choose from list)   |
+  |                                              |
+  |  3) No HAT -- use Pi built-in audio          |
+  |     HDMI (TV/monitor) or 3.5mm jack          |
+  |                                              |
+  +---------------------------------------------+
+```
+
+| Option | Use when |
+|--------|----------|
+| **1 — Auto-detect** | Right for >90% of installs. The Pi probes the HAT EEPROM at first boot, scans the I2C bus for known DAC chips, falls back to USB DAC, then to built-in audio. Choose this unless auto-detect failed on a previous attempt |
+| **2 — I have an audio HAT** | Skip auto-detect and pick the exact profile from a list of 15 supported HATs (HiFiBerry, IQaudio, JustBoom, Allo, InnoMaker, Waveshare). Useful when your HAT lacks an EEPROM or the chip is shared across profiles |
+| **3 — No HAT — built-in audio** | Pi 3/4/5 onboard audio. You then pick between HDMI (TV/monitor) or 3.5mm jack. **Pi 5 has no analog jack** — pick HDMI or let auto-detect handle it |
+
+If you pick **3**, a sub-menu asks for the output:
+- **HDMI** — works on Pi 3, Pi 4, Pi 5. The real ALSA card name (`vc4-hdmi-0`, `HDMI`, depending on kernel) is resolved at first boot via `aplay -L`
+- **3.5mm jack (Headphones)** — works on Pi 3 and Pi 4 only. Pi 5 has no analog jack; if you pick this on Pi 5, the installer logs a warning and automatically falls back to HDMI
+
+---
+
+### Menu 3 — Where is your music? *(Music Server and Server+Player only)*
 
 ```
   +---------------------------------------------+

--- a/install.conf.template
+++ b/install.conf.template
@@ -24,6 +24,29 @@ SMB_SHARE=
 SMB_USER=
 SMB_PASS=
 #
+# Audio output (client/both only — server installs ignore these)
+#
+# AUDIO_HAT picks the soundcard profile setup.sh uses:
+#   auto              -- Detect HAT via EEPROM → I2C scan → USB → built-in (default).
+#                        Right for >90% of installs.
+#   <hat-slug>        -- Skip detection, use a specific HAT profile from
+#                        client/common/audio-hats/. Valid slugs:
+#                        hifiberry-dac-std, hifiberry-dac2hd, hifiberry-digi,
+#                        hifiberry-amp2, hifiberry-dacplusadc, hifiberry-dac,
+#                        iqaudio-codec, iqaudio-dac, iqaudio-digiamp,
+#                        justboom-dac, justboom-digi, allo-boss, allo-digione,
+#                        innomaker-dac-pro, waveshare-wm8960, usb-audio.
+#   internal-audio    -- Pi built-in audio (no HAT, no USB). Pair with
+#                        AUDIO_INTERNAL_OUTPUT below to pick HDMI or jack.
+AUDIO_HAT=auto
+#
+# AUDIO_INTERNAL_OUTPUT — only honoured when AUDIO_HAT=internal-audio:
+#   hdmi -- HDMI audio (TV/monitor). Works on Pi 3, Pi 4, Pi 5.
+#   jack -- 3.5mm headphone jack. Works on Pi 3, Pi 4 only.
+#           Pi 5 has no analog jack — leave blank or pick hdmi.
+# Leave empty for non-internal AUDIO_HAT values.
+AUDIO_INTERNAL_OUTPUT=
+#
 # Advanced options (defaults are production-safe)
 #
 # ENABLE_READONLY: Enable read-only filesystem (overlayroot).

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -282,6 +282,127 @@ function Get-NetworkType {
     }
 }
 
+# ── Audio output menus (client/both only) ────────────────────────
+# Mirror of the bash audio menu in prepare-sd.sh. See that file for
+# the design rationale; this file is the Windows host-side parity.
+function Show-AudioMenu {
+    Write-Host ''
+    Write-Host '  +---------------------------------------------+'
+    Write-Host '  |        Audio output                          |'
+    Write-Host '  |                                              |'
+    Write-Host '  |  1) Auto-detect (recommended)                |'
+    Write-Host '  |     Detects HAT via EEPROM/I2C, falls back   |'
+    Write-Host '  |     to USB DAC or built-in audio             |'
+    Write-Host '  |                                              |'
+    Write-Host '  |  2) I have an audio HAT (choose from list)   |'
+    Write-Host '  |                                              |'
+    Write-Host '  |  3) No HAT -- use Pi built-in audio          |'
+    Write-Host '  |     HDMI (TV/monitor) or 3.5mm jack          |'
+    Write-Host '  |                                              |'
+    Write-Host '  +---------------------------------------------+'
+    Write-Host ''
+    Write-Host '  Auto-detect is the right choice for >90% of installs.'
+    Write-Host '  Use 2 or 3 only if auto-detect failed on a previous attempt.'
+    Write-Host ''
+}
+
+function Get-AudioType {
+    while ($true) {
+        $choice = Read-Host '  Choose [1-3]'
+        switch ($choice) {
+            '1' { return 'auto' }
+            '2' { return 'hat' }
+            '3' { return 'internal' }
+            default { Write-Host '  Invalid choice. Enter 1, 2, or 3.' }
+        }
+    }
+}
+
+# Enumerate supported HATs from $ClientDir\common\audio-hats\*.conf,
+# excluding internal-audio (sub-menu 3) and usb-audio (auto-detect).
+# Returns @( @{Slug='..'; Name='..'}, ... ) sorted by friendly name.
+function Get-SupportedHats {
+    param([string]$ClientDir)
+    $hatDir = Join-Path $ClientDir 'common\audio-hats'
+    if (-not (Test-Path $hatDir)) { return @() }
+    $hats = @()
+    foreach ($f in Get-ChildItem -Path $hatDir -Filter '*.conf') {
+        $slug = [System.IO.Path]::GetFileNameWithoutExtension($f.Name)
+        if ($slug -in @('internal-audio', 'usb-audio')) { continue }
+        $nameLine = Select-String -Path $f.FullName -Pattern '^HAT_NAME=' -SimpleMatch:$false | Select-Object -First 1
+        $name = $slug
+        if ($nameLine) {
+            # HAT_NAME="..." — strip the variable prefix and surrounding quotes.
+            $name = $nameLine.Line -replace '^HAT_NAME=', ''
+            $name = $name.Trim('"').Trim("'")
+            if (-not $name) { $name = $slug }
+        }
+        $hats += [PSCustomObject]@{ Slug = $slug; Name = $name }
+    }
+    return $hats | Sort-Object Name
+}
+
+function Show-HatMenu {
+    param([array]$Hats)
+    Write-Host ''
+    Write-Host '  +---------------------------------------------+'
+    Write-Host '  |        Choose your audio HAT                 |'
+    Write-Host '  +---------------------------------------------+'
+    Write-Host ''
+    for ($i = 0; $i -lt $Hats.Count; $i++) {
+        Write-Host ("  {0,2}) {1}" -f ($i + 1), $Hats[$i].Name)
+    }
+    Write-Host ''
+    Write-Host '  Cancel and return to auto-detect:'
+    Write-Host '   0) Back'
+    Write-Host ''
+}
+
+function Get-HatChoice {
+    param([array]$Hats)
+    $total = $Hats.Count
+    while ($true) {
+        $choice = Read-Host "  Choose [0-$total]"
+        if ($choice -eq '0') { return 'auto' }
+        $n = 0
+        if ([int]::TryParse($choice, [ref]$n) -and $n -ge 1 -and $n -le $total) {
+            return $Hats[$n - 1].Slug
+        }
+        Write-Host "  Invalid choice. Enter a number between 0 and $total."
+    }
+}
+
+function Show-InternalAudioMenu {
+    Write-Host ''
+    Write-Host '  +---------------------------------------------+'
+    Write-Host '  |        Built-in audio output                 |'
+    Write-Host '  |                                              |'
+    Write-Host '  |  1) HDMI (TV / monitor)                      |'
+    Write-Host '  |     Works on Pi 3, Pi 4, Pi 5                |'
+    Write-Host '  |                                              |'
+    Write-Host '  |  2) 3.5mm jack (Headphones)                  |'
+    Write-Host '  |     Works on Pi 3, Pi 4 only                 |'
+    Write-Host '  |     (Pi 5 has no analog jack -- pick 1)      |'
+    Write-Host '  |                                              |'
+    Write-Host '  +---------------------------------------------+'
+    Write-Host ''
+    Write-Host '  On Bookworm/Trixie the real ALSA card name is'
+    Write-Host "  detected at first boot via 'aplay -L' -- you do"
+    Write-Host '  not need to know it here.'
+    Write-Host ''
+}
+
+function Get-InternalOutput {
+    while ($true) {
+        $choice = Read-Host '  Choose [1-2]'
+        switch ($choice) {
+            '1' { return 'hdmi' }
+            '2' { return 'jack' }
+            default { Write-Host '  Invalid choice. Enter 1 or 2.' }
+        }
+    }
+}
+
 function Sanitize-Hostname {
     param([string]$Value)
     $cleaned = $Value -replace '[^A-Za-z0-9.\-]', ''
@@ -609,6 +730,34 @@ Write-Host ''
 Write-Host "Installing as: $InstallType"
 Write-Host ''
 
+# ── Audio output (client/both only) ──────────────────────────────
+$AudioHat = 'auto'
+$AudioInternalOutput = ''
+if ($InstallType -in @('client', 'both')) {
+    Show-AudioMenu
+    $audioType = Get-AudioType
+    switch ($audioType) {
+        'auto' { $AudioHat = 'auto' }
+        'hat' {
+            $hats = Get-SupportedHats -ClientDir $ClientDir
+            Show-HatMenu -Hats $hats
+            $AudioHat = Get-HatChoice -Hats $hats
+        }
+        'internal' {
+            $AudioHat = 'internal-audio'
+            Show-InternalAudioMenu
+            $AudioInternalOutput = Get-InternalOutput
+        }
+    }
+    Write-Host ''
+    if ($AudioInternalOutput) {
+        Write-Host "Audio: $AudioHat ($AudioInternalOutput)"
+    } else {
+        Write-Host "Audio: $AudioHat"
+    }
+    Write-Host ''
+}
+
 # ── Music source (server/both only) ─────────────────────────────
 $MusicSource = ''
 $NfsServer = ''
@@ -660,6 +809,9 @@ NFS_SERVER=$NfsServer
 NFS_EXPORT=$NfsExport
 SMB_SERVER=$SmbServer
 SMB_SHARE=$SmbShare
+# Audio output (client/both only — server installs ignore these)
+AUDIO_HAT=$AudioHat
+AUDIO_INTERNAL_OUTPUT=$AudioInternalOutput
 # Advanced options
 # (PowerShell prep currently uses defaults — the bash side has an
 # interactive Advanced menu that lets the user toggle these. Parity

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -168,6 +168,145 @@ get_music_source() {
     done
 }
 
+# ── Audio output menu (client/both only) ─────────────────────────
+# Three-level menu:
+#   top:    auto-detect | manual HAT | manual built-in
+#   HAT:    list 16 supported HATs (excludes internal-audio and usb-audio,
+#           both of which are reached via "auto" or sub-menu 3)
+#   built:  HDMI vs Headphones (Pi 5 has no jack — flagged in the menu)
+#
+# Values written to install.conf:
+#   AUDIO_HAT=auto             → setup.sh runs full auto-detect (EEPROM → I2C → USB → internal)
+#   AUDIO_HAT=<hat-slug>       → setup.sh skips detection, uses the named profile directly
+#   AUDIO_HAT=internal-audio   → built-in audio path (no HAT, no USB)
+#   AUDIO_INTERNAL_OUTPUT=hdmi|jack   → only when AUDIO_HAT=internal-audio,
+#                                       tells setup.sh which built-in card to bind
+show_audio_menu() {
+    echo ""
+    echo "  +---------------------------------------------+"
+    echo "  |        Audio output                          |"
+    echo "  |                                              |"
+    echo "  |  1) Auto-detect (recommended)                |"
+    echo "  |     Detects HAT via EEPROM/I2C, falls back   |"
+    echo "  |     to USB DAC or built-in audio             |"
+    echo "  |                                              |"
+    echo "  |  2) I have an audio HAT (choose from list)   |"
+    echo "  |                                              |"
+    echo "  |  3) No HAT -- use Pi built-in audio          |"
+    echo "  |     HDMI (TV/monitor) or 3.5mm jack          |"
+    echo "  |                                              |"
+    echo "  +---------------------------------------------+"
+    echo ""
+    echo "  Auto-detect is the right choice for >90% of installs."
+    echo "  Use 2 or 3 only if auto-detect failed on a previous attempt."
+    echo ""
+}
+
+get_audio_type() {
+    local choice
+    while true; do
+        read -rp "  Choose [1-3]: " choice
+        case "$choice" in
+            1) echo "auto";     return ;;
+            2) echo "hat";      return ;;
+            3) echo "internal"; return ;;
+            *) echo "  Invalid choice. Enter 1, 2, or 3." >&2 ;;
+        esac
+    done
+}
+
+# Enumerate supported HATs from client/common/audio-hats/*.conf.
+# Skips `internal-audio` (sub-menu 3) and `usb-audio` (covered by auto-detect).
+# Writes "slug|friendly name" pairs to stdout, sorted by friendly name.
+_list_supported_hats() {
+    local hat_dir="$CLIENT_DIR/common/audio-hats"
+    [[ -d "$hat_dir" ]] || return 1
+    local f slug name
+    for f in "$hat_dir"/*.conf; do
+        [[ -f "$f" ]] || continue
+        slug=$(basename "$f" .conf)
+        case "$slug" in internal-audio|usb-audio) continue ;; esac
+        # HAT_NAME="..." line — strip quotes; tolerate either single or double.
+        name=$(grep -m1 '^HAT_NAME=' "$f" | cut -d= -f2- | sed 's/^["'"'"']//;s/["'"'"']$//')
+        printf '%s|%s\n' "$slug" "${name:-$slug}"
+    done | sort -t'|' -k2,2
+}
+
+show_hat_menu() {
+    echo ""
+    echo "  +---------------------------------------------+"
+    echo "  |        Choose your audio HAT                 |"
+    echo "  +---------------------------------------------+"
+    echo ""
+    local i=1 name
+    while IFS='|' read -r _ name; do
+        printf "  %2d) %s\n" "$i" "$name"
+        i=$((i + 1))
+    done < <(_list_supported_hats)
+    echo ""
+    echo "  Cancel and return to auto-detect:"
+    echo "   0) Back"
+    echo ""
+}
+
+# Maps the numeric choice from show_hat_menu back to the slug. Returns the
+# slug on stdout, "auto" if the user picked 0 (back), or repeats the prompt
+# on invalid input. Reads the slug list a second time to keep the menu and
+# the resolver in lock-step — anything `_list_supported_hats` shows here
+# is selectable here.
+get_hat_choice() {
+    local hats=()
+    while IFS='|' read -r slug _; do
+        hats+=("$slug")
+    done < <(_list_supported_hats)
+    local total=${#hats[@]}
+    local choice
+    while true; do
+        read -rp "  Choose [0-$total]: " choice
+        if [[ "$choice" == "0" ]]; then
+            echo "auto"
+            return
+        fi
+        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= total )); then
+            echo "${hats[$((choice - 1))]}"
+            return
+        fi
+        echo "  Invalid choice. Enter a number between 0 and $total." >&2
+    done
+}
+
+show_internal_audio_menu() {
+    echo ""
+    echo "  +---------------------------------------------+"
+    echo "  |        Built-in audio output                 |"
+    echo "  |                                              |"
+    echo "  |  1) HDMI (TV / monitor)                      |"
+    echo "  |     Works on Pi 3, Pi 4, Pi 5                |"
+    echo "  |                                              |"
+    echo "  |  2) 3.5mm jack (Headphones)                  |"
+    echo "  |     Works on Pi 3, Pi 4 only                 |"
+    echo "  |     (Pi 5 has no analog jack -- pick 1)      |"
+    echo "  |                                              |"
+    echo "  +---------------------------------------------+"
+    echo ""
+    echo "  On Bookworm/Trixie the real ALSA card name is"
+    echo "  detected at first boot via 'aplay -L' -- you do"
+    echo "  not need to know it here."
+    echo ""
+}
+
+get_internal_output() {
+    local choice
+    while true; do
+        read -rp "  Choose [1-2]: " choice
+        case "$choice" in
+            1) echo "hdmi"; return ;;
+            2) echo "jack"; return ;;
+            *) echo "  Invalid choice. Enter 1 or 2." >&2 ;;
+        esac
+    done
+}
+
 # ── Advanced options menu ──────────────────────────────────────────
 # Defaults (production)
 ADV_READONLY="true"
@@ -498,6 +637,36 @@ echo ""
 echo "Installing as: $INSTALL_TYPE"
 echo ""
 
+# ── Audio output (client/both only) ──────────────────────────────
+# AUDIO_HAT default `auto` matches setup.sh's current behaviour: when the
+# install is server-only, no audio is configured, so the variable is
+# never read on the device. We still emit it to install.conf so the file
+# format stays stable across install types — easier to diff and to spot
+# manually-edited typos.
+AUDIO_HAT="auto"
+AUDIO_INTERNAL_OUTPUT=""
+if [[ "$INSTALL_TYPE" == "client" || "$INSTALL_TYPE" == "both" ]]; then
+    show_audio_menu
+    audio_type=$(get_audio_type)
+    case "$audio_type" in
+        auto)
+            AUDIO_HAT="auto"
+            ;;
+        hat)
+            show_hat_menu
+            AUDIO_HAT=$(get_hat_choice)
+            ;;
+        internal)
+            AUDIO_HAT="internal-audio"
+            show_internal_audio_menu
+            AUDIO_INTERNAL_OUTPUT=$(get_internal_output)
+            ;;
+    esac
+    echo ""
+    echo "Audio: $AUDIO_HAT${AUDIO_INTERNAL_OUTPUT:+ ($AUDIO_INTERNAL_OUTPUT)}"
+    echo ""
+fi
+
 # ── Music source (server/both only) ─────────────────────────────
 MUSIC_SOURCE=""
 NFS_SERVER=""
@@ -556,6 +725,15 @@ NFS_SERVER=$NFS_SERVER
 NFS_EXPORT=$NFS_EXPORT
 SMB_SERVER=$SMB_SERVER
 SMB_SHARE=$SMB_SHARE
+# Audio output (client/both only — server installs ignore these)
+#   AUDIO_HAT=auto             → full detection (EEPROM → I2C → USB → built-in)
+#   AUDIO_HAT=<hat-slug>       → skip detection, use named profile
+#   AUDIO_HAT=internal-audio   → built-in (HDMI or 3.5mm jack)
+# AUDIO_INTERNAL_OUTPUT only honoured when AUDIO_HAT=internal-audio:
+#   hdmi → bind to vc4-hdmi-0 / vc4hdmi0 / HDMI (kernel-dependent name)
+#   jack → bind to "Headphones" card (Pi 3/4 only — Pi 5 falls back to HDMI)
+AUDIO_HAT=$AUDIO_HAT
+AUDIO_INTERNAL_OUTPUT=$AUDIO_INTERNAL_OUTPUT
 # Advanced options
 ENABLE_READONLY=$ADV_READONLY
 SKIP_UPGRADE=$ADV_SKIP_UPGRADE

--- a/tests/test_prepare_sd_audio_menu.sh
+++ b/tests/test_prepare_sd_audio_menu.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Functional tests for the Audio output menu in prepare-sd.sh:
+#
+# - top menu (auto | hat | internal) returns the right slugs
+# - HAT sub-menu enumerates client/common/audio-hats/*.conf and excludes
+#   internal-audio + usb-audio
+# - HAT sub-menu choice 0 maps back to "auto" (operator cancellation)
+# - built-in sub-menu maps 1→hdmi, 2→jack
+# - install.conf writer emits AUDIO_HAT and AUDIO_INTERNAL_OUTPUT lines
+#
+# We extract the relevant functions from prepare-sd.sh via sed and source
+# them in a subshell — that keeps the test independent of the script's
+# top-level driver code (which would expect a real SD card to be mounted).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREPARE_SD_SH="$SCRIPT_DIR/../scripts/prepare-sd.sh"
+CLIENT_DIR_REAL="$SCRIPT_DIR/../client"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got '$actual', expected '$expected')"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (missing '$needle')"
+        fail=$((fail + 1))
+    fi
+}
+
+# Source the menu functions from prepare-sd.sh into the current shell. We
+# pull just the function bodies (everything between `get_music_source()`
+# and the next non-function top-level statement) and source them as text —
+# the same approach test_avahi_readiness.sh uses for unit-file heredocs.
+# CLIENT_DIR must be set for _list_supported_hats; we point it at the real
+# client/ tree in this repo so the enumeration is genuine. shellcheck can't
+# see the indirect reference inside `_list_supported_hats` (sourced via
+# eval after we declare it), so the SC2034 disable below is acknowledged.
+# shellcheck disable=SC2034
+CLIENT_DIR="$CLIENT_DIR_REAL"
+fn_block=$(sed -n '/^show_audio_menu()/,/^get_internal_output() {$/p' "$PREPARE_SD_SH")
+# Append the closing 6-line body of get_internal_output (sed range stops at
+# the opening brace — we need to include the body and closing brace).
+fn_block+=$'\n'$(sed -n '/^get_internal_output() {$/,/^}$/p' "$PREPARE_SD_SH" | tail -n +2)
+# shellcheck disable=SC1090
+eval "$fn_block"
+
+echo "=== Static checks ==="
+for fn in show_audio_menu get_audio_type _list_supported_hats show_hat_menu \
+          get_hat_choice show_internal_audio_menu get_internal_output; do
+    if declare -F "$fn" >/dev/null; then
+        echo "  PASS: $fn defined"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $fn not defined after sourcing"
+        fail=$((fail + 1))
+    fi
+done
+
+echo
+echo "=== _list_supported_hats: enumeration ==="
+hats_output=$(_list_supported_hats)
+hat_count=$(printf '%s\n' "$hats_output" | grep -c '|' || true)
+# 17 .conf files total, minus internal-audio and usb-audio = 15 HATs.
+assert_eq "$hat_count" "15" "enumerates 15 supported HATs (17 confs - 2 reserved)"
+
+# Required HATs that MUST appear in the list — these are real boards in the
+# community and removing one is a regression.
+for required in hifiberry-dac-std hifiberry-amp2 iqaudio-dac justboom-dac \
+                allo-boss waveshare-wm8960 innomaker-dac-pro; do
+    assert_contains "$hats_output" "$required|" "list includes $required"
+done
+
+# Reserved entries that MUST NOT appear (handled by other menu branches).
+for excluded in internal-audio usb-audio; do
+    if ! grep -qF "$excluded|" <<<"$hats_output"; then
+        echo "  PASS: list excludes $excluded (covered by other menu branches)"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: list should exclude $excluded"
+        fail=$((fail + 1))
+    fi
+done
+
+echo
+echo "=== _list_supported_hats: HAT_NAME quoting ==="
+# Friendly names come from HAT_NAME="..." — both single and double quotes
+# must be stripped. Sample a known entry.
+hifi_line=$(printf '%s\n' "$hats_output" | grep '^hifiberry-dac-std|')
+hifi_name=${hifi_line#*|}
+assert_eq "$hifi_name" "HiFiBerry DAC+ (Standard/clone)" "hifiberry-dac-std friendly name preserved"
+
+echo
+echo "=== get_audio_type: input → slug mapping ==="
+# Drive the function with stdin and capture the slug. Trailing newline is
+# normal — assert_eq compares exact strings.
+result=$(echo "1" | get_audio_type)
+assert_eq "$result" "auto" "input '1' → 'auto'"
+result=$(echo "2" | get_audio_type)
+assert_eq "$result" "hat" "input '2' → 'hat'"
+result=$(echo "3" | get_audio_type)
+assert_eq "$result" "internal" "input '3' → 'internal'"
+# Invalid input keeps prompting; we send an invalid then a valid value.
+result=$(printf 'x\n4\n2\n' | get_audio_type)
+assert_eq "$result" "hat" "invalid inputs re-prompt until valid"
+
+echo
+echo "=== get_hat_choice: numeric input → slug mapping ==="
+# 0 always returns auto (cancellation).
+result=$(echo "0" | get_hat_choice)
+assert_eq "$result" "auto" "input '0' → 'auto' (back/cancel)"
+# Choice 1 should map to the first alphabetically-sorted HAT — known to be
+# "Allo Boss DAC" (slug: allo-boss) from the static check above.
+result=$(echo "1" | get_hat_choice)
+assert_eq "$result" "allo-boss" "input '1' → first HAT alphabetically (allo-boss)"
+# Choice 15 must map to the last HAT (Waveshare WM8960). If the count
+# changes when someone adds/removes a .conf, this assertion will surface
+# the change so the test stays calibrated.
+result=$(echo "15" | get_hat_choice)
+assert_eq "$result" "waveshare-wm8960" "input '15' → last HAT (waveshare-wm8960)"
+# Out-of-range input re-prompts until valid.
+result=$(printf '99\n0\n' | get_hat_choice)
+assert_eq "$result" "auto" "out-of-range re-prompts; final 0 returns auto"
+
+echo
+echo "=== get_internal_output ==="
+result=$(echo "1" | get_internal_output)
+assert_eq "$result" "hdmi" "input '1' → 'hdmi'"
+result=$(echo "2" | get_internal_output)
+assert_eq "$result" "jack" "input '2' → 'jack'"
+
+echo
+echo "=== install.conf heredoc emits new keys ==="
+# Source the actual prepare-sd.sh heredoc block (where install.conf is
+# written) and check that it includes the two new keys. We grep the
+# script text directly because rendering the heredoc would require
+# bootstrapping the whole driver.
+assert_contains "$(<"$PREPARE_SD_SH")" "AUDIO_HAT=\$AUDIO_HAT" "install.conf heredoc writes AUDIO_HAT"
+assert_contains "$(<"$PREPARE_SD_SH")" "AUDIO_INTERNAL_OUTPUT=\$AUDIO_INTERNAL_OUTPUT" "install.conf heredoc writes AUDIO_INTERNAL_OUTPUT"
+
+echo
+echo "Results: $pass passed, $fail failed"
+exit $(( fail > 0 ? 1 : 0 ))


### PR DESCRIPTION
## Sintesi

Aggiunge un quarto menu top-level a `prepare-sd.sh` (e parità PowerShell `prepare-sd.ps1`) per dare all'utente la possibilità di **disattivare l'auto-detect quando non funziona**, scegliendo manualmente HAT o built-in audio.

```
  +---------------------------------------------+
  |        Audio output                          |
  |  1) Auto-detect (recommended)                |
  |  2) I have an audio HAT (choose from list)   |
  |  3) No HAT -- use Pi built-in audio          |
  +---------------------------------------------+
```

## Motivazione

L'audit pre-PR-#404 ha confermato che `setup.sh:1088` hard-coda il nome card ALSA `Headphones` per built-in audio (`internal-audio.conf`). Corretto solo per Pi 3/4 + kernel legacy. Su Bookworm/Trixie HDMI è `vc4-hdmi-0` / `vc4-hdmi-1`, e il Pi 5 **non ha jack analogico**. Senza override manuale, un utente Pi 5 senza HAT non aveva un percorso pulito nell'installer.

## Architettura

```
  prepare-sd.sh         install.conf              setup.sh sul Pi
  ──────────────        ─────────────             ──────────────
  Audio output menu  →  AUDIO_HAT=<slug>       →  source HAT profile
  Built-in sub-menu  →  AUDIO_INTERNAL_OUTPUT=    override HAT_CARD_NAME
                          hdmi | jack             via aplay -L probe
```

Nuovo helper `detect_internal_card_name()` in `audio-hat-detect.sh` cammina `aplay -L` al primo boot:
- `hdmi` → `vc4-hdmi-0` | `vc4-hdmi-1` | `vc4hdmi0` | `vc4hdmi1` | `HDMI` (priorità di match)
- `jack` → `Headphones` (Pi 3/4 only)

**Pi 5 fallback**: se l'operatore sceglie "jack" ma nessuna card Headphones è presente (hardware Pi 5), setup.sh logga un warning e riprova automaticamente con `hdmi` — l'operatore non si ritrova mai con una card non legata e snapclient che non parte.

## Design highlights

- **Lista HAT dinamica**: enumera `client/common/audio-hats/*.conf` a runtime, escludendo `internal-audio` e `usb-audio`. Aggiungere un nuovo profilo HAT al repo lo rende automaticamente selezionabile senza ulteriori edit del menu
- **HAT_NAME friendly** parsato dai .conf, ordinato alfabeticamente (15 HAT supportati: HiFiBerry × 6, IQaudio × 3, JustBoom × 2, Allo × 2, Innomaker, Waveshare)
- **PowerShell parity** (`prepare-sd.ps1`): stesso wording, stessi prompt, stesso install.conf
- **Backward compatible**: `AUDIO_HAT=auto` di default, `AUDIO_INTERNAL_OUTPUT=""` di default — install.conf esistenti continuano a funzionare

## Pi 5 validation strategy

Senza Pi 5 hardware nella fleet attiva, le fixture `aplay -L` in `test_internal_card_detect.sh` sono **snapshot statici** presi dalla documentazione Raspberry Pi ufficiale e dalle release notes Bookworm — non sintetizzati. Se upstream rinomina una card il test fallisce e ci dice esattamente quale fixture aggiornare.

## Validation

**Done locally:**
- [x] `tests/test_prepare_sd_audio_menu.sh` → 30/30 PASS (HAT enumeration, slug mapping, install.conf heredoc)
- [x] `client/tests/test_internal_card_detect.sh` → 11/11 PASS (Pi 4 legacy / Pi 4 Bookworm / Pi 5 Bookworm fixtures, Pi 5 jack→hdmi fallback, defensive: invalid mode, missing arg, aplay unavailable)
- [x] Suite server → 50/50 PASS (no regression)
- [x] Suite client → 5/5 PASS (escluso `test_discover_server.sh` che fallisce pre-esistente su main, out of scope)
- [x] `shellcheck -S warning -x` clean su tutti i 5 bash modificati + 2 nuovi test
- [x] `bash -n` clean

**Deferred to release-gate:**
- Reflash canary Pi 4 con opzione 3 (built-in HDMI) per validation device-side completa
- Reflash canary Pi 5 (se accessibile) per validation jack→hdmi fallback reale

## Docs

- `INSTALL.md` / `INSTALL.it.md` — nuova sezione "Menu 2 — Audio output" tra install-type e music-source; music rinumerato a Menu 3
- `HARDWARE.md` / `HARDWARE.it.md` — righe HDMI/jack aggiornate con nomi card kernel-dependent + nota fallback Pi 5; nuovo tip che punta al menu manual override

## Files

| File | Change | LOC |
|------|--------|-----|
| `scripts/prepare-sd.sh` | +5 funzioni menu + wiring nel flow + install.conf keys | +178 |
| `scripts/prepare-sd.ps1` | parità Windows | +152 |
| `install.conf.template` | +AUDIO_HAT, +AUDIO_INTERNAL_OUTPUT | +23 |
| `client/common/scripts/setup.sh` | read + override block built-in con fallback Pi 5 | +32 |
| `client/common/scripts/audio-hat-detect.sh` | `detect_internal_card_name()` | +59 |
| `tests/test_prepare_sd_audio_menu.sh` (new) | 30 assert | +147 |
| `client/tests/test_internal_card_detect.sh` (new) | 11 assert, 3 fixture | +163 |
| `docs/INSTALL.md` + `.it.md` | Menu 2 audio + Menu 3 renumber | +32 ×2 |
| `docs/HARDWARE.md` + `.it.md` | row updates + manual override tip | +6 ×2 |

No CHANGELOG — parallel-branch rule, accumulato per release-tag v0.7.5.

## Related

- Risolve il LOW #3 dell'audit batch precedente (Pi 5 Headphones hardcode fragility)
- Indipendente da PR #404 (firstboot pipefail tolerance) — file completamente diversi