### PR TITLE
docs: privacy/local-first restored + ZIP-first onboarding + Italian polish

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -37,6 +37,7 @@ snapMULTI è pensato per chi vuole un **sistema audio multi-room open source** s
 - **Livello richiesto**: devi sapere flashare un'SD con Raspberry Pi Imager, trovare il Pi tramite hostname (`.local`) o IP, e copiare un piccolo file dalla SD card se qualcosa va storto. **Non** ti serve conoscere Docker, systemd, ALSA o Snapcast — li gestisce snapMULTI.
 - **L'SD è importante**: le microSD economiche sono la prima causa di "install che si blocca". Usa una SanDisk / Samsung A1 (o migliore). Minimo 16 GB.
 - **Rete**: il 2,4 GHz funziona ma il 5 GHz o Ethernet sono più stabili.
+- **Privacy**: snapMULTI non fa telemetria, non ha un servizio cloud snapMULTI e non richiede account snapMULTI. Gira nella tua LAN. Installazione e aggiornamenti scaricano comunque pacchetti e immagini Docker, e le integrazioni streaming contattano i rispettivi servizi esterni (Spotify, Tidal, Apple/AirPlay, sorgenti metadati/copertine).
 - **I servizi di streaming hanno requisiti propri**: Spotify Connect richiede Premium. Tidal Connect funziona solo su ARM (l'architettura della CPU dei Raspberry Pi — quindi va su qualsiasi Pi, ma non su un server x86) ed è abilitato di default sugli install Pi (disabilitalo rimuovendo `tidal` da `COMPOSE_PROFILES`, vedi [nota sicurezza](docs/USAGE.it.md#nota-sicurezza-tidal-connect)). AirPlay richiede un dispositivo Apple.
 
 ## Configurazione consigliata per iniziare
@@ -64,7 +65,7 @@ snapMULTI dipende dai metadati cloud-init che Imager scrive quando imposti hostn
 
 ### 2. Scarica i file snapMULTI
 
-Con `git clone https://github.com/lollonet/snapMULTI.git`, oppure scarica ed estrai lo [ZIP dell'ultima release](https://github.com/lollonet/snapMULTI/releases/latest). Il nome della cartella non importa — `prepare-sd.sh` risolve da solo il proprio path.
+Per una prima installazione, scarica ed estrai lo [ZIP dell'ultima release](https://github.com/lollonet/snapMULTI/releases/latest). Usa `git clone https://github.com/lollonet/snapMULTI.git` solo se usi già Git o vuoi contribuire. Il nome della cartella non importa — `prepare-sd.sh` risolve da solo il proprio path.
 
 ### 3. Reinserisci l'SD ed esegui lo script di preparazione
 
@@ -127,15 +128,15 @@ Prima di riflashare, esegui `./scripts/backup-from-sd.sh` per conservare l'indic
 
 ## Se qualcosa fallisce
 
-**Installato ma non lo raggiungi?** Se il Pi ha finito ma `http://<hostname>.local:1780` non si apre: cerca l'indirizzo IP del Pi nella lista dispositivi del router e usa quello. La risoluzione `.local` (mDNS) non funziona su alcune configurazioni Windows e su Wi-Fi guest / mesh / VLAN che isolano i client — tieni il Pi e il telefono/laptop sulla stessa rete normale. Altro aiuto mDNS: [docs/TROUBLESHOOTING.it.md](docs/TROUBLESHOOTING.it.md).
+**Installato ma non lo raggiungi?** Se il Pi ha finito ma `http://<hostname>.local:1780` non si apre: cerca l'indirizzo IP del Pi nella lista dispositivi del router e usa quello. La risoluzione `.local` (mDNS) non funziona su alcune configurazioni Windows e su WiFi ospiti / mesh / VLAN che isolano i client — tieni il Pi e il telefono/laptop sulla stessa rete normale. Altro aiuto mDNS: [docs/TROUBLESHOOTING.it.md](docs/TROUBLESHOOTING.it.md).
 
-Se è il primo boot a interrompersi: snapMULTI esegue l'installazione come servizio systemd e cattura tutto strada facendo. La trap di cleanup scrive un bundle diagnostico anonimizzato sulla **partizione boot** dell'SD (FAT32, leggibile da qualsiasi computer — niente SSH necessario):
+Se è il primo boot a interrompersi: snapMULTI esegue l'installazione come servizio systemd e cattura tutto strada facendo. La trap di cleanup scrive un pacchetto diagnostico anonimizzato sulla **partizione boot** dell'SD (FAT32, leggibile da qualsiasi computer — niente SSH necessario):
 
 ```
 /boot/firmware/snapmulti-diag-install-failed-<UTC-ts>.tar.gz
 ```
 
-Estrai la SD, collegala al laptop, allega il bundle a una [issue GitHub](https://github.com/lollonet/snapMULTI/issues/new/choose). Il bundle è anonimizzato (niente MAC, niente IP della LAN, niente SSID, niente password, niente token API) — si può condividere pubblicamente in sicurezza. Sintomi comuni e smoke test (`scripts/device-smoke.sh`): [docs/TROUBLESHOOTING.it.md](docs/TROUBLESHOOTING.it.md).
+Estrai la SD, collegala al computer, allega il pacchetto diagnostico a una [issue GitHub](https://github.com/lollonet/snapMULTI/issues/new/choose). Il pacchetto è anonimizzato (niente MAC, niente IP della LAN, niente SSID, niente password, niente token API) — si può condividere pubblicamente in sicurezza. Sintomi comuni e test di salute (`scripts/device-smoke.sh`): [docs/TROUBLESHOOTING.it.md](docs/TROUBLESHOOTING.it.md).
 
 ## Glossario
 
@@ -150,7 +151,7 @@ Definizioni rapide dei termini che incontrerai in questo README e nella document
 | **mDNS** / `.local` | "Multicast DNS" — come i dispositivi si annunciano in LAN senza configurare IP manualmente. `pi-server.local` si risolve automaticamente sulla maggior parte delle reti |
 | **NAS** | Network-attached storage — un box separato (Synology, QNAP, custom) che ospita la libreria musicale, montato da snapMULTI via NFS o SMB |
 | **Filesystem read-only** | snapMULTI monta il root in sola lettura dopo l'install (overlayroot + fuse-overlayfs), così un blackout non può corrompere la SD. Le modifiche vengono cancellate al reboot a meno che tu non disattivi la modalità RO |
-| **Bundle diagnostico** | Tarball anonimizzato sulla partizione boot della SD (`snapmulti-diag-*.tar.gz`) — scritto automaticamente quando un'installazione fallisce, allegabile a una issue GitHub senza far trapelare segreti |
+| **Pacchetto diagnostico** | Archivio `.tar.gz` anonimizzato sulla partizione boot della SD (`snapmulti-diag-*.tar.gz`) — scritto automaticamente quando un'installazione fallisce, allegabile a una issue GitHub senza far trapelare segreti |
 
 ## Documentazione
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ snapMULTI is for people who want an **open-source multi-room audio system** with
 - **Skill floor**: you should be comfortable flashing an SD with Raspberry Pi Imager, finding your Pi by hostname (`.local`) or IP, and copying a small file off the SD card if something goes wrong. You do **not** need to know Docker, systemd, ALSA, or Snapcast — snapMULTI handles them.
 - **SD card matters**: cheap microSDs are the #1 cause of "install hangs". Use a SanDisk / Samsung A1 (or better). 16 GB is the minimum.
 - **Network**: 2.4 GHz works but 5 GHz or Ethernet is more stable.
+- **Privacy**: snapMULTI has no telemetry, no hosted snapMULTI cloud, and no account system. It runs on your LAN. Install/update steps still download packages and Docker images, and streaming integrations contact their own providers (Spotify, Tidal, Apple/AirPlay, metadata/artwork sources).
 - **Streaming services have their own requirements**: Spotify Connect needs Premium. Tidal Connect runs only on ARM (the Raspberry Pi CPU architecture — so it works on any Pi, but not on an x86 server) and is enabled by default on Pi installs (opt-out by removing `tidal` from `COMPOSE_PROFILES`, see [security note](docs/USAGE.md#tidal-connect-security-note)). AirPlay needs an Apple device.
 
 ## Recommended first build
@@ -64,7 +65,7 @@ snapMULTI relies on the cloud-init metadata that Imager writes when you set host
 
 ### 2. Get the snapMULTI files
 
-Either `git clone https://github.com/lollonet/snapMULTI.git`, or download and extract the [latest release ZIP](https://github.com/lollonet/snapMULTI/releases/latest). The folder name does not matter — `prepare-sd.sh` resolves its own path.
+For a first install, download and extract the [latest release ZIP](https://github.com/lollonet/snapMULTI/releases/latest). Use `git clone https://github.com/lollonet/snapMULTI.git` only if you already use Git or plan to contribute. The folder name does not matter — `prepare-sd.sh` resolves its own path.
 
 ### 3. Re-insert the SD and run the prep script
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,12 @@ snapMULTI is designed for **home/prosumer networks** behind a firewall:
 - **Secrets**: SMB credentials stored in `/etc/snapmulti-smb-credentials` (mode 600), referenced by a systemd `.mount` unit in `/etc/systemd/system/`; NFS uses host-based auth
 - **Updates**: Docker images built in CI on GitHub Actions, published multi-arch (amd64 + arm64) to Docker Hub. Image signing (cosign / sigstore) is not yet implemented — track via SECURITY advisories if integrity attestation is required for your deployment. Full upgrades use the reflash path (DEC-003)
 
+## Privacy and Telemetry
+
+snapMULTI itself does not collect telemetry and does not depend on a hosted snapMULTI cloud service or snapMULTI account. Control, status, metadata and playback APIs run on the local network.
+
+External traffic can still happen through normal dependencies and integrations: package/image downloads during install or update, Docker Hub pulls, GitHub release downloads, Spotify/Tidal/AirPlay provider traffic, and metadata/artwork lookups. Those services are outside the snapMULTI control plane.
+
 ## Known Limitations
 
 - Host networking exposes service ports to the local network (not just localhost)

--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -148,7 +148,7 @@ Ispeziona con `systemctl cat <unit>`. I file di unit sono installati da `firstbo
 
 Riflashare per primo è il default del progetto (DEC-003). Tutta la config si auto-rileva al primo boot — stesso hostname / stessa sorgente musica / stesso HAT.
 
-Dopo ogni reflash o aggiornamento in-place, esegui lo smoke test sul device per confermare che la piattaforma sia tornata sana: `sudo bash /opt/snapmulti/scripts/device-smoke.sh --server` (oppure `--client` / `--both`). È lo stesso release gate (ADR-005) che `fleet-smoke.sh` esegue su più device. Descrizione completa in [TROUBLESHOOTING.it.md — Prima cosa da fare](TROUBLESHOOTING.it.md#prima-cosa-da-fare--esegui-lo-smoke-test).
+Dopo ogni reflash o aggiornamento in-place, esegui il test di salute sul device per confermare che la piattaforma sia tornata sana: `sudo bash /opt/snapmulti/scripts/device-smoke.sh --server` (oppure `--client` / `--both`). È lo stesso release gate (ADR-005) che `fleet-smoke.sh` esegue su più device. Descrizione completa in [TROUBLESHOOTING.it.md — Prima cosa da fare](TROUBLESHOOTING.it.md#prima-cosa-da-fare--esegui-il-test-di-salute).
 
 ## Profili risorse
 

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -293,7 +293,7 @@ Se un nodo è collegato a un ricevitore AV via cavo ottico, usa HiFiBerry Digi+ 
 
 ## Combinazioni Testate
 
-Queste combinazioni hardware sono state verificate end-to-end (firstboot → smoke test → playback audio) nelle date indicate. Il batch del 2026-04-27 è la validazione release-gate per v0.6.x: 6 device riflashati da `main`, smoke test PASS su ognuno, `hw_ptr` ALSA che avanza durante la riproduzione (audio che raggiunge davvero il DAC, non solo la FIFO).
+Queste combinazioni hardware sono state verificate end-to-end (firstboot → test di salute → playback audio) nelle date indicate. Il batch del 2026-04-27 è la validazione release-gate per v0.6.x: 6 device riflashati da `main`, test di salute PASS su ognuno, `hw_ptr` ALSA che avanza durante la riproduzione (audio che raggiunge davvero il DAC, non solo la FIFO).
 
 | Hostname | Modello Pi | HAT Audio | Chip DAC | Modalità | Display | Sorgente Musica | Validato | Stato |
 |---|---|---|---|---|---|---|---|---|
@@ -369,7 +369,7 @@ Due scenari di produzione catturati il **2026-05-13** con `docker stats --no-str
 
 Host: 2,8 GiB usati / 7,5 GiB totali, **4,6 GiB disponibili**. Temperatura **64,2 °C**.
 
-**Carico client** (per gruppo, tutti verdi al smoke test):
+**Carico client** (per gruppo, tutti verdi al test di salute):
 
 | Client | CPU % snapclient | RAM snapclient | RAM host usata / totale | Temp |
 |--------|------------------|----------------|--------------------------|------|
@@ -407,7 +407,7 @@ Scheda: Pi 4 B Rev 1.5 / **2 GB RAM**. Host: 798 / 1,9 GiB usati (1,1 GiB dispon
 - **Un singolo Pi 4 2 GB regge comodamente la modalità both** quando non ci sono client in fan-out (Scenario B): ~18% CPU e ~390 MiB. Il modello da 2 GB ha margine evidente; 4 GB è sovradimensionato per questo caso d'uso.
 - **Le temperature sono ampiamente sotto il margine** su tutte e cinque le schede — la più calda (`pi-server` a 64 °C) è lontana dalla soglia di throttling (80 °C). Il raffreddamento passivo è stato sufficiente.
 
-> **Come è stato raccolto.** Su ogni dispositivo: `docker stats --no-stream` (o `ps -o pcpu,pmem,rss -C snapclient` per l'install nativa del Pi Zero 2 W), `free -h`, `vcgencmd measure_temp`. Lo smoke test (`scripts/device-smoke.sh`) era verde su ogni dispositivo prima dello snapshot. Le percentuali CPU sono campioni puntuali e variano con l'attività di riproduzione.
+> **Come è stato raccolto.** Su ogni dispositivo: `docker stats --no-stream` (o `ps -o pcpu,pmem,rss -C snapclient` per l'install nativa del Pi Zero 2 W), `free -h`, `vcgencmd measure_temp`. Il test di salute (`scripts/device-smoke.sh`) era verde su ogni dispositivo prima dello snapshot. Le percentuali CPU sono campioni puntuali e variano con l'attività di riproduzione.
 
 ---
 

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -19,7 +19,7 @@ Hai già dimestichezza con Raspberry Pi Imager e terminale? Questa è tutta l'in
 7. Espelli la SD, avvia il Pi e attendi circa 10-15 minuti. Installa, verifica e poi riavvia una volta.
 8. Apri `http://<hostname>.local:1780` per Snapweb oppure `http://<hostname>.local:8180` per myMPD.
 
-Se un passaggio non è chiaro, continua con la procedura dettagliata qui sotto. Se il primo boot fallisce, recupera il bundle diagnostico dalla SD come descritto in [TROUBLESHOOTING.it.md — In caso di dubbio](TROUBLESHOOTING.it.md#in-caso-di-dubbio--prendi-il-bundle-diagnostico).
+Se un passaggio non è chiaro, continua con la procedura dettagliata qui sotto. Se il primo boot fallisce, recupera il pacchetto diagnostico dalla SD come descritto in [TROUBLESHOOTING.it.md — In caso di dubbio](TROUBLESHOOTING.it.md#in-caso-di-dubbio--prendi-il-pacchetto-diagnostico).
 
 ---
 
@@ -105,18 +105,16 @@ lsblk -o NAME,LABEL,MOUNTPOINT | grep bootfs
 
 ## Passo 3 — Scaricare i file snapMULTI
 
-Scegli una delle due opzioni. Entrambe producono una cartella `snapMULTI/` che il passo successivo si aspetta.
+Scegli una delle due opzioni. Se non sei sviluppatore, usa **Opzione A — Scaricare lo ZIP**.
 
 ### Opzione A — Scaricare lo ZIP (senza Git)
 
 1. Apri [https://github.com/lollonet/snapMULTI/releases/latest](https://github.com/lollonet/snapMULTI/releases/latest) nel browser
 2. Sotto **Assets**, clicca **Source code (zip)** per scaricare l'ultima release
 3. Estrai lo ZIP — ottieni una cartella chiamata `snapMULTI-<versione>`. Il nome della cartella non è vincolante — `prepare-sd.sh` ricava la project root dalla propria posizione
-4. Apri un terminale dentro quella cartella estratta
+4. Tieni aperta la cartella — la sezione successiva mostra come aprire un terminale lì
 
 > Preferisci lo ZIP della release taggata al pulsante verde **Code → Download ZIP** della home page del repo — quest'ultimo scarica il branch `main`, che può contenere lavori non rilasciati.
->
-> Esegui `./scripts/prepare-sd.sh` dall'interno della cartella del progetto. Il nome della cartella non importa — `prepare-sd.sh` risolve da solo il proprio path. In alternativa, dalla cartella superiore, usa `./<nome-cartella>/scripts/prepare-sd.sh`.
 
 ### Opzione B — Clone con Git (consigliato se vuoi aggiornare)
 
@@ -142,6 +140,18 @@ cd snapMULTI
 ```
 
 > Il repository include sia il software server che client in un unico monorepo.
+
+### Aprire un terminale nella cartella snapMULTI
+
+Ti serve il terminale solo per eseguire lo script di preparazione della SD.
+
+| OS | Metodo più semplice |
+|----|---------------------|
+| macOS | Apri la cartella estratta nel Finder, poi trascina la cartella dentro una finestra Terminale dopo aver scritto `cd ` |
+| Windows | Apri la cartella estratta in Esplora file, clic destro su uno spazio vuoto, scegli **Apri nel Terminale** |
+| Linux | Apri la cartella nel file manager, clic destro su uno spazio vuoto, scegli **Apri nel Terminale** |
+
+Sei nel posto giusto se `ls scripts` (macOS/Linux) o `dir scripts` (Windows) mostra `prepare-sd.sh` / `prepare-sd.ps1`.
 
 ---
 
@@ -274,6 +284,8 @@ Se scegli **3**, un sotto-menu ti chiede l'uscita:
 | **3 — Condivisione di rete** | Ti verranno chiesti hostname/IP del server e percorso di condivisione. NFS per Linux/Mac/NAS; SMB per condivisioni Windows. Le credenziali sono memorizzate sulla scheda SD temporaneamente e rimosse dopo il primo avvio |
 | **4 — Configurare dopo** | Salta la configurazione musicale. Aggiungi la tua libreria a `/opt/snapmulti/.env` dopo l'installazione (vedi [ADVANCED.it.md — Libreria musicale in rete](ADVANCED.it.md#libreria-musicale-in-rete)) |
 
+> **Prima installazione?** Scegli **1 — Solo streaming** a meno che tu conosca già protocollo NAS, hostname/IP, nome condivisione e credenziali. Puoi aggiungere un NAS dopo un primo boot pulito.
+
 Se scegli **Condivisione di rete**, dovrai quindi inserire:
 - **NFS:** hostname o IP del server (es. `nas.local`) e percorso di export (es. `/volume1/music`)
 - **SMB:** hostname o IP del server, nome condivisione (es. `Music`) e username/password opzionali
@@ -299,7 +311,7 @@ Dovresti vedere **"All checks passed."** e **"SD card ready!"** alla fine.
 1. **Rimuovi la scheda SD** dal tuo computer
 2. Inseriscila nel Pi
 3. Collega l'alimentazione
-4. **Aspetta ~5–10 minuti** — il Pi installa Docker, scarica le immagini e avvia tutti i servizi
+4. **Aspetta ~10–15 minuti** — il Pi installa Docker, scarica le immagini, avvia tutti i servizi, li verifica e poi riavvia una volta
 
 ### Cosa vedrai sull'HDMI
 
@@ -326,6 +338,16 @@ Il Pi **si riavvia automaticamente** quando l'installazione è completa. Dopo il
 
 > **Placeholder hostname.** Da qui in avanti, `<hostname>.local` significa l'hostname che hai impostato in Imager al Passo 1c. Se hai impostato `myradio`, usa `myradio.local` ovunque appaia `<hostname>.local` qui sotto.
 
+### Controllo per principianti — aprire la pagina di stato
+
+Da un altro computer o telefono sulla stessa rete, apri:
+
+```
+http://<hostname>.local:8083/status
+```
+
+Se la pagina si apre e tutti i controlli sono verdi, la piattaforma è sana. Se non si apre, prova lo stesso URL usando l'indirizzo IP del Pi al posto di `<hostname>.local`.
+
 ### Trovare il Pi sulla tua rete
 
 Dal tuo computer, fai ping al Pi usando il suo hostname:
@@ -342,9 +364,9 @@ ssh <username>@<hostname>.local
 
 > **Utenti Windows:** Usa Windows Terminal, PowerShell o [PuTTY](https://putty.org) con `<hostname>.local` come host.
 
-> **Se `.local` non si risolve:** Usa l'indirizzo IP invece. Trovalo nella lista client DHCP del tuo router, o controlla l'output HDMI dopo il riavvio — il Pi stampa il suo IP sulla console.
+> **Se `.local` non si risolve:** Usa l'indirizzo IP invece. Trovalo nell'app del router o del mesh WiFi sotto dispositivi connessi / client DHCP, oppure controlla l'output HDMI dopo il riavvio — il Pi stampa il suo IP sulla console.
 
-### Controllare i container in esecuzione
+### Controllo avanzato — container in esecuzione
 
 ```bash
 sudo docker ps --format 'table {{.Names}}\t{{.Status}}'

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -105,18 +105,16 @@ lsblk -o NAME,LABEL,MOUNTPOINT | grep bootfs
 
 ## Step 3 — Get the snapMULTI files
 
-Pick one of the two options. Both produce a folder named `snapMULTI/` that the next step expects.
+Pick one of the two options. If you are not a developer, use **Option A — Download the ZIP**.
 
 ### Option A — Download the ZIP (no Git required)
 
 1. Open [https://github.com/lollonet/snapMULTI/releases/latest](https://github.com/lollonet/snapMULTI/releases/latest) in your browser
 2. Under **Assets**, click **Source code (zip)** to download the latest release
 3. Extract the ZIP — you get a folder named `snapMULTI-<version>`. The folder name doesn't matter — `prepare-sd.sh` finds its project root via its own location
-4. Open a terminal inside that extracted folder
+4. Keep the folder open — the next section shows how to open a terminal there
 
 > Prefer the tagged release ZIP over the green **Code → Download ZIP** button on the repo home page — the latter ships the `main` branch, which may include unreleased work-in-progress.
->
-> Run `./scripts/prepare-sd.sh` from inside the project folder. The folder name does not matter — `prepare-sd.sh` resolves its own path. Alternatively, from the parent folder, use `./<folder-name>/scripts/prepare-sd.sh`.
 
 ### Option B — Clone with Git (recommended for updates)
 
@@ -142,6 +140,18 @@ cd snapMULTI
 ```
 
 > The repository includes both server and client software in a single monorepo.
+
+### Open a terminal in the snapMULTI folder
+
+You need the terminal only to run the SD preparation script.
+
+| OS | Easiest way |
+|----|-------------|
+| macOS | Open the extracted folder in Finder, then drag the folder into a Terminal window after typing `cd ` |
+| Windows | Open the extracted folder in File Explorer, right-click empty space, choose **Open in Terminal** |
+| Linux | Open the folder in your file manager, right-click empty space, choose **Open in Terminal** |
+
+You are in the right place if `ls scripts` (macOS/Linux) or `dir scripts` (Windows) shows `prepare-sd.sh` / `prepare-sd.ps1`.
 
 ---
 
@@ -272,6 +282,8 @@ If you pick **3**, a sub-menu asks for the output:
 | **3 — Network share** | You'll be asked for server hostname/IP and share path. NFS for Linux/Mac/NAS; SMB for Windows shares. Credentials are stored on the SD card temporarily and removed after first boot |
 | **4 — Set up later** | Skips music config. Add your library to `/opt/snapmulti/.env` after install (see [ADVANCED.md — Music library on the network](ADVANCED.md#music-library-on-the-network)) |
 
+> **First install?** Choose **1 — Streaming only** unless you already know your NAS protocol, hostname/IP, share name and credentials. You can add a NAS later after one clean boot.
+
 If you choose **Network share**, you'll then enter:
 - **NFS:** server hostname or IP (e.g. `nas.local`) and export path (e.g. `/volume1/music`)
 - **SMB:** server hostname or IP, share name (e.g. `Music`), and optional username/password
@@ -297,7 +309,7 @@ You should see **"All checks passed."** and **"SD card ready!"** at the end.
 1. **Remove the SD card** from your computer
 2. Insert it into the Pi
 3. Connect power
-4. **Wait ~5–10 minutes** — the Pi installs Docker, pulls images, and starts all services
+4. **Wait ~10–15 minutes** — the Pi installs Docker, pulls images, starts all services, verifies them, then reboots once
 
 ### What you'll see on HDMI
 
@@ -324,6 +336,16 @@ The Pi **reboots automatically** when installation is complete. After the reboot
 
 > **Hostname placeholder.** From here on, `<hostname>.local` means the hostname you set in Imager at Step 1c. If you set `myradio`, use `myradio.local` everywhere `<hostname>.local` appears below.
 
+### Beginner check — open the status page
+
+From another computer or phone on the same network, open:
+
+```
+http://<hostname>.local:8083/status
+```
+
+If the page opens and every check is green, the platform is healthy. If it does not open, try the same URL with the Pi's IP address instead of `<hostname>.local`.
+
 ### Find the Pi on your network
 
 From your computer, ping the Pi using its hostname:
@@ -340,9 +362,9 @@ ssh <username>@<hostname>.local
 
 > **Windows users:** Use Windows Terminal, PowerShell, or [PuTTY](https://putty.org) with `<hostname>.local` as the host.
 
-> **If `.local` doesn't resolve:** Use the IP address instead. Find it in your router's DHCP client list, or check the HDMI output after reboot — the Pi prints its IP on the console.
+> **If `.local` doesn't resolve:** Use the IP address instead. Find it in your router or mesh-WiFi app under connected devices / DHCP clients, or check the HDMI output after reboot — the Pi prints its IP on the console.
 
-### Check running containers
+### Advanced check — running containers
 
 ```bash
 sudo docker ps --format 'table {{.Names}}\t{{.Status}}'

--- a/docs/TROUBLESHOOTING.it.md
+++ b/docs/TROUBLESHOOTING.it.md
@@ -4,7 +4,7 @@
 
 Guida per sintomi quando qualcosa di snapMULTI non funziona. Per l'installazione da zero vedi [INSTALL.it.md](INSTALL.it.md); per operazioni e personalizzazioni vedi [ADVANCED.it.md](ADVANCED.it.md).
 
-## In caso di dubbio — prendi il bundle diagnostico
+## In caso di dubbio — prendi il pacchetto diagnostico
 
 Se `firstboot.sh` si interrompe, la trap di cleanup scrive un tarball anonimizzato sulla **partizione FAT32 di boot** della SD — leggibile da qualsiasi computer senza SSH:
 
@@ -12,7 +12,7 @@ Se `firstboot.sh` si interrompe, la trap di cleanup scrive un tarball anonimizza
 /boot/firmware/snapmulti-diag-install-failed-<UTC-ts>.tar.gz
 ```
 
-Cosa contiene: l'ultima ora di log di installazione, l'output del rilevamento hardware (modello, HAT audio, rete), il nome dello step fallito, i log dei container. Il bundle è **anonimizzato** prima di finire sulla SD — niente MAC address, niente IP della LAN, niente SSID, niente password, niente token API — quindi è sicuro allegarlo a una [issue GitHub](https://github.com/lollonet/snapMULTI/issues/new/choose) pubblica. La partizione boot sopravvive all'attivazione di overlayroot e alla corruzione del rootfs; è per questo che scriviamo lì invece che in `/var/log`.
+Cosa contiene: l'ultima ora di log di installazione, l'output del rilevamento hardware (modello, HAT audio, rete), il nome dello step fallito, i log dei container. Il pacchetto è **anonimizzato** prima di finire sulla SD — niente MAC address, niente IP della LAN, niente SSID, niente password, niente token API — quindi è sicuro allegarlo a una [issue GitHub](https://github.com/lollonet/snapMULTI/issues/new/choose) pubblica. La partizione boot sopravvive all'attivazione di overlayroot e alla corruzione del rootfs; è per questo che scriviamo lì invece che in `/var/log`.
 
 Lo puoi anche generare manualmente su un device in esecuzione per supporto:
 
@@ -22,7 +22,9 @@ sudo /opt/snapmulti/scripts/diagnostic.sh --reason crash --out-dir /tmp
 
 Stesse regole di anonimizzazione.
 
-## Prima cosa da fare — esegui lo smoke test
+> **Non ti senti a tuo agio con i comandi da terminale?** Fermati qui: allega il pacchetto diagnostico a una issue GitHub e descrivi cosa hai visto su HDMI / LED / app del router. I comandi sotto sono utili, ma il pacchetto diagnostico è il percorso di supporto principale.
+
+## Prima cosa da fare — esegui il test di salute
 
 Prima di addentrarti nei singoli sintomi, esegui il controllo di salute generale sul device:
 
@@ -47,13 +49,13 @@ Output JSON per script / dashboard: `sudo bash /opt/snapmulti/scripts/device-smo
 2. Dal laptop: `ping <hostname>.local`. Se risponde, la rete è OK.
 3. Se SSH funziona: `ssh <username>@<hostname>.local`, poi `sudo journalctl -u snapmulti-firstboot.service -f` per vedere l'install in tempo reale.
 
-**Se è ancora bloccato.** Estrai la SD e cerca `snapmulti-diag-install-failed-*.tar.gz` sulla partizione boot — significa che l'install si è arreso. Allegalo a una issue GitHub. Se nessun bundle esiste e il Pi è completamente irraggiungibile dopo 20 minuti, la SD è la causa più comune (usa SanDisk / Samsung A1 o migliore — vedi [HARDWARE.it.md](HARDWARE.it.md#se-non-sai-cosa-comprareusare)).
+**Se è ancora bloccato.** Estrai la SD e cerca `snapmulti-diag-install-failed-*.tar.gz` sulla partizione boot — significa che l'install si è arreso. Allegalo a una issue GitHub. Se non esiste nessun pacchetto diagnostico e il Pi è completamente irraggiungibile dopo 20 minuti, la SD è la causa più comune (usa SanDisk / Samsung A1 o migliore — vedi [HARDWARE.it.md](HARDWARE.it.md#se-non-sai-cosa-comprareusare)).
 
 ## Il device non compare in rete / `.local` non risolve
 
 **Sintomi.** `ping <hostname>.local` non risponde. Il Pi non appare mai nella lista client DHCP del router.
 
-**Causa probabile.** Mismatch nella configurazione WiFi di Imager (country code sbagliato, SSID 5 GHz su una scheda solo 2,4 GHz, canale DFS che il Pi non riesce a usare al primo boot), oppure il telefono / laptop è su una rete diversa dal Pi (WiFi guest, VLAN separata), oppure il router non relay'a l'mDNS.
+**Causa probabile.** Disallineamento nella configurazione WiFi di Imager (paese sbagliato, SSID 5 GHz su una scheda solo 2,4 GHz, canale DFS che il Pi non riesce a usare al primo boot), oppure il telefono / laptop è su una rete diversa dal Pi (WiFi ospiti, VLAN separata), oppure il router non inoltra l'mDNS.
 
 **Cosa provare.**
 1. Usa l'IP direttamente. Lo trovi nella lista client DHCP del router, o collega l'HDMI: il Pi stampa l'IP sulla console dopo il boot.
@@ -88,7 +90,7 @@ Output JSON per script / dashboard: `sudo bash /opt/snapmulti/scripts/device-smo
 3. Controlla il mixer hardware: `alsamixer -c 0`, F6 per scegliere la card, alza il master e tutti i controlli "Digital" / "Speaker".
 4. Verifica che l'HAT sia rilevato: `aplay -l` deve mostrare il tuo DAC; `dmesg | grep -i 'snd\|hifiberry\|wm8'` deve mostrare il caricamento del driver.
 
-**Se è ancora bloccato.** Esegui lo smoke test (ha un check `audio_modules` che segnala mismatch fra moduli kernel e HAT). Se `config.txt` non ha `dtoverlay=hifiberry-*` ecc., rilancia `setup.sh` e conferma che il rilevamento HAT scelga il modello giusto — le schede senza EEPROM richiedono una scelta manuale.
+**Se è ancora bloccato.** Esegui il test di salute (ha un controllo `audio_modules` che segnala disallineamenti fra moduli kernel e HAT). Se `config.txt` non ha `dtoverlay=hifiberry-*` ecc., rilancia `setup.sh` e conferma che il rilevamento HAT scelga il modello giusto — le schede senza EEPROM richiedono una scelta manuale.
 
 ## Gli speaker non trovano il server (snapclient non si connette)
 
@@ -101,7 +103,7 @@ Output JSON per script / dashboard: `sudo bash /opt/snapmulti/scripts/device-smo
 2. Sul client: `avahi-browse -r _snapcast._tcp --terminate` — deve elencare il server. Se non lo fa, l'mDNS non attraversa la rete.
 3. Come workaround, imposta un server statico nel `.env` del client: `SNAPSERVER_HOST=<server-ip>` e `cd /opt/snapclient && sudo docker compose up -d`.
 
-**Se è ancora bloccato.** La causa più comune è un router che non inoltra l'mDNS tra SSID / VLAN (mesh router e funzioni "guest network" sono tipiche). Metti server e client sullo stesso SSID, oppure installa un mDNS repeater sul router (DD-WRT, OpenWrt, UniFi lo supportano tutti).
+**Se è ancora bloccato.** La causa più comune è un router che non inoltra l'mDNS tra SSID / VLAN (mesh router e rete ospiti sono tipici). Metti server e client sullo stesso SSID, oppure installa un ripetitore mDNS sul router (DD-WRT, OpenWrt, UniFi lo supportano tutti).
 
 ## Spotify / AirPlay / Tidal non visibili nell'app di cast
 
@@ -112,7 +114,7 @@ Output JSON per script / dashboard: `sudo bash /opt/snapmulti/scripts/device-smo
 **Cosa provare.**
 1. Conferma che il container sia up: `cd /opt/snapmulti && docker compose ps` — `librespot` (Spotify), `shairport-sync` (AirPlay), `tidal-connect` (Tidal, solo ARM) tutti `healthy`.
 2. Dal server: `avahi-browse -r _spotify-connect._tcp --terminate`, `avahi-browse -r _raop._tcp --terminate` (AirPlay) — deve elencare il server.
-3. Telefono e server sullo stesso SSID WiFi? Le reti guest e le VLAN bloccano il discovery.
+3. Telefono e server sullo stesso SSID WiFi? Le reti ospiti e le VLAN bloccano il rilevamento automatico.
 4. Tidal Connect è solo ARM ed è **abilitato di default sugli install ARM**. Se non appare: conferma che il Pi sia ARM (`uname -m` restituisce `aarch64`), controlla che `COMPOSE_PROFILES` contenga `tidal` in `/opt/snapmulti/.env` e verifica che il container `tidal-connect` sia `healthy`. Vedi [USAGE.it.md — Nota sicurezza Tidal Connect](USAGE.it.md#nota-sicurezza-tidal-connect) per la disclosure e il path di disabilitazione.
 5. Spotify Connect richiede **Premium** — gli account Free non mostrano il device.
 
@@ -213,11 +215,11 @@ cat /var/log/snapmulti-install.log
 http://<server>:8083/status
 ```
 
-Per un bundle portabile e anonimizzato da allegare a una bug report: `sudo /opt/snapmulti/scripts/diagnostic.sh --reason crash --out-dir /tmp`.
+Per creare un pacchetto diagnostico portabile e anonimizzato da allegare a una segnalazione bug: `sudo /opt/snapmulti/scripts/diagnostic.sh --reason crash --out-dir /tmp`.
 
 ## Ancora bloccato?
 
 - Problema specifico del Pi → [HARDWARE.it.md](HARDWARE.it.md)
 - Personalizzazione / operazioni → [ADVANCED.it.md](ADVANCED.it.md)
 - Architettura / domande a livello servizio → [USAGE.it.md](USAGE.it.md)
-- Bug o comportamento poco chiaro → [apri una issue GitHub](https://github.com/lollonet/snapMULTI/issues/new/choose) e allega il bundle diagnostico.
+- Bug o comportamento poco chiaro → [apri una issue GitHub](https://github.com/lollonet/snapMULTI/issues/new/choose) e allega il pacchetto diagnostico.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -22,6 +22,8 @@ sudo /opt/snapmulti/scripts/diagnostic.sh --reason crash --out-dir /tmp
 
 Same redaction rules.
 
+> **Not comfortable with terminal commands?** Stop here: attach the diagnostic bundle to a GitHub issue and describe what you saw on HDMI / LEDs / router app. The commands below are useful, but the bundle is the support-first path.
+
 ## First check — run the smoke test
 
 Before drilling into a specific symptom, run the all-in-one health check on the device:

--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -39,6 +39,8 @@ Default applicati a ogni container in `docker-compose.yml`:
 
 **Eccezione 2 — `tidal-connect`** (solo ARM): gira come root perché il binario proprietario upstream lo richiede. **Abilitato di default sugli install ARM** — `deploy.sh` scrive `COMPOSE_PROFILES=tidal` in `/opt/snapmulti/.env` quindi il profilo `tidal` è attivo subito su Pi 3/4/5. Per **disabilitarlo** (es. per uno stack completamente free-software), rimuovi `tidal` da `COMPOSE_PROFILES` in `/opt/snapmulti/.env` e fai `sudo systemctl restart snapmulti-server.service`. Vedi [Nota sicurezza Tidal Connect](#nota-sicurezza-tidal-connect) per la disclosure completa.
 
+**Privacy / telemetria**: snapMULTI in sé non "chiama casa". Non esistono un servizio cloud snapMULTI, un piano di controllo ospitato, endpoint di telemetria, SDK di analisi o account snapMULTI. Le API di controllo e metadati girano sulla LAN locale. Traffico esterno esiste comunque per dipendenze e integrazioni scelte: download OS/Docker durante installazione o aggiornamento, scaricamento immagini da Docker Hub, traffico dei servizi Spotify/Tidal/AirPlay e ricerche di metadati/copertine.
+
 **Threat model**: snapMULTI è progettato per una LAN fidata — server e client sulla stessa sottorete dietro un router residenziale. Fuori scope: esposizione WAN (niente autenticazione su JSON-RPC, Snapweb o myMPD), scenari multi-tenant, client malevoli sulla LAN. Se ti serve uno di questi casi, metti davanti un reverse proxy con auth e usa `bind 127.0.0.1` in `config/snapserver.conf`.
 
 ## Sorgenti audio
@@ -73,7 +75,7 @@ Tidal Connect è **abilitato di default sugli install ARM** (`deploy.sh` scrive 
 | Metodo | App | Qualità | Setup |
 |--------|-----|---------|-------|
 | Mittente AirPlay | AirMusic, AllStream | Buona | Installa app → seleziona target AirPlay = hostname del server |
-| TCP via BubbleUPnP | BubbleUPnP + relay ffmpeg | Buona | Cattura in BubbleUPnP, rilancia con `ffmpeg ... tcp://server:4953` |
+| TCP via BubbleUPnP | BubbleUPnP + rilancio con ffmpeg | Buona | Cattura in BubbleUPnP, rilancia con `ffmpeg ... tcp://server:4953` |
 | TCP diretto | Termux + ffmpeg | Lossless | `ffmpeg -f pulse -i default -f s16le -ar 44100 -ac 2 tcp://server:4953` |
 
 ## Interfacce di controllo
@@ -134,4 +136,4 @@ docker inspect --format='{{.State.Health.Status}}' snapserver
 http://<server>:8083/status
 ```
 
-Fallimenti all'install e post-install (con la procedura del bundle diagnostico): [TROUBLESHOOTING.it.md](TROUBLESHOOTING.it.md).
+Fallimenti all'install e post-install (con la procedura del pacchetto diagnostico): [TROUBLESHOOTING.it.md](TROUBLESHOOTING.it.md).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -39,6 +39,8 @@ Defaults applied to every container in `docker-compose.yml`:
 
 **Exception 2 — `tidal-connect`** (ARM only): runs as root because the proprietary upstream binary needs it. **Enabled by default on ARM installs** — `deploy.sh` writes `COMPOSE_PROFILES=tidal` into `/opt/snapmulti/.env` so the `tidal` profile is active out of the box on Pi 3/4/5. To **opt out** (e.g. for a fully free-software stack), remove `tidal` from `COMPOSE_PROFILES` in `/opt/snapmulti/.env` and run `sudo systemctl restart snapmulti-server.service`. See [Tidal Connect security note](#tidal-connect-security-note) for the full disclosure.
 
+**Privacy / telemetry**: snapMULTI itself does not phone home. There is no snapMULTI cloud service, hosted control plane, telemetry endpoint, analytics SDK, or snapMULTI account. Runtime control and metadata APIs are local LAN services. External network traffic still exists for normal dependencies and chosen integrations: OS/Docker downloads during install/update, Docker Hub image pulls, Spotify/Tidal/AirPlay provider traffic, and metadata/artwork lookups.
+
 **Threat model**: snapMULTI is designed for a trusted LAN — server and clients on the same subnet behind a residential router. Out-of-scope: WAN exposure (no authentication on JSON-RPC, Snapweb or myMPD), multi-tenant scenarios, malicious clients on the LAN. If you need any of those, put a reverse proxy with auth in front and use `bind 127.0.0.1` in `config/snapserver.conf`.
 
 ## Audio Sources


### PR DESCRIPTION
Three threads, one polish pass for the community launch.

## Privacy / local-first messaging restored

The opener originally carried "Local-first: no snapMULTI cloud or telemetry" and lost it during the PR #437 cycle. The launch posts (r/raspberry_pi, r/selfhosted, HN drafts) hammer this differentiator, so the landing page now reinforces it in three layered places:

- **`README.md` / `README.it.md`** — new "Privacy" bullet in *Realistic expectations* (system property, not marketing opener)
- **`SECURITY.md`** — new "Privacy and Telemetry" section (authoritative reference for the privacy claim, with the honest caveat that streaming integrations and package downloads still hit external services)
- **`docs/USAGE.md` / `docs/USAGE.it.md`** — "Privacy / telemetry" paragraph in the architecture reference

## ZIP-first onboarding

For a first install, downloading the ZIP is the lower-friction path; `git clone` is only the right call if you already use Git or plan to contribute. `README.md`/`.it.md` and `docs/INSTALL.md`/`.it.md` updated to reflect that order. `INSTALL.md` also gains an explicit "Open a terminal in the snapMULTI folder" section so a non-CLI reader has a concrete checkpoint.

## Italian translation polish

- "bundle diagnostico" → "pacchetto diagnostico" (proper Italian)
- "smoke test" → "test di salute" in reader-facing contexts (the technical term is kept where it's an internal reference)
- "WiFi guest" → "WiFi ospiti"
- "BubbleUPnP + relay ffmpeg" → "BubbleUPnP + rilancio con ffmpeg"

## Beginner safety net in TROUBLESHOOTING

New callout at the top of `docs/TROUBLESHOOTING.md` / `.it.md`: *"Not comfortable with terminal commands? Stop here: attach the diagnostic bundle to a GitHub issue and describe what you saw on HDMI / LEDs / router app. The commands below are useful, but the bundle is the support-first path."*

## Validation

Done locally: EN/IT structural sync verified (matching section headings, identical link targets), `git diff --check` clean, no code touched.

Deferred: none — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)