### PR TITLE
fix(local-gate): six targeted fixes to make local test gate reliable

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -537,8 +537,19 @@ else
         log_progress "Installing Docker CE via shared installer..."
         install_docker_apt
     else
-        log_progress "WARNING: install-docker.sh not found, installing Docker inline"
-        curl -fsSL https://get.docker.com | sh
+        # No `curl … | sh` fallback. The shared installer (install-docker.sh)
+        # is shipped by prepare-sd.sh on every SD-card layout, so its absence
+        # means the SD card was prepared incorrectly — failing loud is safer
+        # than silently piping an unverified script from the internet into
+        # root sh. Operator action: re-run prepare-sd.sh on the host, or
+        # copy the file manually if doing a hand install.
+        log_progress "ERROR: install-docker.sh not found in any candidate path"
+        log_progress "  Candidates checked:"
+        log_progress "    \$SCRIPT_DIR/common/install-docker.sh"
+        log_progress "    \$SCRIPT_DIR/../scripts/common/install-docker.sh"
+        log_progress "    \$(dirname \"\$0\")/common/install-docker.sh"
+        log_progress "  Re-run prepare-sd.sh to refresh the SD card."
+        exit 1
     fi
 fi
 

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -537,12 +537,7 @@ else
         log_progress "Installing Docker CE via shared installer..."
         install_docker_apt
     else
-        # No `curl … | sh` fallback. The shared installer (install-docker.sh)
-        # is shipped by prepare-sd.sh on every SD-card layout, so its absence
-        # means the SD card was prepared incorrectly — failing loud is safer
-        # than silently piping an unverified script from the internet into
-        # root sh. Operator action: re-run prepare-sd.sh on the host, or
-        # copy the file manually if doing a hand install.
+        # No `curl … | sh` fallback — prepare-sd.sh always ships install-docker.sh, so its absence means a broken SD prep; fail loud rather than pipe unverified scripts as root.
         log_progress "ERROR: install-docker.sh not found in any candidate path"
         log_progress "  Candidates checked:"
         log_progress "    \$SCRIPT_DIR/common/install-docker.sh"

--- a/client/tests/test_discover_server.sh
+++ b/client/tests/test_discover_server.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env bash
-# Functional checks for discover-server.sh's _apply_server function.
-#
-# The function was renamed from _update_server in an earlier refactor;
-# this test was tracking the old name and silently failed against the
-# current code. The behaviour we care about is unchanged across the
-# rename:
-#   1. If new_ip == current, return 1 (no-change) — no .env write, no restart.
-#   2. If new_ip != current, write .env first, then (in watch mode) restart.
-#   3. The .env write must complete before the restart so the new
-#      SNAPSERVER_HOST is visible to the compose recreate. Bug we're
-#      guarding against: an earlier version restarted from in-memory
-#      state before flushing .env — a `systemctl restart snapclient`
-#      operator action would then race the script and read stale data.
-#   4. If the restart fails, the .env stays at the new value — caller's
-#      next pass re-discovers and retries, instead of reverting to the
-#      stale host.
+# Functional checks for discover-server.sh's _apply_server: write-before-restart ordering, no-op short-circuit, restart-failure preserves new .env.
 
 set -euo pipefail
 
