### PR TITLE
docs: hardware validation tier (Validated / Expected / Experimental)

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -15,11 +15,11 @@ snapMULTI è pensato per chi vuole un **sistema audio multi-room open source** s
 
 > **Uscita audio.** snapMULTI manda un segnale di linea dal Pi — non amplifica. Serve uno di:
 > - una **cassa attiva** (amplificatore integrato, es. Edifier R1280T, Audioengine A2+),
-> - un **HAT con amplificatore integrato** (es. [HiFiBerry AMP2](https://www.hifiberry.com/shop/boards/hifiberry-amp2/)) che pilota casse passive,
-> - un **DAC HAT** (es. HiFiBerry DAC+ / DAC2 Pro) verso amplificatore esterno e casse passive, oppure
-> - un **HAT digitale** (es. HiFiBerry Digi+) verso un sintoamplificatore AV via S/PDIF.
+> - un **DAC HAT validato** (famiglia HiFiBerry DAC+ o InnoMaker PCM5122) verso amplificatore esterno e casse passive,
+> - un **HAT digitale validato** (famiglia HiFiBerry Digi+) verso un sintoamplificatore AV via S/PDIF, oppure
+> - un'uscita configurata manualmente (DAC USB, HDMI, jack del Pi, HAT amplificato) se ti senti a tuo agio nel diagnosticare hardware audio.
 >
-> Esempi di setup completi e combinazioni testate: [docs/HARDWARE.it.md#configurazioni-consigliate](docs/HARDWARE.it.md#configurazioni-consigliate).
+> Esempi di setup completi, stato di validazione e uscite sperimentali: [docs/HARDWARE.it.md#configurazioni-consigliate](docs/HARDWARE.it.md#configurazioni-consigliate).
 
 ## Per chi è snapMULTI
 
@@ -103,7 +103,7 @@ Espelli l'SD, inseriscila nel Pi, accendi. Aspetta circa 10-15 minuti — l'inst
 **Ha funzionato quando**: con uno schermo collegato, il display HDMI mostra la schermata "in riproduzione" di snapMULTI (copertina / spettro). In ogni caso, da un altro dispositivo apri `http://<hostname>.local:8083/status` — tutti i controlli devono essere verdi. Poi fai cast di qualcosa (vedi **Dopo l'installazione** più sotto).
 
 > **Procedura dettagliata** con troubleshooting e percorso di recupero diagnostico: [docs/INSTALL.it.md](docs/INSTALL.it.md).
-> **Matrice di compatibilità** (modelli Pi, DAC HAT, setup di rete): [docs/HARDWARE.it.md](docs/HARDWARE.it.md).
+> **Policy hardware** (combinazioni Pi/audio validate vs sperimentali): [docs/HARDWARE.it.md](docs/HARDWARE.it.md).
 
 ## Dopo l'installazione
 
@@ -157,7 +157,7 @@ Definizioni rapide dei termini che incontrerai in questo README e nella document
 | **Server** | Il Raspberry Pi (o qualsiasi box Linux) che ospita le sorgenti musicali — Snapcast, MPD, Spotify Connect, AirPlay, Tidal — e distribuisce l'audio a uno o più altoparlanti |
 | **Audio Player** *(o "client" / "altoparlante")* | Un Raspberry Pi che riceve l'audio dal server e lo riproduce attraverso un DAC / amplificatore / altoparlante collegato. Uno per stanza |
 | **Snapcast** | Il motore open source di sincronizzazione multi-room su cui snapMULTI è costruito. Lato server: `snapserver`; lato client: `snapclient` |
-| **HAT** | "Hardware Attached on Top" — una piccola scheda che si innesta sul GPIO del Pi. snapMULTI funziona con HAT audio (DAC, amplificatore o digitale S/PDIF) |
+| **HAT** | "Hardware Attached on Top" — una piccola scheda che si innesta sul GPIO del Pi. La validazione di lancio snapMULTI copre famiglie HAT audio specifiche; controlla la policy hardware prima di comprare |
 | **mDNS** / `.local` | "Multicast DNS" — come i dispositivi si annunciano in LAN senza configurare IP manualmente. `pi-server.local` si risolve automaticamente sulla maggior parte delle reti |
 | **NAS** | Network-attached storage — un box separato (Synology, QNAP, custom) che ospita la libreria musicale, montato da snapMULTI via NFS o SMB |
 | **Filesystem read-only** | snapMULTI monta il root in sola lettura dopo l'install (overlayroot + fuse-overlayfs), così un blackout non può corrompere la SD. Le modifiche vengono cancellate al reboot a meno che tu non disattivi la modalità RO |

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ snapMULTI is for people who want an **open-source multi-room audio system** with
 
 > **Sound output.** snapMULTI sends a line-level signal from the Pi — it does not amplify. You need one of:
 > - an **active speaker** (built-in amp, e.g. Edifier R1280T, Audioengine A2+),
-> - a **HAT with integrated amplifier** (e.g. [HiFiBerry AMP2](https://www.hifiberry.com/shop/boards/hifiberry-amp2/)) driving passive speakers,
-> - a **DAC HAT** (e.g. HiFiBerry DAC+ / DAC2 Pro) into an external amplifier and passive speakers, or
-> - a **digital HAT** (e.g. HiFiBerry Digi+) feeding an AV receiver over S/PDIF.
+> - a **validated DAC HAT** (HiFiBerry DAC+ family or InnoMaker PCM5122) into an external amplifier and passive speakers,
+> - a **validated digital HAT** (HiFiBerry Digi+ family) feeding an AV receiver over S/PDIF, or
+> - a manually configured output (USB DAC, HDMI, Pi jack, amplifier HAT) if you are comfortable troubleshooting audio hardware.
 >
-> Full setup examples and tested combinations: [docs/HARDWARE.md#recommended-setups](docs/HARDWARE.md#recommended-setups).
+> Full setup examples, validation status and experimental outputs: [docs/HARDWARE.md#recommended-setups](docs/HARDWARE.md#recommended-setups).
 
 ## Who is this for
 
@@ -103,7 +103,7 @@ Eject the SD, insert it in the Pi, power on. Wait about 10-15 minutes — the fi
 **It worked when**: with a screen attached, the HDMI display shows the snapMULTI now-playing screen (cover art / spectrum). Either way, from another device open `http://<hostname>.local:8083/status` — every check should be green. Then cast something (see **After install** below).
 
 > **Detailed walk-through** with troubleshooting and the diagnostic-bundle recovery path: [docs/INSTALL.md](docs/INSTALL.md).
-> **Compatibility matrix** (which Pi models, DAC HATs, network setups): [docs/HARDWARE.md](docs/HARDWARE.md).
+> **Hardware policy** (validated vs experimental Pi/audio combinations): [docs/HARDWARE.md](docs/HARDWARE.md).
 
 ## After install
 
@@ -157,7 +157,7 @@ Quick definitions of terms you'll see in this README and the docs.
 | **Server** | The Raspberry Pi (or any Linux box) that hosts the music sources — Snapcast, MPD, Spotify Connect, AirPlay, Tidal — and fans audio out to one or more speakers |
 | **Audio Player** *(or "client" / "speaker")* | A Raspberry Pi that receives audio from the server and plays it through an attached DAC / amp / speaker. One per room |
 | **Snapcast** | The open-source multi-room sync engine snapMULTI is built on. Server-side: `snapserver`; client-side: `snapclient` |
-| **HAT** | "Hardware Attached on Top" — a small board that plugs onto the Pi's GPIO header. snapMULTI works with audio HATs (DAC, amplifier, or digital S/PDIF) |
+| **HAT** | "Hardware Attached on Top" — a small board that plugs onto the Pi's GPIO header. snapMULTI launch validation covers specific audio HAT families; see the hardware policy before buying |
 | **mDNS** / `.local` | "Multicast DNS" — how devices announce themselves on the LAN without manual IP setup. `pi-server.local` resolves automatically on most networks |
 | **NAS** | Network-attached storage — a separate box (Synology, QNAP, custom) hosting your music library, mounted by snapMULTI over NFS or SMB |
 | **Read-only filesystem** | snapMULTI mounts the root filesystem read-only after install (overlayroot + fuse-overlayfs) so a power cut can't corrupt the SD card. Changes are wiped on reboot unless you toggle off RO mode |

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -16,12 +16,33 @@ Suggerimenti rapidi per chi non vuole leggere tutta la guida.
 
 | Ruolo | Compra / usa | Perché |
 |-------|--------------|--------|
-| **Server + Player** (un Pi che fa tutto) | **Pi 4 4 GB** (o **Pi 5**), SD A1/A2 di marca ≥ 16 GB, alimentatore ufficiale 15 W, **DAC USB** oppure **HiFiBerry DAC+ / DAC2 Pro** | Il modello 4 GB lascia margine per le scansioni MPD + i picchi di Spotify / Tidal; le card A1/A2 sono il fattore numero uno contro l'install che si appende |
+| **Server + Player** (un Pi che fa tutto) | **Pi 4 4 GB**, SD A1/A2 di marca ≥ 16 GB, alimentatore ufficiale 15 W, **famiglia HiFiBerry DAC+** oppure **HAT InnoMaker PCM5122** | È il percorso validato per il lancio. Il modello 4 GB lascia margine per le scansioni MPD + i picchi di Spotify / Tidal; le card A1/A2 sono il fattore numero uno contro l'install che si appende |
 | **Solo server** (gli altoparlanti stanno in altre stanze) | **Pi 4 2 GB+** oppure un mini PC / NAS con Docker | Lo stack server è ~1 GB di limiti container; 2 GB di RAM host bastano |
-| **Altoparlante / client** | Un **Pi 3 B+ / Pi 4 / Pi 5** con DAC HAT o DAC USB, oppure un **Pi Zero 2 W** headless (install nativa — niente Docker) | snapclient è leggerissimo; la scelta dipende dal volere o no il display copertine HDMI (solo Pi 4) |
+| **Altoparlante / client** | **Pi 3 B+ / Pi 4** con HiFiBerry DAC+/Digi+ o InnoMaker PCM5122, oppure **Pi Zero 2 W + InnoMaker PCM5122** headless (install nativa — niente Docker) | Sono i percorsi client validati per il lancio. Usa altri DAC solo se ti senti a tuo agio nel diagnosticare ALSA |
 | **Evita** | Pi Zero 2 W come server o in both-mode (512 MB di RAM non bastano), Raspberry Pi OS 32-bit, SD card senza marca, hub USB-alimentati senza alimentatore proprio quando pilotano più Pi | Sono i fallimenti ricorrenti negli install reali |
 
 Il resto di questa guida entra nei *perché* e nei casi limite.
+
+## Policy supporto hardware
+
+snapMULTI mantiene intenzionalmente piccola la matrice hardware di lancio. L'audio su Raspberry Pi è la zona dove nascono più problemi "quasi funziona", quindi la promessa pubblica si basa solo sui dispositivi che abbiamo davvero riflashato, avviato, verificato con test di salute e ascoltato in riproduzione.
+
+| Livello | Significato | Aspettativa di supporto |
+|---------|-------------|-------------------------|
+| **Validato** | Testato end-to-end dal progetto: primo boot, reboot in read-only, smoke/fleet smoke e playback reale dall'uscita audio | Consigliato per prime installazioni e build reference/commerciali |
+| **Atteso funzionante** | Stesso chipset o stesso percorso audio Linux di hardware validato, ma non ancora testato fisicamente dal progetto | Buono per utenti esperti; segnala i risultati |
+| **Sperimentale / manuale** | Presente nel menu installer o configurabile via ALSA, ma non validato per il lancio | Nessuna promessa di compatibilità; usalo solo se sai diagnosticare dispositivi audio |
+
+Uscite audio validate per il lancio:
+
+| Famiglia uscita | Stato validazione |
+|-----------------|-------------------|
+| Famiglia HiFiBerry DAC+ / PCM5122 analogico | **Validato** |
+| HAT InnoMaker PCM5122 analogici, incluso Pi Zero 2 W headless | **Validato** |
+| Famiglia HiFiBerry Digi+ / WM8804 S/PDIF | **Validato** |
+| Audio onboard/bcm2835 su client Pi 4 | **Validato, ma qualità limitata** |
+| Uscita HDMI su client/display Pi 4 | **Validato per il percorso display/client** |
+| DAC USB generici, HAT amplificati, IQaudio, JustBoom, Allo, Waveshare | **Sperimentale / manuale finché non validati fisicamente** |
 
 ## Requisiti del Server
 
@@ -76,17 +97,17 @@ I client Snapcast sono leggeri — ricevono audio e lo riproducono attraverso gl
 | CPU | Qualsiasi ARMv6+ o x86_64 | Anche il Pi Zero W (originale) funziona |
 | RAM | 256 MB | Snapclient usa pochissima memoria |
 | Storage | 8 GB microSD | 16 GB consigliati |
-| Uscita audio | 3.5mm, HDMI, DAC USB o HAT I2S | Vedi sezione uscita audio |
+| Uscita audio | HAT I2S validato, HDMI/onboard, o DAC USB manuale | Vedi policy supporto hardware e sezione uscita audio |
 
 ### Dispositivi Client
 
 | Dispositivo | Uscita Audio | Consumo | Note |
 |-------------|--------------|---------|------|
-| **Raspberry Pi Zero 2 W** | DAC USB o HAT I2S | 0,75 W | Miglior opzione economica; solo WiFi 2,4 GHz; solo audio (senza display) |
+| **Raspberry Pi Zero 2 W** | HAT I2S validato | 0,75 W | Miglior opzione economica; solo WiFi 2,4 GHz; solo audio (senza display) |
 | **Raspberry Pi Zero W** (v1) | DAC USB o HAT I2S | 0,5 W | Funziona ma lento; nessun GPIO audio; solo WiFi 2,4 GHz |
-| **Raspberry Pi 3B/3B+** | Jack 3.5mm, HDMI, DAC USB | 2,5 W | Uscita audio integrata, WiFi 5 GHz + Ethernet |
-| **Raspberry Pi 4** (2 GB+) | Jack 3.5mm, HDMI, DAC USB | 3–6 W | Necessario per client con display copertine (fb-display) |
-| **Raspberry Pi 5** | HDMI, DAC USB | 4–8 W | Sovradimensionato per uso client |
+| **Raspberry Pi 3B/3B+** | HAT I2S validato, onboard/USB manuale | 2,5 W | WiFi 5 GHz + Ethernet; onboard/USB non sono il percorso consigliato per il lancio |
+| **Raspberry Pi 4** (2 GB+) | HAT I2S validato, HDMI, onboard, USB manuale | 3–6 W | Necessario per client con display copertine (fb-display) |
+| **Raspberry Pi 5** | HDMI, USB manuale | 4–8 W | Sovradimensionato per uso client; validazione di lancio più sottile rispetto a Pi 4 |
 | **Vecchio telefono Android** | Altoparlante integrato | Batteria | Tramite [app Snapcast Android](https://github.com/badaix/snapdroid) |
 | **Qualsiasi PC Linux** | Audio integrato | Varia | `apt install snapclient` |
 
@@ -113,22 +134,22 @@ Dettagli:
 - **Hardware guard per server / both** — all'inizio di `firstboot.sh`, `_validate_profile_hardware()` rifiuta `INSTALL_TYPE=server` e `INSTALL_TYPE=both` su Pi Zero 2 W. Il primo boot si interrompe con `log_error` ed `exit 1`, segnalando subito il vincolo invece di fallire più tardi durante `docker compose pull` con un OOM oscuro. Per recuperare, riflashare l'SD scegliendo Audio Player
 - **Zram swap disabilitato** — `tune_pi_zero_2w_swap_safety()` in `scripts/common/system-tune.sh` maschera `dev-zram0.swap` / `rpi-zram-writeback.service` e rimuove `/var/swap` al primo boot. Senza questa correzione, `rpi-zram-writeback` scrive sul file swap che vive nel layer alto tmpfs da 256 MB dell'overlay e il kernel va in panic quando il tmpfs si riempie (osservato il 2026-05-11)
 - **Ruolo single-client, niente failover multi-server** — lo snapclient nativo usa direttamente l'autodiscovery di libavahi-client. La macchina a stati di failover multi-server di `discover-server.sh` (TCP probing, anti-flapping, scelta IPv4 intelligente) non è disponibile sul Pi Zero 2 W. Accettabile per i setup headless tipici a singola stanza; se serve failover usa un client Pi 3 B+ o Pi 4
-- **Compatibilità HAT I2S** — funziona con HAT basati su PCM5122 (HiFiBerry DAC+, InnoMaker Mini). L'impostazione USB `otg_mode=1` di Imager interferisce con I2S — `prepare-sd.sh` e `setup.sh` lo correggono automaticamente
+- **Compatibilità HAT I2S** — la validazione di lancio copre HAT PCM5122 HiFiBerry/InnoMaker. Altre schede PCM5122 sono attese funzionanti ma restano non validate finché non testate. L'impostazione USB `otg_mode=1` di Imager interferisce con I2S — `prepare-sd.sh` e `setup.sh` lo correggono automaticamente
 - **Modalità gadget USB** — per debug senza WiFi, collegare la porta USB dati al computer. Richiede `dtoverlay=dwc2` sotto `[all]` in config.txt (non sotto `[cm5]`)
 
 ### Qualità dell'Uscita Audio
 
 | Metodo di Uscita | Qualità | Note |
 |------------------|---------|------|
-| **DAC HAT I2S** (HiFiBerry DAC+, DAC2 Pro) | Eccellente | Migliore qualità analogica, uscita RCA, si collega direttamente al GPIO del Pi |
-| **HAT S/PDIF I2S** (HiFiBerry Digi+) | Eccellente | Uscita digitale ottica/coassiale verso ricevitore AV o DAC esterno; nessuna conversione analogica sul Pi |
-| **DAC USB** | Molto buona | Ampia gamma di opzioni; funziona con Pi Zero (nessun header GPIO necessario) |
-| **HDMI** | Buona | Usa il tuo TV/ricevitore AV come dispositivo di uscita. Il nome della card ALSA varia per kernel: `vc4-hdmi-0` (Bookworm/Trixie KMS), `HDMI` (legacy). Risolto automaticamente al primo boot via `aplay -L` |
-| **Jack 3.5mm** (Pi 3/4) | Adeguata | Rumore di fondo percepibile su alcuni modelli; va bene per ascolto casual. **Il Pi 5 non ha jack analogico** — scegliere "jack" nel menu installer ricade automaticamente su HDMI |
+| **DAC HAT I2S** (HiFiBerry DAC+ / InnoMaker PCM5122 validati) | Eccellente | Migliore qualità analogica, uscita RCA, si collega direttamente al GPIO del Pi |
+| **HAT S/PDIF I2S** (HiFiBerry Digi+ validato) | Eccellente | Uscita digitale ottica/coassiale verso ricevitore AV o DAC esterno; nessuna conversione analogica sul Pi |
+| **DAC USB** | Molto buona se supportato da Linux | Manuale/sperimentale finché uno specifico modello non viene validato fisicamente |
+| **HDMI** | Buona | Validato sul percorso client/display Pi 4. Il nome della card ALSA varia per kernel: `vc4-hdmi-0` (Bookworm/Trixie KMS), `HDMI` (legacy). Risolto automaticamente al primo boot via `aplay -L` |
+| **Jack 3.5mm** (Pi 3/4) | Adeguata | Validato solo come fallback onboard. Rumore di fondo percepibile su alcuni modelli; va bene per ascolto casual. **Il Pi 5 non ha jack analogico** — scegliere "jack" nel menu installer ricade automaticamente su HDMI |
 
-> **Suggerimento:** Usa un HAT I2S per la migliore qualità. [HiFiBerry DAC+ Zero](https://www.hifiberry.com/shop/boards/dacplus-zero/) per i nodi client, [HiFiBerry DAC2 Pro](https://www.hifiberry.com/shop/boards/dac2-pro/) o [HiFiBerry Digi+](https://www.hifiberry.com/shop/boards/hifiberry-digi/) per nodi collegati a ricevitori AV.
+> **Suggerimento:** per la prima installazione usa HAT I2S validati per il lancio: famiglia HiFiBerry DAC+ o InnoMaker PCM5122 per analogico, famiglia HiFiBerry Digi+ per S/PDIF.
 
-> **Override manuale:** `prepare-sd.sh` offre un menu *Uscita audio* (auto-detect, scegliere un HAT dalla lista, oppure scegliere HDMI/jack integrato). L'auto-detect è la scelta giusta per oltre il 90% delle installazioni — usa i percorsi manuali solo se l'auto-detect è già fallito una volta. Vedi [INSTALL.it.md — Menu 2 — Uscita audio](INSTALL.it.md#menu-2--uscita-audio-solo-audio-player-e-serverplayer).
+> **Override manuale:** `prepare-sd.sh` offre un menu *Uscita audio* (auto-detect, scegliere un HAT dalla lista, oppure scegliere HDMI/jack integrato). Le voci oltre la matrice validata sono aiuti di compatibilità, non una promessa di supporto per il lancio. Vedi [INSTALL.it.md — Menu 2 — Uscita audio](INSTALL.it.md#menu-2--uscita-audio-solo-audio-player-e-serverplayer).
 
 ### Metodo di Installazione Client
 
@@ -293,7 +314,7 @@ Se un nodo è collegato a un ricevitore AV via cavo ottico, usa HiFiBerry Digi+ 
 
 ## Combinazioni Testate
 
-Queste combinazioni hardware sono state verificate end-to-end (firstboot → test di salute → playback audio) nelle date indicate. Il batch del 2026-04-27 è la validazione release-gate per v0.6.x: 6 device riflashati da `main`, test di salute PASS su ognuno, `hw_ptr` ALSA che avanza durante la riproduzione (audio che raggiunge davvero il DAC, non solo la FIFO).
+Queste combinazioni hardware sono state verificate end-to-end (firstboot → test di salute → playback audio) nelle date indicate. Considera questa tabella la fonte di verità per l'hardware validato al lancio. Il batch del 2026-04-27 è la validazione release-gate per v0.6.x: 6 device riflashati da `main`, test di salute PASS su ognuno, `hw_ptr` ALSA che avanza durante la riproduzione (audio che raggiunge davvero il DAC, non solo la FIFO).
 
 | Hostname | Modello Pi | HAT Audio | Chip DAC | Modalità | Display | Sorgente Musica | Validato | Stato |
 |---|---|---|---|---|---|---|---|---|

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -16,12 +16,33 @@ Quick recommendations if you don't want to read the whole guide.
 
 | Role | Buy / use | Why |
 |------|-----------|-----|
-| **Server + Player** (one Pi does everything) | **Pi 4 4 GB** (or **Pi 5**), good-brand A1/A2 SD ≥ 16 GB, official 15 W PSU, **USB DAC** or **HiFiBerry DAC+ / DAC2 Pro** | The 4 GB model leaves headroom for MPD scans + Spotify / Tidal peaks; A1/A2 cards are the #1 install-hang preventer |
+| **Server + Player** (one Pi does everything) | **Pi 4 4 GB**, good-brand A1/A2 SD ≥ 16 GB, official 15 W PSU, **HiFiBerry DAC+ family** or **InnoMaker PCM5122 HAT** | This is the launch-validated path. The 4 GB model leaves headroom for MPD scans + Spotify / Tidal peaks; A1/A2 cards are the #1 install-hang preventer |
 | **Server only** (speakers live in other rooms) | **Pi 4 2 GB+** or any mini PC / NAS with Docker | Server stack is ~1 GB of container limits; 2 GB host RAM is enough |
-| **Speaker / client** | Any **Pi 3 B+ / Pi 4 / Pi 5** with a DAC HAT or USB DAC, or a **Pi Zero 2 W** headless (native install — no Docker) | snapclient is tiny; the choice depends on whether you want the cover-art HDMI display (Pi 4 only) |
+| **Speaker / client** | **Pi 3 B+ / Pi 4** with HiFiBerry DAC+/Digi+ or InnoMaker PCM5122, or **Pi Zero 2 W + InnoMaker PCM5122** headless (native install — no Docker) | These are the launch-validated client paths. Use other DACs only if you are comfortable troubleshooting ALSA |
 | **Avoid** | Pi Zero 2 W as server or in both-mode (512 MB RAM is not enough), 32-bit Raspberry Pi OS, no-brand cheap SD cards, USB-powered hubs without their own PSU when driving multiple Pis | These are the recurring failure modes in real installs |
 
 The rest of this guide goes into the *why* and the corner cases.
+
+## Hardware support policy
+
+snapMULTI intentionally keeps the launch hardware matrix small. Audio on Raspberry Pi is where most "almost works" failures happen, so the public promise is based on devices we have actually reflashed, booted, smoke-tested and heard playing audio.
+
+| Tier | Meaning | Support expectation |
+|------|---------|---------------------|
+| **Validated** | Tested end-to-end by the project: first boot, read-only reboot, smoke/fleet smoke, and real playback through the output | Recommended for first installs and commercial/reference builds |
+| **Expected to work** | Same chipset or Linux audio path as validated hardware, but not physically tested by the project yet | Good for experienced users; please report results |
+| **Experimental / manual** | Present in the installer menu or configurable with ALSA, but not launch-validated | No compatibility promise; use only if you can debug audio devices |
+
+Launch-validated audio outputs:
+
+| Output family | Validation status |
+|---------------|-------------------|
+| HiFiBerry DAC+ family / PCM5122 analog | **Validated** |
+| InnoMaker PCM5122 analog HATs, including Pi Zero 2 W headless | **Validated** |
+| HiFiBerry Digi+ family / WM8804 S/PDIF | **Validated** |
+| Pi onboard/bcm2835 audio on Pi 4 client | **Validated, but quality-limited** |
+| HDMI output on Pi 4 display client | **Validated for display/client path** |
+| Generic USB DACs, amplifier HATs, IQaudio, JustBoom, Allo, Waveshare | **Experimental / manual until physically validated** |
 
 ## Server Requirements
 
@@ -76,17 +97,17 @@ Snapcast clients are lightweight — they receive audio and play it through spea
 | CPU | Any ARMv6+ or x86_64 | Even Pi Zero W (original) works |
 | RAM | 256 MB | Snapclient uses very little memory |
 | Storage | 8 GB microSD | 16 GB recommended |
-| Audio output | 3.5mm, HDMI, USB DAC, or I2S HAT | See audio output section |
+| Audio output | Validated I2S HAT, HDMI/onboard, or manual USB DAC | See hardware support policy and audio output section |
 
 ### Client Device Options
 
 | Device | Audio Output | Power | Notes |
 |--------|--------------|-------|-------|
-| **Raspberry Pi Zero 2 W** | USB DAC or I2S HAT | 0.75 W | Best budget option; 2.4 GHz WiFi only; audio-only (no display) |
+| **Raspberry Pi Zero 2 W** | Validated I2S HAT | 0.75 W | Best budget option; 2.4 GHz WiFi only; audio-only (no display) |
 | **Raspberry Pi Zero W** (v1) | USB DAC or I2S HAT | 0.5 W | Works but slow; no GPIO audio; 2.4 GHz WiFi only |
-| **Raspberry Pi 3B/3B+** | 3.5mm jack, HDMI, USB DAC | 2.5 W | Built-in audio output, 5 GHz WiFi + Ethernet |
-| **Raspberry Pi 4** (2 GB+) | 3.5mm jack, HDMI, USB DAC | 3–6 W | Required for client with cover art display (fb-display) |
-| **Raspberry Pi 5** | HDMI, USB DAC | 4–8 W | Overkill for client use |
+| **Raspberry Pi 3B/3B+** | Validated I2S HAT, manual onboard/USB | 2.5 W | 5 GHz WiFi + Ethernet; onboard/USB paths are not the recommended launch path |
+| **Raspberry Pi 4** (2 GB+) | Validated I2S HAT, HDMI, onboard, manual USB | 3–6 W | Required for client with cover art display (fb-display) |
+| **Raspberry Pi 5** | HDMI, manual USB | 4–8 W | Overkill for client use; launch validation is thinner than Pi 4 |
 | **Old Android phone** | Built-in speaker | Battery | Via [Snapcast Android app](https://github.com/badaix/snapdroid) |
 | **Any Linux PC** | Built-in audio | Varies | `apt install snapclient` |
 
@@ -113,22 +134,22 @@ Detail:
 - **Hardware guard for server / both** — at the start of `firstboot.sh`, `_validate_profile_hardware()` rejects `INSTALL_TYPE=server` and `INSTALL_TYPE=both` on Pi Zero 2 W. The first boot aborts with `log_error` and `exit 1`, surfacing the constraint immediately instead of failing later during `docker compose pull` with a cryptic OOM. Reflash the SD card with the Audio Player choice to recover
 - **Zram swap disabled** — `tune_pi_zero_2w_swap_safety()` in `scripts/common/system-tune.sh` masks `dev-zram0.swap` / `rpi-zram-writeback.service` and removes `/var/swap` at first boot. Without this fix, `rpi-zram-writeback` writes to the swap file living in the 256 MB overlay tmpfs upper layer and the kernel panics when the tmpfs fills (observed 2026-05-11)
 - **Single-client role, no multi-server failover** — the native snapclient uses libavahi-client autodiscovery directly. The multi-server failover state machine from `discover-server.sh` (TCP probing, anti-flapping, smart IPv4 selection) is not available on Pi Zero 2 W. Acceptable for typical single-room headless setups; if you need failover, use a Pi 3 B+ or Pi 4 client
-- **I2S HAT compatibility** — works with PCM5122-based HATs (HiFiBerry DAC+, InnoMaker Mini). The USB `otg_mode=1` setting from Imager conflicts with I2S — `prepare-sd.sh` and `setup.sh` fix this automatically
+- **I2S HAT compatibility** — launch validation covers PCM5122-based HiFiBerry/InnoMaker HATs. Other PCM5122 boards are expected to work but should be treated as unvalidated until tested. The USB `otg_mode=1` setting from Imager conflicts with I2S — `prepare-sd.sh` and `setup.sh` fix this automatically
 - **USB gadget mode** — for debugging without WiFi, connect the data USB port to your computer. Requires `dtoverlay=dwc2` under `[all]` in config.txt (not under `[cm5]`)
 
 ### Audio Output Quality
 
 | Output Method | Quality | Notes |
 |---------------|---------|-------|
-| **I2S DAC HAT** (HiFiBerry DAC+, DAC2 Pro) | Excellent | Best analog quality, RCA output, connects directly to Pi GPIO |
-| **I2S S/PDIF HAT** (HiFiBerry Digi+) | Excellent | Digital optical/coaxial out to AV receiver or external DAC; no analog conversion on the Pi |
-| **USB DAC** | Very good | Wide range of options; works with Pi Zero (no GPIO header needed) |
-| **HDMI** | Good | Use your TV/AV receiver as output device. ALSA card name varies by kernel: `vc4-hdmi-0` (Bookworm/Trixie KMS), `HDMI` (legacy). Resolved automatically at first boot via `aplay -L` |
-| **3.5mm jack** (Pi 3/4) | Adequate | Noticeable noise floor on some boards; fine for casual listening. **Pi 5 has no analog jack** — picking "jack" in the install menu auto-falls back to HDMI |
+| **I2S DAC HAT** (validated HiFiBerry DAC+ / InnoMaker PCM5122) | Excellent | Best analog quality, RCA output, connects directly to Pi GPIO |
+| **I2S S/PDIF HAT** (validated HiFiBerry Digi+) | Excellent | Digital optical/coaxial out to AV receiver or external DAC; no analog conversion on the Pi |
+| **USB DAC** | Very good when supported by Linux | Manual/experimental until a specific model is physically validated |
+| **HDMI** | Good | Validated on Pi 4 display/client path. ALSA card name varies by kernel: `vc4-hdmi-0` (Bookworm/Trixie KMS), `HDMI` (legacy). Resolved automatically at first boot via `aplay -L` |
+| **3.5mm jack** (Pi 3/4) | Adequate | Validated only as onboard fallback. Noticeable noise floor on some boards; fine for casual listening. **Pi 5 has no analog jack** — picking "jack" in the install menu auto-falls back to HDMI |
 
-> **Tip:** Use an I2S HAT for the best quality. [HiFiBerry DAC+ Zero](https://www.hifiberry.com/shop/boards/dacplus-zero/) for client nodes, [HiFiBerry DAC2 Pro](https://www.hifiberry.com/shop/boards/dac2-pro/) or [HiFiBerry Digi+](https://www.hifiberry.com/shop/boards/hifiberry-digi/) for nodes connected to AV receivers.
+> **Tip:** Use launch-validated I2S HATs for the first install: HiFiBerry DAC+ family or InnoMaker PCM5122 for analog output, HiFiBerry Digi+ family for S/PDIF.
 
-> **Manual override:** `prepare-sd.sh` offers an *Audio output* menu (auto-detect, pick a HAT from the list, or pick built-in HDMI/jack). Auto-detect is right for >90% of installs — use the manual paths only if auto-detect failed previously. See [INSTALL.md — Menu 2 — Audio output](INSTALL.md#menu-2--audio-output-audio-player-and-serverplayer-only).
+> **Manual override:** `prepare-sd.sh` offers an *Audio output* menu (auto-detect, pick a HAT from the list, or pick built-in HDMI/jack). Menu entries beyond the validated matrix are compatibility helpers, not a launch support promise. See [INSTALL.md — Menu 2 — Audio output](INSTALL.md#menu-2--audio-output-audio-player-and-serverplayer-only).
 
 ### Client Install Method
 
@@ -293,7 +314,7 @@ If a node connects to an AV receiver via optical cable, use HiFiBerry Digi+ inst
 
 ## Tested Combinations
 
-These hardware combinations have been verified end-to-end (firstboot → smoke test → audio playback) on the dates indicated. The 2026-04-27 batch was the v0.6.x release-gate validation: 6 devices reflashed from `main`, smoke test PASS on each, ALSA `hw_ptr` advancing during playback (audio actually reaching the DAC, not just the FIFO).
+These hardware combinations have been verified end-to-end (firstboot → smoke test → audio playback) on the dates indicated. Treat this table as the source of truth for launch-validated hardware. The 2026-04-27 batch was the v0.6.x release-gate validation: 6 devices reflashed from `main`, smoke test PASS on each, ALSA `hw_ptr` advancing during playback (audio actually reaching the DAC, not just the FIFO).
 
 | Hostname | Pi Model | Audio HAT | DAC chip | Mode | Display | Music Source | Validated | Status |
 |---|---|---|---|---|---|---|---|---|

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -27,14 +27,14 @@ Se un passaggio non è chiaro, continua con la procedura dettagliata qui sotto. 
 
 | Elemento | Note |
 |----------|------|
-| Raspberry Pi 4 o 5 (2 GB+ RAM) | Pi 5 completamente supportato; Pi 3B+ testato (profilo minimal) |
+| Raspberry Pi 4 (2 GB+ RAM) | Pi 4 è il target migliore per il lancio; Pi 5 e Pi 3B+ sono usabili ma hanno una matrice di validazione più sottile |
 | Scheda microSD (16 GB+) | Classe 10 / A1 o migliore. 32 GB consigliati |
 | Alimentatore | Ufficiale 15W USB-C per Pi 4 |
 | Un secondo computer | macOS, Linux o Windows — per preparare la scheda SD |
 | Connessione di rete | Ethernet (consigliato) o WiFi |
-| Uscita audio | DAC USB, HAT HiFiBerry o HDMI |
+| Uscita audio | HAT I2S HiFiBerry/InnoMaker validato, HiFiBerry Digi+, oppure fallback HDMI/onboard |
 
-Per un Pi speaker (modalità Audio Player): come sopra più un modo per collegare gli altoparlanti (HAT o dispositivo audio USB).
+Per un Pi speaker (modalità Audio Player): come sopra più un modo per collegare gli altoparlanti. Per la prima installazione, resta dentro la [matrice hardware validata](HARDWARE.it.md#policy-supporto-hardware).
 
 ---
 
@@ -246,9 +246,11 @@ Se il rilevamento automatico fallisce:
 
 | Opzione | Quando sceglierla |
 |---------|-------------------|
-| **1 — Auto-detect** | Scelta corretta per >90% delle installazioni. Il Pi sonda l'EEPROM del HAT al primo boot, scansiona il bus I2C per chip DAC noti, e ricade su USB DAC e poi audio integrato. Sceglila a meno che l'auto-detect non sia già fallito una volta |
-| **2 — Ho un HAT audio** | Salta l'auto-detect e scegli il profilo esatto da una lista di 15 HAT supportati (HiFiBerry, IQaudio, JustBoom, Allo, InnoMaker, Waveshare). Utile quando il tuo HAT non ha EEPROM o il chip è condiviso tra profili |
+| **1 — Auto-detect** | Scelta migliore se stai usando hardware HiFiBerry/InnoMaker validato per il lancio. Il Pi sonda l'EEPROM del HAT al primo boot, scansiona il bus I2C per chip DAC noti, e ricade su USB DAC e poi audio integrato |
+| **2 — Ho un HAT audio** | Salta l'auto-detect e scegli un profilo dalla lista di compatibilità. Utile quando il tuo HAT non ha EEPROM o il chip è condiviso tra profili. Le voci fuori dalla matrice validata sono sperimentali/manuali, non una promessa di supporto |
 | **3 — Senza HAT — audio integrato** | Audio integrato Pi 3/4/5. Poi scegli HDMI (TV/monitor) o jack 3.5mm. **Il Pi 5 non ha jack analogico** — scegli HDMI o lascia fare all'auto-detect |
+
+> Per stabilità al lancio, preferisci l'hardware indicato come **Validato** in [HARDWARE.it.md — Policy supporto hardware](HARDWARE.it.md#policy-supporto-hardware). DAC USB e molti profili HAT possono funzionare, ma non sono ancora tutti validati fisicamente dal progetto.
 
 Se scegli **3**, un sotto-menu ti chiede l'uscita:
 - **HDMI** — funziona su Pi 3, Pi 4, Pi 5. Il nome reale della card ALSA (`vc4-hdmi-0`, `HDMI`, dipende dal kernel) viene risolto al primo boot via `aplay -L`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,14 +27,14 @@ If any step is unclear, continue with the detailed walkthrough below. If first b
 
 | Item | Notes |
 |------|-------|
-| Raspberry Pi 4 or 5 (2 GB+ RAM) | Pi 5 fully supported; Pi 3B+ tested (minimal profile) |
+| Raspberry Pi 4 (2 GB+ RAM) | Pi 4 is the best launch target; Pi 5 and Pi 3B+ are usable but have a thinner validation matrix |
 | microSD card (16 GB+) | Class 10 / A1 or better. 32 GB recommended |
 | Power supply | Official 15W USB-C for Pi 4 |
 | A second computer | macOS, Linux, or Windows — to prepare the SD card |
 | Network connection | Ethernet (recommended) or WiFi |
-| Audio output | USB DAC, HiFiBerry HAT, or HDMI |
+| Audio output | Validated HiFiBerry/InnoMaker I2S HAT, HiFiBerry Digi+, or HDMI/onboard fallback |
 
-For a speaker Pi (Audio Player mode): same as above plus a way to connect speakers (HAT or USB audio device).
+For a speaker Pi (Audio Player mode): same as above plus a way to connect speakers. For first installs, stay inside the [validated hardware matrix](HARDWARE.md#hardware-support-policy).
 
 ---
 
@@ -244,9 +244,11 @@ If auto-detection fails:
 
 | Option | Use when |
 |--------|----------|
-| **1 — Auto-detect** | Right for >90% of installs. The Pi probes the HAT EEPROM at first boot, scans the I2C bus for known DAC chips, falls back to USB DAC, then to built-in audio. Choose this unless auto-detect failed on a previous attempt |
-| **2 — I have an audio HAT** | Skip auto-detect and pick the exact profile from a list of 15 supported HATs (HiFiBerry, IQaudio, JustBoom, Allo, InnoMaker, Waveshare). Useful when your HAT lacks an EEPROM or the chip is shared across profiles |
+| **1 — Auto-detect** | Best first choice when you are using launch-validated HiFiBerry/InnoMaker hardware. The Pi probes the HAT EEPROM at first boot, scans the I2C bus for known DAC chips, falls back to USB DAC, then to built-in audio |
+| **2 — I have an audio HAT** | Skip auto-detect and pick a profile from the compatibility list. Useful when your HAT lacks an EEPROM or the chip is shared across profiles. Entries outside the validated matrix are experimental/manual, not a support promise |
 | **3 — No HAT — built-in audio** | Pi 3/4/5 onboard audio. You then pick between HDMI (TV/monitor) or 3.5mm jack. **Pi 5 has no analog jack** — pick HDMI or let auto-detect handle it |
+
+> For launch stability, prefer the hardware listed as **Validated** in [HARDWARE.md — Hardware support policy](HARDWARE.md#hardware-support-policy). USB DACs and many HAT profiles may work, but they are not all physically validated by the project yet.
 
 If you pick **3**, a sub-menu asks for the output:
 - **HDMI** — works on Pi 3, Pi 4, Pi 5. The real ALSA card name (`vc4-hdmi-0`, `HDMI`, depending on kernel) is resolved at first boot via `aplay -L`


### PR DESCRIPTION
## Summary

Introduces an explicit three-tier hardware policy across the user-facing docs (README, HARDWARE, INSTALL) before the community launch, so a visitor with a random DAC knows up-front whether to expect zero-friction install or some ALSA troubleshooting.

| Tier | Meaning | Audience |
|---|---|---|
| **Validated** | Tested end-to-end by the project: first boot → read-only reboot → smoke / fleet smoke → real playback through the output | Recommended for first installs and reference builds |
| **Expected to work** | Same chipset or Linux audio path as a validated device, not physically tested by the project yet | Experienced users; results-please |
| **Experimental / manual** | Present in `prepare-sd.sh` audio menu or configurable via ALSA, but not launch-validated | No compatibility promise |

Today's launch-validated audio matrix:

- HiFiBerry DAC+ family / PCM5122 analog
- InnoMaker PCM5122 analog HATs (including Pi Zero 2 W headless)
- HiFiBerry Digi+ family / WM8804 S/PDIF
- Pi onboard / HDMI on Pi 4 client

Everything else (USB DACs, IQaudio, JustBoom, Allo, Waveshare, amplifier HATs) is now explicitly tagged as experimental / manual until physically validated.

## Files touched

| File | Change |
|---|---|
| `README.md` + `README.it.md` | Sound-output bullet list rewritten to validated HAT families + manual catch-all |
| `docs/HARDWARE.md` + `.it.md` | New `## Hardware support policy` section (+34 lines); quick-recommendations table now lists validated DACs; client device + audio output quality tables tagged with validation status |
| `docs/INSTALL.md` + `.it.md` | Pre-flight hardware item updated; audio menu options re-described with validation framing; cross-link added to the new HARDWARE policy section |

EN/IT mirrors synced 1:1 (per repo convention).

## Why now

Pre-launch reality check. The previous wording treated all DAC/HAT options as roughly equivalent. That over-promises against what we have actually tested — and a first-time visitor who buys a random USB DAC because the README seems to endorse it has a much worse experience than one who buys a HiFiBerry knowing it is the recommended path. Honesty up-front avoids reactive support tickets later.

## Validation

**Done locally:**
- Pre-push hook (shellcheck + hadolint + python tests) — passes (no code touched)
- Diff: 6 files, +100/-54 lines
- Italian diacritics verified (à è é ì ò ù)
- Cross-reference `INSTALL.md` → `HARDWARE.md#hardware-support-policy` anchor matches new section heading
- No anglicismi declinati in the IT mirrors

**Deferred to release-gate:** none — pure doc edit, no runtime behavior change.

## Coordination

Branches from current `main` (post-#445/#446/#447/#448 merge). Independent from the v0.7.7 release-gate smoke validation already in progress on snapvideo — that work can land before, during, or after this PR without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)