### PR TITLE
style(firstboot): trim multi-line comment blocks per CLAUDE.md convention

### DIFF
--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -64,12 +64,7 @@ if [[ ! -d "$SNAP_BOOT" ]]; then
 fi
 
 # ── Read install.conf ────────────────────────────────────────────
-# Pipelines below append `|| true` to neutralize `grep`'s exit-1 when a key
-# is missing: without it, `set -euo pipefail` would propagate the failure
-# through the command substitution and kill firstboot.sh silently — BEFORE
-# the logger, the TUI, or the failure trap are wired up. The `${VAR:-default}`
-# safety net immediately after only triggers if VAR is *unset or empty*, not
-# if the assignment itself aborts.
+# `|| true` neutralises grep's exit-1 when a key is missing — otherwise pipefail kills firstboot before the TUI/logger are up.
 INSTALL_TYPE="server"
 if [[ -f "$SNAP_BOOT/install.conf" ]]; then
     INSTALL_TYPE=$(grep -m1 '^INSTALL_TYPE=' "$SNAP_BOOT/install.conf" | cut -d= -f2 | tr -d '[:space:]' || true)
@@ -90,10 +85,7 @@ SMB_PASS=""
 }
 # shellcheck disable=SC2034
 if [[ -f "$SNAP_BOOT/install.conf" ]]; then
-    # See comment above the INSTALL_TYPE block for the rationale on `|| true`.
-    # Each grep|cut|tr pipeline tolerates the key being absent — downstream
-    # code (mount-music.sh, sanitize_*) already handles empty values via
-    # case statements and fallback paths.
+    # Same `|| true` pattern as INSTALL_TYPE above; sanitize_* handles empty values.
     MUSIC_SOURCE=$(grep -m1 '^MUSIC_SOURCE=' "$SNAP_BOOT/install.conf" | cut -d= -f2 | tr -d '[:space:]' || true)
     # Source sanitize.sh for re-validation
     if [[ -f "$SNAP_BOOT/common/sanitize.sh" ]]; then


### PR DESCRIPTION
## Sintesi

claude-review LOW finding su PR #404 (mergeato come 58ddabf): due blocchi commento aggiunti in #404 (6 e 4 righe rispettivamente) eccedono la convention CLAUDE.md "one short line max" per i commenti.

## Modifica

`scripts/firstboot.sh`: trim 2 blocchi commento → 1 riga ciascuno, il secondo cross-referenzia il primo invece di duplicare il rationale.

Contenuto tecnico invariato — cambia solo il line count (-10 / +2).

## Validation

**Done locally:**
- [x] `bash tests/test_firstboot_install_conf_tolerance.sh` → 13/13 PASS (no functional change)
- [x] `shellcheck -S warning -x scripts/firstboot.sh` clean
- [x] `bash -n` clean

No CHANGELOG — parallel-branch rule.