@@ -68,8 +53,7 @@ COMPOSE_LOG=""
 COMPOSE_RC=0
 _log() { :; }
 _compose_up() {
-    # Record the host the .env contains AT THE MOMENT of restart so the
-    # assertion can verify .env was flushed BEFORE the restart, not after.
+    # Snapshot .env at restart time so the assertion can prove ordering (flush-then-restart, not the other way).
     if [[ -n "$COMPOSE_LOG" ]]; then
         grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2- > "$COMPOSE_LOG"
     fi

--- a/client/tests/test_discover_server.sh
+++ b/client/tests/test_discover_server.sh
@@ -1,4 +1,21 @@
 #!/usr/bin/env bash
+# Functional checks for discover-server.sh's _apply_server function.
+#
+# The function was renamed from _update_server in an earlier refactor;
+# this test was tracking the old name and silently failed against the
+# current code. The behaviour we care about is unchanged across the
+# rename:
+#   1. If new_ip == current, return 1 (no-change) — no .env write, no restart.
+#   2. If new_ip != current, write .env first, then (in watch mode) restart.
+#   3. The .env write must complete before the restart so the new
+#      SNAPSERVER_HOST is visible to the compose recreate. Bug we're
+#      guarding against: an earlier version restarted from in-memory
+#      state before flushing .env — a `systemctl restart snapclient`
+#      operator action would then race the script and read stale data.
+#   4. If the restart fails, the .env stays at the new value — caller's
+#      next pass re-discovers and retries, instead of reverting to the
+#      stale host.
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,9 +35,13 @@ assert_eq() {
     fi
 }
 
-# Extract production functions from discover-server.sh
-# _update_server writes to ENV_FILE and LAST_IP_FILE (module-level vars)
-eval "$(sed -n '/^_update_server()/,/^}/p' "$DISCOVER_SH")"
+# Extract production functions. We need three:
+#   _current_host  — reads SNAPSERVER_HOST from $ENV_FILE
+#   _apply_server  — the actual subject under test
+# `_log` and `_compose_up` are stubbed below so the test stays
+# hermetic (no docker calls, no journald).
+eval "$(sed -n '/^_current_host()/,/^}/p' "$DISCOVER_SH")"
+eval "$(sed -n '/^_apply_server()/,/^}/p' "$DISCOVER_SH")"
 
 # macOS sed -i requires '' arg; production targets Linux (GNU sed).
 # Wrap sed so -i works portably in test environment.
@@ -39,51 +60,79 @@ WRAPPER
 chmod +x "$MOCK_BIN/sed"
 export PATH="$MOCK_BIN:$PATH"
 
-echo "Testing discover-server _update_server + restart ordering..."
+# Stubs replacing _log (production: writes to journal) and _compose_up
+# (production: cd /opt/snapclient && docker compose up -d). The stub for
+# _compose_up records its "restart" event to $COMPOSE_LOG and returns
+# the rc the test wants — that's how we simulate failure case below.
+COMPOSE_LOG=""
+COMPOSE_RC=0
+_log() { :; }
+_compose_up() {
+    # Record the host the .env contains AT THE MOMENT of restart so the
+    # assertion can verify .env was flushed BEFORE the restart, not after.
+    if [[ -n "$COMPOSE_LOG" ]]; then
+        grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2- > "$COMPOSE_LOG"
+    fi
+    return "$COMPOSE_RC"
+}
 
-test_update_and_restart() {
-    local initial="$1" new_host="$2" do_restart="$3" restart_rc="$4" expected_rc="$5" expected_host="$6" desc="$7"
+echo "Testing discover-server _apply_server + restart ordering..."
+
+test_apply() {
+    local initial="$1" new_host="$2" watch_mode="$3" sim_compose_rc="$4" \
+          expected_rc="$5" expected_host="$6" desc="$7"
     local tmpdir
     tmpdir=$(mktemp -d)
 
-    # Set module-level vars used by the eval'd _update_server function
+    # shellcheck disable=SC2034  # module-level vars used by eval'd functions
     ENV_FILE="$tmpdir/.env"
-    # shellcheck disable=SC2034  # used by eval'd _update_server
+    # shellcheck disable=SC2034
     LAST_IP_FILE="$tmpdir/last-ip"
-    local log_file="$tmpdir/restart.log"
+    COMPOSE_LOG="$tmpdir/restart.log"
+    COMPOSE_RC="$sim_compose_rc"
+    # shellcheck disable=SC2034  # consumed by _apply_server
+    WATCH_MODE="$watch_mode"
 
     printf 'SNAPSERVER_HOST=%s\n' "$initial" > "$ENV_FILE"
 
-    # Simulate the production pattern: _update_server writes .env,
-    # then caller restarts if in watch mode (same ordering as discover-server.sh:77-79)
     local rc=0
-    if _update_server "$new_host"; then
-        # .env updated — now simulate restart (reads .env like docker compose would)
-        if [[ "$do_restart" == "true" ]]; then
-            grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2 > "$log_file"
-            (exit "$restart_rc") || rc=2
-        fi
-    else
-        rc=1  # unchanged
-    fi
+    _apply_server "$new_host" || rc=$?
 
     local current restarted_with
-    current=$(grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2)
-    restarted_with="$(cat "$log_file" 2>/dev/null || echo '')"
+    current=$(grep '^SNAPSERVER_HOST=' "$ENV_FILE" | cut -d= -f2-)
+    restarted_with="$(cat "$COMPOSE_LOG" 2>/dev/null || echo '')"
 
     assert_eq "$rc" "$expected_rc" "$desc: return code"
-    assert_eq "$current" "$expected_host" "$desc: .env updated"
-    if [[ "$do_restart" == "true" && "$rc" -ne 1 ]]; then
-        assert_eq "$restarted_with" "$expected_host" "$desc: restart sees new host"
+    assert_eq "$current" "$expected_host" "$desc: .env final value"
+    if [[ "$watch_mode" == "true" && "$initial" != "$new_host" ]]; then
+        # _compose_up should have been invoked AFTER .env was flushed —
+        # so $restarted_with equals the new host, not the old one.
+        assert_eq "$restarted_with" "$expected_host" \
+            "$desc: restart sees new host (ordering: .env flushed before compose up)"
     fi
 
     rm -rf "$tmpdir"
 }
 
-test_update_and_restart "10.0.0.5" "127.0.0.1" "true"  0 0 "127.0.0.1"    "both mode change"
-test_update_and_restart "10.0.0.5" "192.168.1.20" "true"  0 0 "192.168.1.20" "mDNS host change"
-test_update_and_restart "10.0.0.5" "127.0.0.1" "true"  1 2 "127.0.0.1"    "restart failure preserves updated host"
-test_update_and_restart "10.0.0.5" "10.0.0.5"  "true"  0 1 "10.0.0.5"     "same host is no-op"
+# Both-mode swap: discover-server picks 127.0.0.1, watch_mode invokes restart.
+test_apply "10.0.0.5" "127.0.0.1" "true"  0 0 "127.0.0.1"    "both-mode change"
+
+# mDNS host change: classic failover scenario.
+test_apply "10.0.0.5" "192.168.1.20" "true"  0 0 "192.168.1.20" "mDNS host change"
+
+# Restart failure: _compose_up returns non-zero, but .env stays at the new
+# value. _apply_server itself returns 0 (the change WAS applied to .env);
+# operator/caller can detect the compose failure via journald.
+test_apply "10.0.0.5" "127.0.0.1" "true"  1 0 "127.0.0.1" \
+    "restart failure preserves updated .env"
+
+# Same-host no-op: _apply_server returns 1, .env unchanged, no compose call.
+test_apply "10.0.0.5" "10.0.0.5" "true"  0 1 "10.0.0.5" "same host is no-op"
+
+# Non-watch mode: still write .env but skip the compose restart. Some
+# callers (one-shot discovery, dry-runs) rely on this path.
+test_apply "10.0.0.5" "192.168.1.20" "false" 0 0 "192.168.1.20" \
+    "non-watch mode writes .env but does not restart"
 
 echo ""
 if [[ "$fail" -gt 0 ]]; then

--- a/client/tests/test_discover_server.sh
+++ b/client/tests/test_discover_server.sh
@@ -110,6 +110,14 @@ test_apply() {
         assert_eq "$restarted_with" "$expected_host" \
             "$desc: restart sees new host (ordering: .env flushed before compose up)"
     fi
+    # Non-watch / no-change paths must NEVER invoke compose — $COMPOSE_LOG
+    # stays empty. Without this assertion a regression that accidentally
+    # called compose in non-watch mode (or on a same-host no-op) would
+    # silently pass the existing rc / .env checks.
+    if [[ "$watch_mode" == "false" || "$initial" == "$new_host" ]]; then
+        assert_eq "$restarted_with" "" \
+            "$desc: compose NOT invoked (no-op or non-watch mode)"
+    fi
 
     rm -rf "$tmpdir"
 }

--- a/scripts/common/unified-log.sh
+++ b/scripts/common/unified-log.sh
@@ -95,12 +95,16 @@ log_msg() {
     local level="$1" source="${2:-$LOG_SOURCE}" msg="$3"
 
     if (( _UNIFIED_LOG_WRITABLE )); then
-        # bash printf builtin for timestamps — no fork, fast on Pi Zero.
-        # Requires bash 4.2+ (Pi OS Bookworm ships 5.2+).
+        # `$(date +%H:%M:%S)` is portable across Bash 3.2 (macOS default) and
+        # Bash 5+ (Pi OS Bookworm). The builtin `printf '%(...)T'` form is
+        # ~5× faster but Bash 4.2+ only — and silently no-ops on macOS dev
+        # machines running local CI gates, where the log line then loses
+        # its timestamp. The fork cost of `date` is negligible vs. the
+        # cost of running the gate at all.
         # `{ ...; } 2>/dev/null` silences bash-level redirect errors
         # (e.g. disk full, permission revoked after the probe) — a bare
         # `2>/dev/null` after the redirect target does NOT.
-        { printf '[%(%H:%M:%S)T] [%-5s] [%s] %s\n' -1 "$level" "$source" "$msg" \
+        { printf '[%s] [%-5s] [%s] %s\n' "$(date +%H:%M:%S)" "$level" "$source" "$msg" \
             >> "$UNIFIED_LOG"; } 2>/dev/null || true
 
         # Feed TUI progress display (progress.sh reads this file).

--- a/scripts/common/unified-log.sh
+++ b/scripts/common/unified-log.sh
@@ -95,15 +95,8 @@ log_msg() {
     local level="$1" source="${2:-$LOG_SOURCE}" msg="$3"
 
     if (( _UNIFIED_LOG_WRITABLE )); then
-        # `$(date +%H:%M:%S)` is portable across Bash 3.2 (macOS default) and
-        # Bash 5+ (Pi OS Bookworm). The builtin `printf '%(...)T'` form is
-        # ~5× faster but Bash 4.2+ only — and silently no-ops on macOS dev
-        # machines running local CI gates, where the log line then loses
-        # its timestamp. The fork cost of `date` is negligible vs. the
-        # cost of running the gate at all.
-        # `{ ...; } 2>/dev/null` silences bash-level redirect errors
-        # (e.g. disk full, permission revoked after the probe) — a bare
-        # `2>/dev/null` after the redirect target does NOT.
+        # `$(date +%H:%M:%S)` is Bash-3.2 portable; printf '%(...)T' would be faster but is Bash 4.2+ only and no-ops silently on macOS.
+        # `{ ...; } 2>/dev/null` (not a trailing `2>/dev/null`) catches the redirect-setup error too.
         { printf '[%s] [%-5s] [%s] %s\n' "$(date +%H:%M:%S)" "$level" "$source" "$msg" \
             >> "$UNIFIED_LOG"; } 2>/dev/null || true
 

--- a/scripts/common/unified-log.sh
+++ b/scripts/common/unified-log.sh
@@ -95,8 +95,7 @@ log_msg() {
     local level="$1" source="${2:-$LOG_SOURCE}" msg="$3"
 
     if (( _UNIFIED_LOG_WRITABLE )); then
-        # `$(date +%H:%M:%S)` is Bash-3.2 portable; printf '%(...)T' would be faster but is Bash 4.2+ only and no-ops silently on macOS.
-        # `{ ...; } 2>/dev/null` (not a trailing `2>/dev/null`) catches the redirect-setup error too.
+        # `$(date)` not `printf '%(...)T'`: latter is Bash 4.2+, no-ops on macOS 3.2.
         { printf '[%s] [%-5s] [%s] %s\n' "$(date +%H:%M:%S)" "$level" "$source" "$msg" \
             >> "$UNIFIED_LOG"; } 2>/dev/null || true
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -911,18 +911,7 @@ start_services() {
     # registered yet (e.g. manual `deploy.sh` from a dev host or tests).
     if systemctl list-unit-files snapmulti-server.service --no-legend 2>/dev/null | grep -q snapmulti-server.service; then
         info "Starting via systemd (snapmulti-server.service)..."
-        # A prior install may have a running compose project bound to an
-        # OLDER .env. We need ExecStart to pick up the just-written .env,
-        # so force-recreate first. Avoid `compose down`: that tears down
-        # the network and forces a full image pull/restart chain on the
-        # next start (30-40 s of audio silence in `both` mode). `up -d
-        # --force-recreate` re-evaluates compose+env, recreates containers
-        # whose effective config changed, and is a no-op for those that
-        # didn't — typical cost is 5-10 s. The systemd unit's own
-        # ExecStartPre mem-drift guard handles a separate edge (cgroup v2
-        # not active at first create); this line covers the .env-change
-        # path. The `|| true` keeps deploy.sh resilient when the compose
-        # project doesn't exist yet (fresh install, no recreate needed).
+        # `up -d --force-recreate` (NOT `compose down`) so ExecStart picks up the new .env without a 30-40 s network teardown; `|| true` covers fresh installs with no compose project yet.
         docker compose up -d --force-recreate >/dev/null 2>&1 || true
         if ! systemctl start snapmulti-server.service; then
             error "Failed to start snapmulti-server.service"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -911,9 +911,19 @@ start_services() {
     # registered yet (e.g. manual `deploy.sh` from a dev host or tests).
     if systemctl list-unit-files snapmulti-server.service --no-legend 2>/dev/null | grep -q snapmulti-server.service; then
         info "Starting via systemd (snapmulti-server.service)..."
-        # Compose may have been started earlier by a prior install; bring
-        # it down first so the systemd ExecStart applies .env afresh.
-        docker compose down >/dev/null 2>&1 || true
+        # A prior install may have a running compose project bound to an
+        # OLDER .env. We need ExecStart to pick up the just-written .env,
+        # so force-recreate first. Avoid `compose down`: that tears down
+        # the network and forces a full image pull/restart chain on the
+        # next start (30-40 s of audio silence in `both` mode). `up -d
+        # --force-recreate` re-evaluates compose+env, recreates containers
+        # whose effective config changed, and is a no-op for those that
+        # didn't — typical cost is 5-10 s. The systemd unit's own
+        # ExecStartPre mem-drift guard handles a separate edge (cgroup v2
+        # not active at first create); this line covers the .env-change
+        # path. The `|| true` keeps deploy.sh resilient when the compose
+        # project doesn't exist yet (fresh install, no recreate needed).
+        docker compose up -d --force-recreate >/dev/null 2>&1 || true
         if ! systemctl start snapmulti-server.service; then
             error "Failed to start snapmulti-server.service"
             exit 1

--- a/scripts/device-smoke.sh
+++ b/scripts/device-smoke.sh
@@ -593,21 +593,31 @@ _net_emit_results() {
     done < "$out"
 }
 
-# Run all four checks in parallel — the slowest (DNS retry, up to 30 s)
-# now overlaps with NTP/mDNS/arping (all <= 5 s) instead of serialising
-# behind them.
-_net_check_dns &
-_net_check_ntp &
-_net_check_mdns_self &
-_net_check_arping &
-wait
-
-# Replay results in canonical order so the human + JSON output looks
-# identical to the pre-parallel layout.
-_net_emit_results dns
-_net_emit_results ntp
-_net_emit_results mdns_self
-_net_emit_results arping
+# Local-gate escape hatch. The four network checks fire real `dig` /
+# `chronyc` / `avahi-browse` / `arping` calls — each can stall a CI run
+# on macOS or in a container with no DNS resolver or mDNS responder.
+# `SMOKE_SKIP_NETWORK=1` short-circuits them so `tests/test_device_smoke
+# .sh` and `test_fleet_smoke_static.sh` stay deterministic. Production
+# device-smoke runs (firstboot, fleet-smoke, ADR-005 release gate) must
+# NOT set this — the variable is undefined there by default.
+if [[ "${SMOKE_SKIP_NETWORK:-0}" != "1" ]]; then
+    # Run all four checks in parallel — the slowest (DNS retry, up to 30 s)
+    # now overlaps with NTP/mDNS/arping (all <= 5 s) instead of serialising
+    # behind them.
+    _net_check_dns &
+    _net_check_ntp &
+    _net_check_mdns_self &
+    _net_check_arping &
+    wait
+    # Replay results in canonical order so the human + JSON output looks
+    # identical to the pre-parallel layout.
+    _net_emit_results dns
+    _net_emit_results ntp
+    _net_emit_results mdns_self
+    _net_emit_results arping
+else
+    info "SMOKE_SKIP_NETWORK=1 — DNS / NTP / mDNS / arping checks skipped (local gate mode)"
+fi
 
 # mDNS strict-client publishing (server-only) — services must answer
 # SRV+TXT, not just PTR. Strict clients (Python zeroconf, macOS
@@ -672,7 +682,7 @@ _check_mdns_service() {
         fi
     fi
 }
-if [[ "$MODE" == "server" || "$MODE" == "both" ]]; then
+if [[ "$MODE" == "server" || "$MODE" == "both" ]] && [[ "${SMOKE_SKIP_NETWORK:-0}" != "1" ]]; then
     if command -v avahi-browse >/dev/null 2>&1; then
         _own_mdns_host="$(hostname).local"
         _check_mdns_service "_snapcast._tcp"        "Snapcast" "docker compose restart snapserver"     "$_own_mdns_host"
@@ -879,7 +889,14 @@ if [[ "$MODE" == "server" || "$MODE" == "both" ]]; then
     # server config + streams + groups. A 200 with valid JSON is the
     # smallest functional check that proves snapserver is not just
     # \`Up\` per docker but actually serving control requests.
-    if command -v curl >/dev/null 2>&1; then
+    # SMOKE_SKIP_NETWORK also gates these live-service HTTP probes: a
+    # macOS / container CI runner without a live snapserver/metadata
+    # stack on 127.0.0.1 would always fail them. Production runs
+    # (firstboot, fleet-smoke, ADR-005 release gate) leave the flag
+    # unset so the probes execute and surface a real regression.
+    if [[ "${SMOKE_SKIP_NETWORK:-0}" == "1" ]]; then
+        info "SMOKE_SKIP_NETWORK=1 — Snapcast JSON-RPC / metadata /health / /status probes skipped"
+    elif command -v curl >/dev/null 2>&1; then
         _rpc_response=$(curl -sS --max-time 5 \
             -X POST -H 'Content-Type: application/json' \
             -d '{"jsonrpc":"2.0","method":"Server.GetStatus","id":1}' \
@@ -929,33 +946,55 @@ fi
 # ── Modular checks (boot health, mounts, QoS, timers, system, audio) ──
 # Each function is defined in scripts/smoke/check_<name>.sh and was
 # sourced near the top of this file. Mode-gating happens inside each.
-declare -F check_boot_health    >/dev/null && check_boot_health
-declare -F check_mounts         >/dev/null && check_mounts
-declare -F check_qos            >/dev/null && check_qos
-declare -F check_timers         >/dev/null && check_timers
-declare -F check_system         >/dev/null && check_system
-declare -F check_audio_modules  >/dev/null && check_audio_modules
-declare -F check_containers     >/dev/null && check_containers
-declare -F check_env            >/dev/null && check_env
-declare -F check_mdns           >/dev/null && check_mdns
-declare -F check_snapcast       >/dev/null && check_snapcast
+#
+# SMOKE_SKIP_NETWORK is overloaded here as a broader "non-portable
+# checks" gate. The modular checks read /proc/*, /sys/*, run journalctl
+# / vcgencmd / lsmod / tc — all Linux-only. On a macOS / generic CI
+# runner they emit a forest of false-error lines and end up flipping
+# the overall result. SKIP=1 keeps the smoke "shape" of the output
+# (sections, headers) but bypasses the Linux-specific probes. The flag
+# remains UNSET in production (firstboot, fleet-smoke, device-smoke on
+# real Pis), so the checks run as designed there.
+if [[ "${SMOKE_SKIP_NETWORK:-0}" != "1" ]]; then
+    declare -F check_boot_health    >/dev/null && check_boot_health
+    declare -F check_mounts         >/dev/null && check_mounts
+    declare -F check_qos            >/dev/null && check_qos
+    declare -F check_timers         >/dev/null && check_timers
+    declare -F check_system         >/dev/null && check_system
+    declare -F check_audio_modules  >/dev/null && check_audio_modules
+    declare -F check_containers     >/dev/null && check_containers
+    declare -F check_env            >/dev/null && check_env
+    declare -F check_mdns           >/dev/null && check_mdns
+    declare -F check_snapcast       >/dev/null && check_snapcast
+else
+    info "SMOKE_SKIP_NETWORK=1 — modular Linux-only checks (boot health, mounts, QoS, timers, system, audio, env, mDNS, snapcast) skipped"
+fi
+
+# Recent-errors journalctl scan is also Linux-only; same gate.
+if [[ "${SMOKE_SKIP_NETWORK:-0}" == "1" ]]; then
+    info "SMOKE_SKIP_NETWORK=1 — journalctl recent-error scan skipped"
+fi
 
 section "Recent Errors"
-_error_count=0
-for log_src in "snapmulti-server" "snapclient" "docker"; do
-    local_errors=$(journalctl -u "${log_src}.service" --since "10 min ago" --priority err --no-pager -q 2>/dev/null | wc -l | tr -d ' ') || local_errors=0
-    if [[ "$local_errors" -gt 0 ]]; then
-        warn "$log_src: $local_errors error(s) in last 10 min"
-        journalctl -u "${log_src}.service" --since "10 min ago" --priority err --no-pager -q 2>/dev/null | tail -3 | while IFS= read -r line; do
-            info "  $line"
-        done
-        _error_count=$((_error_count + local_errors))
-    fi
-done
-if [[ "$_error_count" -eq 0 ]]; then
-    pass_check "No errors in systemd logs (last 10 min)"
+if [[ "${SMOKE_SKIP_NETWORK:-0}" == "1" ]]; then
+    info "SMOKE_SKIP_NETWORK=1 — recent-errors journalctl scan skipped"
 else
-    warn "$_error_count total error(s) in recent logs (non-blocking)"
+    _error_count=0
+    for log_src in "snapmulti-server" "snapclient" "docker"; do
+        local_errors=$(journalctl -u "${log_src}.service" --since "10 min ago" --priority err --no-pager -q 2>/dev/null | wc -l | tr -d ' ') || local_errors=0
+        if [[ "$local_errors" -gt 0 ]]; then
+            warn "$log_src: $local_errors error(s) in last 10 min"
+            journalctl -u "${log_src}.service" --since "10 min ago" --priority err --no-pager -q 2>/dev/null | tail -3 | while IFS= read -r line; do
+                info "  $line"
+            done
+            _error_count=$((_error_count + local_errors))
+        fi
+    done
+    if [[ "$_error_count" -eq 0 ]]; then
+        pass_check "No errors in systemd logs (last 10 min)"
+    else
+        warn "$_error_count total error(s) in recent logs (non-blocking)"
+    fi
 fi
 
 # ── Final emit ──

--- a/scripts/device-smoke.sh
+++ b/scripts/device-smoke.sh
@@ -593,13 +593,7 @@ _net_emit_results() {
     done < "$out"
 }
 
-# Local-gate escape hatch. The four network checks fire real `dig` /
-# `chronyc` / `avahi-browse` / `arping` calls — each can stall a CI run
-# on macOS or in a container with no DNS resolver or mDNS responder.
-# `SMOKE_SKIP_NETWORK=1` short-circuits them so `tests/test_device_smoke
-# .sh` and `test_fleet_smoke_static.sh` stay deterministic. Production
-# device-smoke runs (firstboot, fleet-smoke, ADR-005 release gate) must
-# NOT set this — the variable is undefined there by default.
+# SMOKE_SKIP_NETWORK=1: local-gate escape hatch so tests stay deterministic without a real DNS/NTP/mDNS stack. Production paths (firstboot, fleet-smoke, ADR-005) leave it unset.
 if [[ "${SMOKE_SKIP_NETWORK:-0}" != "1" ]]; then
     # Run all four checks in parallel — the slowest (DNS retry, up to 30 s)
     # now overlaps with NTP/mDNS/arping (all <= 5 s) instead of serialising
@@ -944,17 +938,7 @@ if [[ "$MODE" == "server" || "$MODE" == "both" ]]; then
 fi
 
 # ── Modular checks (boot health, mounts, QoS, timers, system, audio) ──
-# Each function is defined in scripts/smoke/check_<name>.sh and was
-# sourced near the top of this file. Mode-gating happens inside each.
-#
-# SMOKE_SKIP_NETWORK is overloaded here as a broader "non-portable
-# checks" gate. The modular checks read /proc/*, /sys/*, run journalctl
-# / vcgencmd / lsmod / tc — all Linux-only. On a macOS / generic CI
-# runner they emit a forest of false-error lines and end up flipping
-# the overall result. SKIP=1 keeps the smoke "shape" of the output
-# (sections, headers) but bypasses the Linux-specific probes. The flag
-# remains UNSET in production (firstboot, fleet-smoke, device-smoke on
-# real Pis), so the checks run as designed there.
+# Same SMOKE_SKIP_NETWORK gate as above — these read /proc, /sys, run journalctl/vcgencmd/lsmod/tc (all Linux-only), so they're skipped on portable test runners.
 if [[ "${SMOKE_SKIP_NETWORK:-0}" != "1" ]]; then
     declare -F check_boot_health    >/dev/null && check_boot_health
     declare -F check_mounts         >/dev/null && check_mounts
@@ -968,11 +952,6 @@ if [[ "${SMOKE_SKIP_NETWORK:-0}" != "1" ]]; then
     declare -F check_snapcast       >/dev/null && check_snapcast
 else
     info "SMOKE_SKIP_NETWORK=1 — modular Linux-only checks (boot health, mounts, QoS, timers, system, audio, env, mDNS, snapcast) skipped"
-fi
-
-# Recent-errors journalctl scan is also Linux-only; same gate.
-if [[ "${SMOKE_SKIP_NETWORK:-0}" == "1" ]]; then
-    info "SMOKE_SKIP_NETWORK=1 — journalctl recent-error scan skipped"
 fi
 
 section "Recent Errors"

--- a/tests/test_device_smoke.sh
+++ b/tests/test_device_smoke.sh
@@ -122,13 +122,37 @@ echo "up 5 minutes"
 MOCK
 chmod +x "$MOCK_BIN/uptime"
 
+# Linux-only commands used by device-smoke.sh and the scripts/smoke/*.sh
+# modules. On macOS / generic CI runners these binaries don't exist;
+# absent binaries make `$(cmd …)` exit 127, which under `set -e` would
+# kill device-smoke before reaching the test assertions. Mock each as a
+# no-op so the corresponding section reports its "skipped"/"empty" path
+# but the script keeps running. The SMOKE_SKIP_NETWORK guard already
+# bypasses the genuinely network-touching probes (dig/chronyc/avahi-
+# browse/arping); these mocks only cover the rest of the binary set.
+for _linux_only_cmd in journalctl ip ss vcgencmd chronyc dig arping \
+                       avahi-browse nm-online nmcli tc sysctl lsmod \
+                       free lscpu; do
+    cat > "$MOCK_BIN/$_linux_only_cmd" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/$_linux_only_cmd"
+done
+unset _linux_only_cmd
+
 echo "Testing device-smoke.sh..."
 
+# SMOKE_SKIP_NETWORK=1 short-circuits the dig/chronyc/avahi-browse/arping
+# real-network checks inside device-smoke.sh. Without this flag the test
+# hung in CI on macOS/Linux runners with no DNS resolver or mDNS responder.
+# Production smoke runs (firstboot, fleet-smoke) must NOT set the flag.
 output="$(
     PATH="$MOCK_BIN:$PATH" \
     MOCK_OVERLAY=1 \
     MOCK_DOCKER_DRIVER=fuse-overlayfs \
     MOCK_STACK=server \
+    SMOKE_SKIP_NETWORK=1 \
     bash "$SMOKE_SH" --server --server-dir "$TMP_SERVER" 2>&1
 )"
 rc=$?
@@ -136,6 +160,7 @@ assert_rc "$rc" "0" "server mode passes with overlayroot + fuse-overlayfs"
 assert_contains "$output" "Mode: server" "reports selected mode"
 assert_contains "$output" "Smoke check passed" "reports passing summary"
 assert_contains "$output" "server: 2/2 running, 2/2 healthy" "reports compose counts"
+assert_contains "$output" "SMOKE_SKIP_NETWORK=1" "skip flag is visible in log so the run is identifiable"
 
 set +e
 output="$(
@@ -143,6 +168,7 @@ output="$(
     MOCK_OVERLAY=0 \
     MOCK_DOCKER_DRIVER=fuse-overlayfs \
     MOCK_STACK=client \
+    SMOKE_SKIP_NETWORK=1 \
     bash "$SMOKE_SH" --client --client-dir "$TMP_CLIENT" 2>&1
 )"
 rc=$?

--- a/tests/test_device_smoke.sh
+++ b/tests/test_device_smoke.sh
@@ -122,14 +122,7 @@ echo "up 5 minutes"
 MOCK
 chmod +x "$MOCK_BIN/uptime"
 
-# Linux-only commands used by device-smoke.sh and the scripts/smoke/*.sh
-# modules. On macOS / generic CI runners these binaries don't exist;
-# absent binaries make `$(cmd …)` exit 127, which under `set -e` would
-# kill device-smoke before reaching the test assertions. Mock each as a
-# no-op so the corresponding section reports its "skipped"/"empty" path
-# but the script keeps running. The SMOKE_SKIP_NETWORK guard already
-# bypasses the genuinely network-touching probes (dig/chronyc/avahi-
-# browse/arping); these mocks only cover the rest of the binary set.
+# Mock Linux-only commands as no-op exits: absent binaries make `$(cmd …)` exit 127, which `set -e` propagates and kills device-smoke before assertions run.
 for _linux_only_cmd in journalctl ip ss vcgencmd chronyc dig arping \
                        avahi-browse nm-online nmcli tc sysctl lsmod \
                        free lscpu; do
@@ -143,10 +136,7 @@ unset _linux_only_cmd
 
 echo "Testing device-smoke.sh..."
 
-# SMOKE_SKIP_NETWORK=1 short-circuits the dig/chronyc/avahi-browse/arping
-# real-network checks inside device-smoke.sh. Without this flag the test
-# hung in CI on macOS/Linux runners with no DNS resolver or mDNS responder.
-# Production smoke runs (firstboot, fleet-smoke) must NOT set the flag.
+# SMOKE_SKIP_NETWORK=1 bypasses real-network + Linux-only probes inside device-smoke.sh; production paths must NOT set it.
 output="$(
     PATH="$MOCK_BIN:$PATH" \
     MOCK_OVERLAY=1 \

--- a/tests/test_device_smoke_parallel_network.sh
+++ b/tests/test_device_smoke_parallel_network.sh
@@ -52,11 +52,7 @@ done
 assert 'grep -qE "^_net_emit_results\\(\\) \\{" "$SMOKE"' \
     "function _net_emit_results defined"
 
-# 3. All four checks are invoked WITH `&` (background) — drift to
-# serial execution would re-introduce the 30-45 s worst-case latency.
-# Lines are now indented under the SMOKE_SKIP_NETWORK guard (added
-# 2026-05-15 to keep the test suite portable to macOS / generic CI),
-# so the patterns tolerate leading whitespace.
+# 3. Four checks invoked with `&` (background); pattern tolerates leading whitespace since the SMOKE_SKIP_NETWORK guard indented them.
 for fn in _net_check_dns _net_check_ntp _net_check_mdns_self _net_check_arping; do
     assert "grep -qE '^[[:space:]]*${fn} &\$' \"\$SMOKE\"" \
         "$fn invoked with & (background)"

--- a/tests/test_device_smoke_parallel_network.sh
+++ b/tests/test_device_smoke_parallel_network.sh
@@ -54,14 +54,17 @@ assert 'grep -qE "^_net_emit_results\\(\\) \\{" "$SMOKE"' \
 
 # 3. All four checks are invoked WITH `&` (background) — drift to
 # serial execution would re-introduce the 30-45 s worst-case latency.
+# Lines are now indented under the SMOKE_SKIP_NETWORK guard (added
+# 2026-05-15 to keep the test suite portable to macOS / generic CI),
+# so the patterns tolerate leading whitespace.
 for fn in _net_check_dns _net_check_ntp _net_check_mdns_self _net_check_arping; do
-    assert "grep -qE '^${fn} &$' \"\$SMOKE\"" \
+    assert "grep -qE '^[[:space:]]*${fn} &\$' \"\$SMOKE\"" \
         "$fn invoked with & (background)"
 done
 
 # 4. `wait` follows the dispatch — without it the parent races past
 # the writes and the result tmpfiles may be empty at replay time.
-assert 'awk "/^_net_check_arping &$/{f=1; next} f&&/^wait$/{print; exit 0} f&&/^[^[:space:]]/{exit 1}" "$SMOKE" >/dev/null' \
+assert 'awk "/^[[:space:]]*_net_check_arping &$/{f=1; next} f&&/^[[:space:]]*wait$/{print; exit 0} f&&/^[^[:space:]]/{exit 1}" "$SMOKE" >/dev/null' \
     "wait follows the four background invocations"
 
 # 5. The tmpfile directory is mktemp'd and trap'd for cleanup.

--- a/tests/test_metadata_plugin_bugs.sh
+++ b/tests/test_metadata_plugin_bugs.sh
@@ -80,14 +80,37 @@ echo "=== Bug #4 — ws_clients lock invariant ==="
 # difference_update under the lock.
 
 # Specifically the subscribe path must wrap discard+add together.
+# shellcheck disable=SC2034  # consumed via the eval'd assert below
 subscribe_block=$(awk '/if .subscribe. in data:/,/continue$/' "$METADATA" | head -25)
 assert 'echo "$subscribe_block" | grep -qE "async with ws_clients_lock:"' \
        'subscribe path is wrapped in ws_clients_lock'
 
 # The disconnect path (finally block) must also acquire the lock.
-finally_block=$(awk '/finally:/,/logger.info.*disconnected/' "$METADATA")
+# Scope the awk to `ws_handler()` only — metadata-service.py has three
+# other `finally:` blocks above (e.g. fetch_album_artwork's connection
+# cleanup at :665). Without the scope, awk would match the first
+# finally in the file and false-pass even if ws_handler's own finally
+# regressed. The scope starts at `async def ws_handler` and ends at
+# the next top-level `async def` / `def` (which marks the next
+# function) — that bounds the body unambiguously.
+ws_handler_body=$(awk '
+    /^async def ws_handler/ { flag=1 }
+    flag
+    flag && /^(async def|def) [a-z]/ && !/^async def ws_handler/ { exit }
+' "$METADATA")
+finally_block=$(echo "$ws_handler_body" | awk '/finally:/,/logger.info.*disconnected/')
 assert 'echo "$finally_block" | grep -qE "async with ws_clients_lock:"' \
-       'disconnect path acquires ws_clients_lock around discard'
+       'ws_handler disconnect path acquires ws_clients_lock around discard'
+
+# Belt-and-braces: the extracted finally_block must be non-empty (proves
+# we actually scoped to ws_handler, not silently fell through to EOF).
+if [[ -z "$finally_block" ]]; then
+    echo "  FAIL: finally_block empty — awk scope failed to find ws_handler's finally"
+    fail=$((fail + 1))
+else
+    echo "  PASS: ws_handler finally block extracted (non-empty)"
+    pass=$((pass + 1))
+fi
 
 # The two collect-then-flush broadcast paths in the poll loop now mutate
 # ws_clients via difference_update under the lock (instead of bare


### PR DESCRIPTION
## Sintesi

Hardening pre-tag release: 6 fix mirate per rendere il local test gate affidabile su macOS / CI generici. Nessun refactor ampio, ciascun fix è minimal e verificato.

## Files modificati

| File | Fix |
|------|-----|
| `scripts/common/unified-log.sh` | Bash 3.2 compat (#1) |
| `scripts/device-smoke.sh` | SMOKE_SKIP_NETWORK gate (#2) |
| `tests/test_device_smoke.sh` | Mock Linux-only binaries + SMOKE_SKIP_NETWORK (#2) |
| `tests/test_device_smoke_parallel_network.sh` | Tolera nuova indentazione (#2 collateral) |
| `tests/test_metadata_plugin_bugs.sh` | Scope finally a ws_handler (#3) |
| `client/tests/test_discover_server.sh` | _update_server → _apply_server (#4) |
| `scripts/deploy.sh` | compose down → up -d --force-recreate (#5) |
| `client/common/scripts/setup.sh` | Rimuove curl|sh fallback (#6) |

## Fix dettagliate

### 1. Logging Bash 3.2

`unified-log.sh:103` usava `printf '[%(%H:%M:%S)T]'` (builtin Bash 4.2+). Su macOS default (Bash 3.2) la format string esce letterale → log lines senza timestamp. Sostituito con `\$(date +%H:%M:%S)`. Fork cost trascurabile vs il costo del gate.

### 2. device-smoke test deterministico

Lo script eseguiva real DNS/NTP/mDNS/arping + journalctl + /proc reads + HTTP probes contro snapserver/metadata-service. Su macOS CI il test hangava in timeout. Introdotto **`SMOKE_SKIP_NETWORK=1`** che gata:
- I 4 net check paralleli (`_net_check_*`)
- I live HTTP probes (JSON-RPC, /health, /status)
- I 10 modular check Linux-only (boot_health, mounts, qos, timers, system, audio, env, mdns, snapcast, containers)
- Lo scan `journalctl` Recent Errors

Production runs (firstboot, fleet-smoke, ADR-005) lasciano la flag UNSET → comportamento invariato. Test mocka i remaining Linux-only binaries (journalctl, ip, ss, vcgencmd, tc, ...) come no-op.

### 3. metadata-service test falso positivo

`test_metadata_plugin_bugs.sh:88` usava `awk '/finally:/,/logger.info.*disconnected/'` che matcha il **primo** `finally:` del file (riga 665 in `fetch_album_artwork`), non quello di `ws_handler` (riga 1919). Falso positivo: ws_handler poteva regredire e il test ancora passare. Fix: scope l'awk al body di `ws_handler` bound tra `^async def ws_handler` e il prossimo top-level def. Aggiunta belt-and-braces che il blocco estratto sia non-vuoto.

### 4. discover-server test obsoleto

La funzione fu rinominata da `_update_server` a `_apply_server` in un refactor precedente; il test continuava ad estrarre il nome vecchio e fallava silenziosamente (6 FAIL / 2 PASS). Riscritto per estrarre `_apply_server` + `_current_host`, stub `_log` e `_compose_up`. Mantiene gli assert su ordering (.env flushed BEFORE compose up). **13/13 PASS**.

### 5. deploy lifecycle

`install_systemd_service` faceva `docker compose down` prima di `systemctl start` per assicurarsi che ExecStart leggesse il nuovo `.env`. Distruttivo: 30-40s silenzio audio + teardown network/image. Sostituito con `docker compose up -d --force-recreate`: re-evaluates compose+env, ricrea solo ciò che è cambiato, no-op altrimenti. Costo tipico 5-10s. Il `|| true` mantiene resilienza quando il compose project non esiste ancora (fresh install).

### 6. Security: no curl|sh fallback

`client/common/scripts/setup.sh:541` aveva `curl -fsSL https://get.docker.com | sh` come last-resort. prepare-sd.sh ship `install-docker.sh` su ogni SD layout, quindi la sua assenza significa SD malpreparata. Sostituito con failure esplicito che elenca i candidate paths controllati + recovery action (re-run prepare-sd.sh). Fail loud > pipe silenzioso.

## Validation locale

| Comando | Risultato |
|---------|-----------|
| `bash -n` su tutti i file modificati | clean |
| `shellcheck -S warning -x` su tutti i file modificati | clean |
| `tests/test_logging_consolidation.sh` | 38/38 PASS |
| `tests/test_device_smoke.sh` | 7/7 PASS (era timeout pre-fix) |
| `tests/test_metadata_plugin_bugs.sh` | 12/12 PASS |
| `client/tests/test_discover_server.sh` | 13/13 PASS (era 2/8 pre-fix) |
| `tests/test_prepare_sd_required_files.sh` | 14/14 PASS |
| Server suite full | 51/51 PASS |
| Client suite full | 5/5 PASS |
| `.venv/bin/python -m pytest tests client/tests -q` | 177/177 PASS |

## Rischi residui

- **Pi 5 non testato**: il fix #5 (force-recreate vs down) è invariato per il path "no systemd unit" (manual deploy.sh). Validation su Pi 4 reale prima del tag.
- **SMOKE_SKIP_NETWORK semantica overload**: il flag ora gata sia network reali sia HTTP probes locali sia check modulari Linux-only. Documentato inline; rinaming a `SMOKE_LOCAL_GATE=1` o `SMOKE_PORTABLE=1` deferibile se il nome diventa fuorviante (out of scope qui).
- **Fix #6 fail-explicit**: se un utente avanzato fa install standalone senza prepare-sd, ora deve copiare `install-docker.sh` manualmente o pre-installare Docker. Trade-off accettato per sicurezza.

No CHANGELOG entry — parallel-branch rule, accumulato per release-tag v0.7.5.