### PR TITLE
docs: 7 community-launch polish — version drift, missing index, claim accuracy, broken anchor, screenshot promise, LED hint

### DIFF
--- a/CONTRIBUTING.it.md
+++ b/CONTRIBUTING.it.md
@@ -42,6 +42,7 @@ Ogni argomento ha UN solo file autorevole (tabella SSOT completa in [CLAUDE.md](
 | `docs/ADVANCED.md` | Personalizzazioni operative — multi-room, NAS (NFS / SMB), `.env` personalizzato, deploy manuale, fs read-only, strategia di aggiornamento, MPD CLI, JSON-RPC |
 | `docs/HARDWARE.md` | Modelli Pi supportati, uscite audio, scelta SD / rete / hardware, note Pi Zero 2 W |
 | `docs/USAGE.md` | Riferimento architettura — servizi, porte, sorgenti audio, modello di sicurezza |
+| `docs/CLIENT-METADATA.md` | Guida integrazione client — contratti Snapserver JSON-RPC + metadata-service WS/HTTP, forme di subscribe, regole artwork, controllo trasporto, anti-pattern (per chi scrive una UI / dashboard / controller esterno) |
 | `config/snapserver.conf` | Schema autorevole dei parametri sorgente (commenti inline) |
 
 I mirror italiani (`*.it.md`) seguono i file inglesi 1:1 — aggiornali nella stessa PR quando modifichi la documentazione inglese. Correttezza diacritica completa (usa `à è é ì ò ù`, mai gli equivalenti ASCII).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Each topic has ONE authoritative file (full SSOT table in [CLAUDE.md](CLAUDE.md)
 | `docs/ADVANCED.md` | Operational customisation — multi-room, NAS (NFS / SMB), custom `.env`, manual deploy, read-only fs, update strategy, MPD CLI, JSON-RPC |
 | `docs/HARDWARE.md` | Supported Pi models, audio outputs, SD / network / hardware choice, Pi Zero 2 W notes |
 | `docs/USAGE.md` | Architecture reference — services, ports, audio sources, security model |
+| `docs/CLIENT-METADATA.md` | Client integration guide — Snapserver JSON-RPC + metadata-service WS/HTTP contracts, subscribe forms, artwork rules, transport control, anti-patterns (for anyone writing a UI / dashboard / external controller) |
 | `config/snapserver.conf` | Authoritative source-parameter schema (inline comments) |
 
 Italian mirrors (`*.it.md`) follow the English files 1:1 — update them in the same PR when you change English docs. Full diacritical correctness (use `à è é ì ò ù`, never the ASCII equivalents).

--- a/README.it.md
+++ b/README.it.md
@@ -86,7 +86,7 @@ Lo script chiede: **Audio Player** (solo altoparlante) / **Music Server** (Spoti
 
 Espelli l'SD, inseriscila nel Pi, accendi. Aspetta circa 10-15 minuti. L'installer al primo boot gira senza SSH, mostra l'avanzamento su HDMI se hai uno schermo collegato. Fatto.
 
-> **Procedura dettagliata** con screenshot e troubleshooting: [docs/INSTALL.it.md](docs/INSTALL.it.md).
+> **Procedura dettagliata** con troubleshooting e percorso di recupero diagnostico: [docs/INSTALL.it.md](docs/INSTALL.it.md).
 > **Matrice di compatibilità** (modelli Pi, DAC HAT, setup di rete): [docs/HARDWARE.it.md](docs/HARDWARE.it.md).
 
 ## Dopo l'installazione

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The script asks: **Audio Player** (speaker only) / **Music Server** (Spotify+Air
 
 Eject SD, insert in the Pi, power on. Wait about 10-15 minutes. The first-boot installer runs without SSH, shows progress on HDMI if you have a screen attached. Done.
 
-> **Detailed walk-through** with screenshots and troubleshooting: [docs/INSTALL.md](docs/INSTALL.md).
+> **Detailed walk-through** with troubleshooting and the diagnostic-bundle recovery path: [docs/INSTALL.md](docs/INSTALL.md).
 > **Compatibility matrix** (which Pi models, DAC HATs, network setups): [docs/HARDWARE.md](docs/HARDWARE.md).
 
 ## After install

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ snapMULTI is designed for **home/prosumer networks** behind a firewall:
 - **Network**: Host networking for low-latency audio; not designed for public-facing deployment
 - **Filesystem**: Optional read-only root via overlayroot (protects SD card from corruption)
 - **Secrets**: SMB credentials stored in `/etc/snapmulti-smb-credentials` (mode 600), referenced by a systemd `.mount` unit in `/etc/systemd/system/`; NFS uses host-based auth
-- **Updates**: Docker images are signed and built in CI; full upgrades use the reflash path
+- **Updates**: Docker images built in CI on GitHub Actions, published multi-arch (amd64 + arm64) to Docker Hub. Image signing (cosign / sigstore) is not yet implemented — track via SECURITY advisories if integrity attestation is required for your deployment. Full upgrades use the reflash path (DEC-003)
 
 ## Known Limitations
 

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -231,7 +231,7 @@ Configurazione del firewall (regole `ufw`) e setup QoS / `cake` qdisc sono docum
 |----------|------------|
 | `lollonet/snapmulti-server:latest` | ~80–120 MB |
 | `lollonet/snapmulti-airplay:latest` | ~30–50 MB |
-| `ghcr.io/devgianlu/go-librespot:v0.7.0` | ~30–50 MB |
+| `ghcr.io/devgianlu/go-librespot:v0.7.1` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
 | `ghcr.io/jcorporation/mympd/mympd:latest` | ~30–50 MB |

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -231,7 +231,7 @@ Firewall configuration (`ufw` rules) and QoS / `cake` qdisc setup are documented
 |-------|------|
 | `lollonet/snapmulti-server:latest` | ~80–120 MB |
 | `lollonet/snapmulti-airplay:latest` | ~30–50 MB |
-| `ghcr.io/devgianlu/go-librespot:v0.7.0` | ~30–50 MB |
+| `ghcr.io/devgianlu/go-librespot:v0.7.1` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
 | `ghcr.io/jcorporation/mympd/mympd:latest` | ~30–50 MB |

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -318,7 +318,7 @@ snapMULTI Auto-Install
 
 Il Pi **si riavvia automaticamente** quando l'installazione è completa. Dopo il riavvio, il display diventa scuro (normale — nessun desktop su Lite OS).
 
-> Se l'HDMI rimane nero per tutto il tempo: l'installazione continua comunque in background — `firstboot.sh` gira come servizio systemd e non ha bisogno del display. Aspetta 10 minuti; per controllare lo stato senza schermo, fai `ssh <username>@<hostname>.local` ed esegui `sudo journalctl -u snapmulti-firstboot.service -f`.
+> Se l'HDMI rimane nero per tutto il tempo: l'installazione continua comunque in background — `firstboot.sh` gira come servizio systemd e non ha bisogno del display. **Il LED verde ACT del Pi lampeggerà in modo irregolare per tutti i 10–15 minuti — è attività sulla scheda SD, il tuo segnale che l'install sta procedendo.** Aspetta tutta la finestra; per controllare lo stato senza schermo, fai `ssh <username>@<hostname>.local` ed esegui `sudo journalctl -u snapmulti-firstboot.service -f`.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -316,7 +316,7 @@ snapMULTI Auto-Install
 
 The Pi **reboots automatically** when installation is complete. After the reboot, the display goes dark (normal — no desktop on Lite OS).
 
-> If the HDMI stays blank throughout: the installation is still running in the background — `firstboot.sh` is a systemd service that does not need a display. Wait 10 minutes; to check progress without a screen, `ssh <username>@<hostname>.local` and run `sudo journalctl -u snapmulti-firstboot.service -f`.
+> If the HDMI stays blank throughout: the installation is still running in the background — `firstboot.sh` is a systemd service that does not need a display. **The green ACT LED on the Pi will flash irregularly throughout the 10–15 min — that's SD-card activity, your sign the install is making progress.** Wait the full window; to check progress without a screen, `ssh <username>@<hostname>.local` and run `sudo journalctl -u snapmulti-firstboot.service -f`.
 
 ---
 

--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -107,7 +107,7 @@ avahi-browse -r _raop._tcp --terminate
 ss -tlnp | grep -E '1704|1705|1780'
 ```
 
-Quando la discovery non funziona (Spotify / AirPlay / Tidal non visibili, speaker mancanti in Snapweb): [TROUBLESHOOTING.it.md — Discovery mDNS](TROUBLESHOOTING.it.md#discovery-mdns).
+Quando la discovery non funziona, vedi [TROUBLESHOOTING.it.md](TROUBLESHOOTING.it.md) — le sezioni rilevanti sono "Il device non compare in rete / `.local` non risolve" (il Pi non è visibile dai client), "Gli speaker non trovano il server (snapclient non si connette)" (discovery snapclient) e "Spotify / AirPlay / Tidal non visibili nell'app di cast" (discovery lato app).
 
 ## Unit systemd
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -107,7 +107,7 @@ avahi-browse -r _raop._tcp --terminate
 ss -tlnp | grep -E '1704|1705|1780'
 ```
 
-When discovery fails (Spotify / AirPlay / Tidal not visible, speakers missing in Snapweb): [TROUBLESHOOTING.md — mDNS discovery](TROUBLESHOOTING.md#mdns-discovery).
+When discovery fails, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — the relevant sections are "Device doesn't show up on the network / `.local` doesn't resolve" (your Pi is invisible to clients), "Speakers don't find the server (snapclient won't connect)" (snapclient discovery), and "Spotify / AirPlay / Tidal not visible in the casting app" (source-app discovery).
 
 ## Systemd Units
 


### PR DESCRIPTION
## Summary

Doc-only polish bundle for community-launch hygiene. None are user-blocking; together they remove every papercut a careful first-time reader (or external security auditor) would notice. Two external reviewers independently flagged item #5 (screenshot promise) as the one thing keeping docs from 10/10.

## Fixes

| # | File(s) | Fix | Source |
|---|---------|-----|--------|
| 1 | `docs/HARDWARE.md` + `.it.md` | `go-librespot:v0.7.0` → `v0.7.1` (matches `docker-compose.yml` pin) | self-audit |
| 2 | `CONTRIBUTING.md` + `.it.md` | Add `docs/CLIENT-METADATA.md` row to Documentation table | self-audit |
| 3 | `SECURITY.md` | Drop the inaccurate "images are signed" claim; replace with the real CI scope + note that cosign/sigstore is not yet implemented | self-audit |
| 4 | `docs/USAGE.md` + `.it.md` | Fix broken `TROUBLESHOOTING.md#mdns-discovery` anchor — rewrote to reference three real section titles instead | self-audit |
| 5 | `README.md` + `.it.md` | "Detailed walk-through with screenshots and troubleshooting" → INSTALL.md has no images. Replaced "screenshots" with "the diagnostic-bundle recovery path" (what readers most need to know exists) | both external reviewers |
| 6 | `docs/INSTALL.md` + `.it.md` Step 5 | Headless-wait paragraph now mentions the green ACT LED flashing irregularly throughout the 10-15 min as the SD-activity progress signal. Removes the "10 minutes in the dark with no idea if it's working" anxiety | external reviewer assessment |

## Validation

- `git diff --stat`: 11 files, +11 / -9 lines
- All edits inside markdown prose or tables; no code path touched
- Anchor cross-doc audit confirmed the 3 referenced TROUBLESHOOTING section titles ("Device doesn't show up...", "Speakers don't find the server...", "Spotify / AirPlay / Tidal not visible...") exist verbatim in both EN and IT files

## Out of scope

- **Release manifest** (decoupling Git tag from Docker image tag via `release-manifest.json`) — external reviewer recommended shipping before community launch, but the design is mid-triad (iter 2 escalated, design decision pending). Treating as a v0.7.7 feature, not pre-launch polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)