### PR TITLE
docs: drop stale #432 forward-reference in THIRD-PARTY-NOTICES

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -84,8 +84,7 @@ recipe.
 - **For a 100 % free-software stack**: opt out of the `tidal` profile as
   described above. The other six containers (snapserver, mpd,
   shairport-sync, go-librespot, metadata, mympd) ship from sources
-  without proprietary binaries. A future release will track issue #432
-  ("make Tidal truly opt-in") to flip this default
+  without proprietary binaries
 
 ## Display & visualisation
 


### PR DESCRIPTION
## Summary
- Closes #432 as won't-do
- Removes the dangling "a future release will track #432 to flip this default" promise from the free-software-stack bullet in `THIRD-PARTY-NOTICES.md` so the doc reflects the actual project decision

## Rationale

Issue #432 proposed making Tidal Connect truly opt-in (default OFF on ARM, operator must explicitly enable). After weighing trade-offs:

| | Default-on-ARM (status quo) | Truly opt-in (#432 proposal) |
|---|---|---|
| Beginner UX (prepare-sd.sh path) | Tidal works out of the box on Pi | Operator must edit install.conf before SD insert |
| Advanced user opt-out | Already documented (3 places: README, USAGE, THIRD-PARTY-NOTICES) | New mechanism + new install.conf field |
| Coherence with appliance model | Just works | Adds friction for the 90% case |
| Cost to ship | 0 LOC | ~80 LOC + sync + tests + 4 doc files × 2 languages |

The current behaviour is the right default for an audio appliance: Tidal works on the supported hardware (ARM) out of the box, and the operator who wants a 100% free-software stack has a documented one-line `.env` edit.

## Validation

**Done locally:**
- `git grep "#432"` → only the line being removed; no other forward references
- `git grep "truly opt-in"` → none
- shellcheck + hadolint via pre-push hook → all pass
- Diff: 1 file, +1/-2 lines

**Deferred to release-gate:** none — pure doc edit, no runtime behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)