### PR TITLE
fix(ci): upstream-release-check.yml — silently invalidated by Unicode ellipsis inside expression delimiter

### DIFF
--- a/.github/workflows/upstream-release-check.yml
+++ b/.github/workflows/upstream-release-check.yml
@@ -169,9 +169,13 @@ jobs:
           _Auto-created by `.github/workflows/upstream-release-check.yml`. New issues are de-duplicated by title (`[upstream] __NAME__ __LATEST__`)._
           TEMPLATE
           )
-          # Substitute via the env vars (NOT via ${{ … }}) to keep
-          # untrusted-input handling consistent even though matrix
-          # values are workflow-controlled today.
+          # Substitute via env vars rather than GitHub Actions expressions
+          # to keep untrusted-input handling consistent even though matrix
+          # values are workflow-controlled today. Avoid writing the literal
+          # expression delimiters in any comment inside a run block — the
+          # parser scans run-block text for expression patterns before the
+          # shell sees it, and a non-ASCII char inside such a pattern
+          # silently invalidates the whole workflow file at registration.
           body=${body//__NAME__/${NAME}}
           body=${body//__LATEST__/${LATEST}}
           body=${body//__PINNED__/${PINNED}}


### PR DESCRIPTION
## Root cause

Line 172 contained `\${{ … }}` (Unicode U+2026 horizontal ellipsis between literal GitHub-expression delimiters) inside a bash comment within a `run:` block. GitHub Actions' expression lexer scans every run-block text for `\${{ ... }}` patterns BEFORE the shell sees it; it aborted on the non-ASCII char and silently invalidated the entire workflow file at registration time.

## Observable symptoms (all explained by the parse abort)

| Symptom | Underlying cause |
|---------|------------------|
| `gh api .../actions/workflows` returns `name:` as the file path, not "Upstream Release Check" | Top-level `name:` field never parsed |
| Workflow reacts to `push` events despite `on:` declaring only `schedule` + `workflow_dispatch` | `on:` block never parsed → fallback reaction |
| Every push to any branch produces a failure run with zero jobs and zero logs | `jobs:` block never parsed → nothing to execute → empty failure |
| Only this workflow rosso | Only file with non-ASCII inside `\${{ }}` |

## Minimal patch

```diff
-          # Substitute via the env vars (NOT via \${{ … }}) to keep
-          # untrusted-input handling consistent even though matrix
-          # values are workflow-controlled today.
+          # Substitute via env vars rather than GitHub Actions expressions
+          # to keep untrusted-input handling consistent even though matrix
+          # values are workflow-controlled today. Avoid writing the literal
+          # expression delimiters in any comment inside a run block — the
+          # parser scans run-block text for expression patterns before the
+          # shell sees it, and a non-ASCII char inside such a pattern
+          # silently invalidates the whole workflow file at registration.
```

Plus a guard sentence so future contributors don't reintroduce the pattern.

## Validation

- `actionlint .github/workflows/upstream-release-check.yml` → exit 0 (before fix: line 153:743 expression parse error)
- `grep -nE '#.*\\\$\{\{' .github/workflows/upstream-release-check.yml` → no matches
- Remaining non-ASCII characters in the file are em-dashes inside plain YAML comments or shell comments WITHOUT `\${{ }}` delimiter context — safe.

## Should this block community launch?

**No.** The workflow itself is an advisory watcher (Monday cron + manual dispatch), not a release gate. Historical red runs remain in Actions history (GitHub doesn't allow deletion), but future pushes will stop producing phantom failures and the next Monday cron — or a manual `gh workflow run upstream-release-check.yml` after merge — will execute the actual check logic with proper job + log output.

Polish, not blocker.

## Out of scope

- Historical failed runs (cannot be removed via API)
- Other workflow lint warnings flagged by actionlint (custom `snapcast-runner` label, shellcheck style suggestions in other workflows) — separate cleanup pass if desired