### PR TITLE
fix(install-tui): silence apt + update-initramfs output during client setup

### DIFF
--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -298,8 +298,10 @@ _ensure_hat_detect_tools() {
     if (( ${#_missing[@]} > 0 )); then
         if [[ "${AUDIO_HAT:-auto}" == "auto" ]]; then
             echo "Installing minimal HAT detection tools: ${_missing[*]}"
-            DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>&1 | tail -3 || true
-            if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${_missing[@]}"; then
+            # Redirect apt output to the install log so it cannot stomp the
+            # TUI on /dev/tty3 (kernel console = active VT during install).
+            DEBIAN_FRONTEND=noninteractive apt-get update -qq >> "${UNIFIED_LOG:-/dev/null}" 2>&1 || true
+            if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${_missing[@]}" >> "${UNIFIED_LOG:-/dev/null}" 2>&1; then
                 echo "FATAL: AUDIO_HAT=auto requested but cannot install detection tools (${_missing[*]})" >&2
                 echo "FATAL: Set AUDIO_HAT explicitly in install.conf to skip auto-detection." >&2
                 exit 1
@@ -548,7 +550,9 @@ elif declare -F install_dependencies &>/dev/null; then
     INSTALL_ROLE=client SKIP_UPGRADE=true install_dependencies
 else
     log_progress "WARNING: install-deps.sh not found, installing base packages inline"
-    apt-get update && apt-get install -y ca-certificates curl alsa-utils avahi-daemon avahi-utils
+    # apt output to log only — keeps the install TUI on /dev/tty3 unstomped
+    DEBIAN_FRONTEND=noninteractive apt-get update -qq >> "${UNIFIED_LOG:-/dev/null}" 2>&1 \
+        && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates curl alsa-utils avahi-daemon avahi-utils >> "${UNIFIED_LOG:-/dev/null}" 2>&1
 fi
 
 progress 2 "Installing Docker CE..."
@@ -1476,7 +1480,8 @@ if [[ "${ENABLE_READONLY:-false}" == "true" ]]; then
 
     # Install fuse-overlayfs package (needed after reboot when overlayroot is active)
     log_progress "Installing fuse-overlayfs..."
-    if ! apt-get install -y fuse-overlayfs; then
+    # apt output → install log, not the install TUI on /dev/tty3
+    if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq fuse-overlayfs >> "${UNIFIED_LOG:-/dev/null}" 2>&1; then
         log_progress "ERROR: fuse-overlayfs not available — read-only mode will be skipped"
         ENABLE_READONLY=false
         return 0
@@ -1564,9 +1569,14 @@ DefaultEnvironment="LIBMOUNT_FORCE_MOUNT2=always"
 SYSDEOF
     log_progress "systemd overlayfs workaround installed (trixie remount fix)"
 
-    # Enable overlayfs (takes effect after reboot)
-    log_progress "Enabling overlayfs..."
-    if ! raspi-config nonint do_overlayfs 0; then
+    # Enable overlayfs (takes effect after reboot). raspi-config internally
+    # apt-installs overlayroot/cryptsetup which triggers update-initramfs
+    # to rebuild BOTH kernels (rpi-v8 + rpi-2712) — ~20s of progress output
+    # that previously stomped the install TUI on /dev/tty3 visually
+    # (functional install was fine, but the HDMI display went messy until
+    # the next progress.sh redraw tick). Redirecting to the install log
+    # keeps the TUI clean.
+    if ! raspi-config nonint do_overlayfs 0 >> "${UNIFIED_LOG:-/dev/null}" 2>&1; then
         log_progress "WARNING: raspi-config failed to enable overlayfs"
         log_progress "         Reverting systemd workaround"
         rm -f /etc/systemd/system.conf.d/overlayfs-workaround.conf


### PR DESCRIPTION
## Summary

Stops the install TUI on `/dev/tty3` from being visually overdrawn during the overlayroot install phase on a fresh reflash. UX-visible regression observed on snapvideo v0.7.7 reflash 2026-05-21: HDMI display went messy for ~22s while `raspi-config` triggered `update-initramfs` rebuilds, then recovered when the next progress.sh redraw tick won back the screen.

**Functional install was always fine** — this PR only fixes the visual quality during install.

## Root cause

`scripts/firstboot.sh` does `chvt 3` so the install TUI on `/dev/tty3` is visible on HDMI. That makes `/dev/tty3` the active VT, so `/dev/console` resolves there. Anything that writes directly to `console` — kernel printk, dpkg progress (carriage-return lines), `update-initramfs` output — lands on the same physical screen as the TUI box and overdraws it until the next TUI tick repaints.

**Worst offender:** `raspi-config nonint do_overlayfs 0` (setup.sh:1569) internally `apt-install`s `overlayroot + cryptsetup`, which triggers `initramfs-tools` postinst → `update-initramfs` regenerating both kernel images (rpi-v8 + rpi-2712), ~22 s of output to console.

Three other apt invocations had the same shape (302, 551, 1479) but shorter durations.

## Fix

Redirect each `apt-get install / apt-get update / raspi-config` invocation's stdout+stderr to `${UNIFIED_LOG:-/dev/null}` (the existing install log destination), mirroring the pattern already used at `scripts/common/setup-docker.sh:102`. Also added `-qq` to the two bare `apt-get install` lines for defense in depth.

| Line | Before | After |
|---|---|---|
| 302 | `… apt-get install -y -qq "${_missing[@]}"` (and `update … \| tail -3`) | both redirected to `UNIFIED_LOG` |
| 551 | `apt-get update && apt-get install -y ca-certificates curl alsa-utils …` | `-qq` added + redirected |
| 1479 | `apt-get install -y fuse-overlayfs` | `-qq` added + redirected |
| 1569 | `raspi-config nonint do_overlayfs 0` | redirected |

## Diff stat

```
client/common/scripts/setup.sh | 24 +++++++++++++++++-------
1 file changed, 17 insertions(+), 7 deletions(-)
```

No code logic change — error propagation via `if !` preserved.

## Validation

**Done locally:**
- `shellcheck -S warning client/common/scripts/setup.sh` → clean
- All 4 sites grep-confirmed using the same `>> "${UNIFIED_LOG:-/dev/null}" 2>&1` pattern as the existing healthy site (`setup-docker.sh:102`)
- No test fixture asserts the exact pre-fix command string on these lines (verified with grep across `tests/`)

**Verifiable next reflash:**
- `/var/log/snapmulti-install.log` retains the same content (apt output, dpkg progress, update-initramfs lines) — just routed through the file instead of bouncing to the console
- HDMI TUI box stays intact through Step 9/10 (read-only filesystem)

## Why now

snapvideo was just reflashed to v0.7.7 for the release-gate smoke validation (per ADR-005). Observed live: `[00:17:32-00:17:54]` window where `apt install overlayroot` + `update-initramfs` x2 stomped the TUI, recovered after the call returned. Fixing pre-Reddit launch removes one paper-cut from the install-day visual experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)