### PR TITLE
fix(#447 review): meta.txt double-prefix + persist_env_kv sed metachar safety

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -785,13 +785,7 @@ EOF
     local _coherent_tag
     _coherent_tag=$(derive_image_tag "${IMAGE_TAG:-}" "$_image_set")
 
-    # awk-based replacement avoids sed metacharacter issues with values
-    # containing `|`, `\`, or `&` (latent bug pre-fix in claude-review
-    # LOW finding on PR #447). awk treats k and v as plain strings; the
-    # temp-file + mv is also atomic, so a kernel panic mid-write cannot
-    # leave a truncated .env. In production these values are version
-    # strings (`v0.7.7`, `dev`, `0.7.7`) — the fix is preventive, not
-    # responding to a live incident.
+    # awk -v avoids sed metacharacter corruption; temp-file mv is atomic
     persist_env_kv() {
         local key="$1" value="$2"
         if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -785,10 +785,22 @@ EOF
     local _coherent_tag
     _coherent_tag=$(derive_image_tag "${IMAGE_TAG:-}" "$_image_set")
 
+    # awk-based replacement avoids sed metacharacter issues with values
+    # containing `|`, `\`, or `&` (latent bug pre-fix in claude-review
+    # LOW finding on PR #447). awk treats k and v as plain strings; the
+    # temp-file + mv is also atomic, so a kernel panic mid-write cannot
+    # leave a truncated .env. In production these values are version
+    # strings (`v0.7.7`, `dev`, `0.7.7`) — the fix is preventive, not
+    # responding to a live incident.
     persist_env_kv() {
         local key="$1" value="$2"
         if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
-            sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+            awk -v k="$key" -v v="$value" '
+                BEGIN { pat = "^" k "=" }
+                $0 ~ pat { print k "=" v; next }
+                { print }
+            ' "$ENV_FILE" > "${ENV_FILE}.tmp" \
+                && mv -- "${ENV_FILE}.tmp" "$ENV_FILE"
         else
             printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
         fi

--- a/scripts/diagnostic.sh
+++ b/scripts/diagnostic.sh
@@ -178,12 +178,19 @@ log "Collecting snapMULTI diagnostics (reason=$REASON, out=$BUNDLE_PATH)"
     # falls through to the manifest at the boot-partition staging
     # path; finally "unknown" so the diagnostic bundle has consistent
     # shape across all installs (legacy + new).
-    echo "snapmulti_release=$(grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapmulti/.env 2>/dev/null \
-                              || grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapclient/.env 2>/dev/null \
-                              || echo unknown)"
-    echo "snapmulti_image_set=$(grep -m1 '^SNAPMULTI_IMAGE_SET=' /opt/snapmulti/.env 2>/dev/null \
-                                 || grep -m1 '^SNAPMULTI_IMAGE_SET=' /opt/snapclient/.env 2>/dev/null \
-                                 || echo unknown)"
+    # `cut -d= -f2-` strips the `KEY=` prefix so meta.txt emits
+    # `snapmulti_release=v0.7.7` (not the double-prefixed
+    # `snapmulti_release=SNAPMULTI_RELEASE=v0.7.7` form). Mirrors the
+    # pattern already used by scripts/smoke/check_system.sh for the
+    # same .env keys. Fixes claude-review MEDIUM finding on PR #447.
+    echo "snapmulti_release=$( \
+        (grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapmulti/.env  2>/dev/null | cut -d= -f2-) \
+        || (grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapclient/.env 2>/dev/null | cut -d= -f2-) \
+        || echo unknown)"
+    echo "snapmulti_image_set=$( \
+        (grep -m1 '^SNAPMULTI_IMAGE_SET=' /opt/snapmulti/.env  2>/dev/null | cut -d= -f2-) \
+        || (grep -m1 '^SNAPMULTI_IMAGE_SET=' /opt/snapclient/.env 2>/dev/null | cut -d= -f2-) \
+        || echo unknown)"
 } > "$STAGE_DIR/meta.txt"
 
 # release-manifest.json from the boot partition (no secrets, no

--- a/scripts/diagnostic.sh
+++ b/scripts/diagnostic.sh
@@ -178,11 +178,7 @@ log "Collecting snapMULTI diagnostics (reason=$REASON, out=$BUNDLE_PATH)"
     # falls through to the manifest at the boot-partition staging
     # path; finally "unknown" so the diagnostic bundle has consistent
     # shape across all installs (legacy + new).
-    # `cut -d= -f2-` strips the `KEY=` prefix so meta.txt emits
-    # `snapmulti_release=v0.7.7` (not the double-prefixed
-    # `snapmulti_release=SNAPMULTI_RELEASE=v0.7.7` form). Mirrors the
-    # pattern already used by scripts/smoke/check_system.sh for the
-    # same .env keys. Fixes claude-review MEDIUM finding on PR #447.
+    # cut -d= -f2- strips the KEY= prefix that grep -m1 includes
     echo "snapmulti_release=$( \
         (grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapmulti/.env  2>/dev/null | cut -d= -f2-) \
         || (grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapclient/.env 2>/dev/null | cut -d= -f2-) \


### PR DESCRIPTION
## Summary

Post-merge fix for the two findings raised by claude-review on PR #447 (release-manifest decoupling, #433). The PR was merged before the review feedback was addressed — this PR closes the loop.

| Severity | File | Issue |
|---|---|---|
| **MEDIUM** | `scripts/diagnostic.sh:181–186` | `meta.txt` double-prefixes release identity: `snapmulti_release=SNAPMULTI_RELEASE=v0.7.7` |
| **LOW** | `scripts/deploy.sh:791` | `persist_env_kv` uses unescaped `${value}` in `sed` — latent corruption risk if value ever contains `|`, `\`, or `&` |

## MEDIUM — diagnostic.sh meta.txt double-prefix

`grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapmulti/.env` returns the full line `SNAPMULTI_RELEASE=v0.7.7`. Wrapping it in `echo \"snapmulti_release=$(...)\"` produced:

```
snapmulti_release=SNAPMULTI_RELEASE=v0.7.7
snapmulti_image_set=SNAPMULTI_IMAGE_SET=0.7.7
```

Tooling that parses `meta.txt` as key=value sees doubled prefixes. Fix mirrors the pattern already used in `scripts/smoke/check_system.sh` for the same `.env` keys: pipe through `| cut -d= -f2-` to strip the leading `KEY=`.

## LOW — deploy.sh persist_env_kv sed metacharacter safety

```bash
# Before:
sed -i \"s|^${key}=.*|${key}=${value}|\" \"\$ENV_FILE\"
```

In production these values are version strings (`v0.7.7`, `dev`, `0.7.7`) so the bug never triggers — but it's latent. A value containing `|`, `\`, or `&` would silently corrupt the `.env` line.

Replaced the in-place `sed` with an `awk` rewrite + temp-file `mv` for atomicity:

```bash
# After:
awk -v k=\"\$key\" -v v=\"\$value\" '
    BEGIN { pat = \"^\" k \"=\" }
    \$0 ~ pat { print k \"=\" v; next }
    { print }
' \"\$ENV_FILE\" > \"\${ENV_FILE}.tmp\" && mv -- \"\${ENV_FILE}.tmp\" \"\$ENV_FILE\"
```

Two improvements:

1. **No sed metacharacter dance.** `awk -v k=… -v v=…` treats both as plain strings.
2. **Atomic via mv.** A kernel panic mid-write can no longer leave a truncated `.env`.

Verified locally with adversarial values:

```
SNAPMULTI_RELEASE=v0.7.7
IMAGE_TAG=dev
WEIRD=still|safe&
```

Idempotent update + metacharacter values both clean.

## Diff stat

```
scripts/deploy.sh     | 14 +++++++++++++-
scripts/diagnostic.sh | 19 +++++++++++++------
2 files changed, 26 insertions(+), 7 deletions(-)
```

## Validation

**Done locally:**
- `shellcheck -S warning scripts/diagnostic.sh scripts/deploy.sh` → clean
- `persist_env_kv` smoke-tested in isolation with `WEIRD=has|pipe&amp\back` style values — output matches expected
- No test fixture asserts the exact pre-fix command string on either site

**Deferred to release-gate:** none — both fixes are surgical, no behaviour change for the happy path (version-string values), no public API touched.

## Coordination

Independent branch off `main` (post-#447 merge). No conflict with the other open PRs:

| PR | Touches | Conflict with this? |
|---|---|---|
| #449 (`docs/hardware-validation-tier`) | README, HARDWARE, INSTALL | No (different files) |
| #450 (`fix/install-tui-silence-apt-output`) | `client/common/scripts/setup.sh` | No (different file) |

## Audit context

Triggered by `/fix-review 447 --all`. The full audit also scanned the last 25 merged non-Dependabot PRs (since 2026-05-10) for unaddressed MEDIUM findings — only #447 was actually merged with skipped feedback. PR #418 had a MEDIUM that *was* addressed within the same PR before merge (false positive in the grep). So the unfinished-review-debt is one PR only, and this closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)