### PR TITLE
fix(avahi): wired-priority defeats <host>-2.local rename race (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Avahi wired-priority defeats the `<host>-2.local` rename race (#425)** — on installs where the user configured WiFi credentials *and* Ethernet is plugged at first boot, `tune_avahi_daemon` previously enumerated both interfaces from the default route table during the 6-second window before `boot-tune.sh` disabled WiFi. Both wlan0 and eth0 momentarily published the same `<host>.local`, and LAN mDNS reflectors (e.g. FritzBox) cached the WiFi address; when eth0 then claimed the same name, Avahi negotiated a conflict and renamed to `<host>-2.local` (observed live on snapvideo 2026-05-16). `tune_avahi_daemon` now checks `/sys/class/net/eth*` and `/sys/class/net/en*` for `carrier=1` first: if a wired interface has carrier we restrict `allow-interfaces=<eth>` to wired only, so the reflector never sees a transient WiFi announcement to cache. WiFi-only devices (no wired carrier) fall through to the existing default-route + IPv4-up enumeration, unchanged. Defensive — does not change the steady-state behaviour after `boot-tune.sh` disables WiFi, but eliminates the first-boot race window. `tests/test_avahi_readiness.sh` gains 3 assertions covering the `/sys/class/net` enumeration, carrier check, and `wired_iface` precedence.
+
 ## [0.7.6] — 2026-05-16
 
 > Consolidates changes from v0.7.4 (2026-05-13) and v0.7.5 (2026-05-15) which shipped without separate CHANGELOG sections — see per-tag [GitHub Releases](https://github.com/lollonet/snapMULTI/releases) for the tag-level narrative.

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -454,26 +454,46 @@ tune_avahi_daemon() {
     # Restrict to the primary physical interface. On Ethernet+WiFi
     # devices, Avahi can otherwise publish the same hostname on the
     # transient WiFi DHCP address before WiFi exclusivity disables wlan0;
-    # macOS then keeps the stale .local address in cache.
+    # macOS and consumer mDNS reflectors (e.g. FritzBox) then keep the
+    # stale .local address in cache, which forces a hostname rename to
+    # <host>-2.local on conflict (issue #425).
+    #
+    # Wired-carrier priority: if any eth*/en* interface has carrier we
+    # restrict Avahi to wired only — this mirrors boot-tune.sh which
+    # disables WiFi when Ethernet has an IP, but takes effect during the
+    # first-boot window before boot-tune has run. WiFi-only devices (no
+    # eth carrier) fall through to the default-route enumeration.
     local ifaces=""
     local iface
-    for iface in $(ip -o route show default 2>/dev/null | awk '
-        {
-            for (i = 1; i <= NF; i++) {
-                if ($i == "dev" && $(i + 1) ~ /^(eth|wlan|en)/ && !seen[$(i + 1)]++) {
-                    print $(i + 1)
+    local wired_iface=""
+    for iface in /sys/class/net/eth* /sys/class/net/en*; do
+        [[ -e "$iface" ]] || continue
+        if [[ "$(cat "$iface/carrier" 2>/dev/null)" == "1" ]]; then
+            wired_iface="${iface##*/}"
+            break
+        fi
+    done
+    if [[ -n "$wired_iface" ]]; then
+        ifaces="$wired_iface"
+    else
+        for iface in $(ip -o route show default 2>/dev/null | awk '
+            {
+                for (i = 1; i <= NF; i++) {
+                    if ($i == "dev" && $(i + 1) ~ /^(eth|wlan|en)/ && !seen[$(i + 1)]++) {
+                        print $(i + 1)
+                    }
                 }
             }
-        }
-    '); do
-        [[ -n "$ifaces" ]] && ifaces="${ifaces},"
-        ifaces="${ifaces}${iface}"
-    done
-    if [[ -z "$ifaces" ]]; then
-        for iface in $(ip -o -4 addr show scope global up 2>/dev/null | awk '$2 ~ /^(eth|wlan|en)/ && !seen[$2]++ {print $2}'); do
+        '); do
             [[ -n "$ifaces" ]] && ifaces="${ifaces},"
             ifaces="${ifaces}${iface}"
         done
+        if [[ -z "$ifaces" ]]; then
+            for iface in $(ip -o -4 addr show scope global up 2>/dev/null | awk '$2 ~ /^(eth|wlan|en)/ && !seen[$2]++ {print $2}'); do
+                [[ -n "$ifaces" ]] && ifaces="${ifaces},"
+                ifaces="${ifaces}${iface}"
+            done
+        fi
     fi
     if [[ -n "$ifaces" ]]; then
         if ! grep -q "^allow-interfaces=${ifaces}$" "$conf"; then

--- a/tests/test_avahi_readiness.sh
+++ b/tests/test_avahi_readiness.sh
@@ -232,6 +232,20 @@ assert 'grep -qF "ip -o route show default" "$SYSTEM_TUNE_SH"' \
 assert 'grep -qF "ip -o -4 addr show scope global up" "$SYSTEM_TUNE_SH"' \
        'tune_avahi_daemon has IPv4-up physical-interface fallback'
 
+# #425 — wired-carrier priority prevents the dual-publish race during
+# the 6-sec window where wlan0 still has its DHCP address before
+# boot-tune.sh disables WiFi. When eth*/en* has carrier we restrict
+# Avahi to wired only, so the reflector never sees a transient WiFi
+# announcement that would force a <host>-2.local rename on conflict.
+assert 'grep -qF "for iface in /sys/class/net/eth* /sys/class/net/en*" "$SYSTEM_TUNE_SH"' \
+       'tune_avahi_daemon enumerates wired interfaces by /sys/class/net'
+
+assert 'grep -qF "carrier" "$SYSTEM_TUNE_SH"' \
+       'tune_avahi_daemon checks wired carrier state'
+
+assert 'grep -qF "wired_iface" "$SYSTEM_TUNE_SH"' \
+       'tune_avahi_daemon prefers wired interface when carrier is up'
+
 echo
 echo "=== firstboot.sh — Avahi retune after network ==="
 


### PR DESCRIPTION
## Summary

Closes #425. Defensive fix for the first-boot mDNS hostname rename race that surfaced live on snapvideo 2026-05-16 (Ethernet plugged + WiFi credentials configured in `prepare-sd.sh`).

`tune_avahi_daemon` now picks **wired interface only** when any `eth*` / `en*` has `carrier=1`. WiFi-only devices keep the existing default-route + IPv4-up enumeration.

## Why this only manifests on a subset of installs

The bug needs three concurrent conditions:
1. WiFi credentials configured in `prepare-sd.sh` (fallback path)
2. Ethernet physically connected and DHCP-served at first boot
3. LAN has an mDNS reflector caching announcements (FritzBox, common consumer setup)

Subsequent boots are immune because `boot-tune.sh` disables WiFi as soon as eth0 has an IP, and the reflector cache ages out. The fix closes the 6-second window between Avahi's first publish and `boot-tune.sh` running — wired-only `allow-interfaces` prevents wlan0 from ever publishing.

## What changed

- `scripts/common/system-tune.sh::tune_avahi_daemon` — check `/sys/class/net/eth*` and `/sys/class/net/en*` for `carrier=1` first; restrict `allow-interfaces=` to wired when found. Fall through to existing logic when no wired carrier.
- `tests/test_avahi_readiness.sh` — 3 new assertions: `/sys/class/net` enumeration, carrier check, `wired_iface` precedence.
- `CHANGELOG.md` — `[Unreleased] → Fixed`.

## Validation

Done locally:
- [x] `bash -n` + `shellcheck -S warning` on `scripts/common/system-tune.sh`
- [x] `tests/test_avahi_readiness.sh` 36/36 PASS (was 33 before, +3 new)
- [x] All other `tests/test_*.sh` pass (no regressions)
- [x] Static review: change confined to interface-enumeration branch; restart cascade + drop-in untouched

Deferred to release-gate (ADR-005):
- [ ] `device-smoke.sh --both` green on real Pi after reflash
- [ ] Manual: snapvideo first-boot with WiFi creds + eth plugged → `hostname -f` returns canonical `<host>.local` (no `-2` suffix)

## Notes

- Steady-state behaviour after `boot-tune.sh` disables WiFi is unchanged — this only affects the firstboot window.
- No SSOT docs touched (HARDWARE / USAGE describe behaviour, not implementation detail of `tune_avahi_daemon`).