### PR TITLE
chore(release): roll [Unreleased] into v0.7.8 (script-only release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8] — 2026-05-21
+
+> First release exercising the manifest gate end-to-end as a **script-only release**: `image_set` stays at `0.7.7`, `requires_image_rebuild=false`. The `build-push.yml` gate verifies the 5 production images already exist on Docker Hub at `:0.7.7` and skips the rebuild matrix (~30 s CI vs 10+ min on a normal tag).
+
 ### Fixed
 - **`scripts/diagnostic.sh` meta.txt no longer double-prefixes release-identity keys (#451)** — `grep -m1 '^SNAPMULTI_RELEASE=' /opt/snapmulti/.env` returns the full line (`SNAPMULTI_RELEASE=v0.7.7`), and the original wrapper produced `snapmulti_release=SNAPMULTI_RELEASE=v0.7.7` in the diagnostic bundle. Tooling that parses meta.txt as key=value saw doubled prefixes. Added `| cut -d= -f2-` to strip the leading `KEY=`, mirroring the pattern already used by `scripts/smoke/check_system.sh`. Addresses the MEDIUM finding raised by claude-review on PR #447 (release-manifest decoupling) that was not addressed before merge.
 - **`scripts/deploy.sh::persist_env_kv` is sed-metacharacter safe and atomic (#451)** — the previous in-place `sed -i "s|^${key}=.*|${key}=${value}|"` would silently corrupt the `.env` line if `${value}` contained `|`, `\`, or `&`. In production these values are version strings (`v0.7.7`, `dev`) so the bug never triggered, but it was latent. Replaced with an awk rewrite that treats `k` and `v` as plain strings (no metacharacter dance) and uses temp-file + `mv` for atomicity (a kernel panic mid-write can no longer leave a truncated `.env`). Addresses the LOW finding from claude-review on PR #447.

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.7",
+  "snapmulti_release": "v0.7.8",
   "image_set": "0.7.7",
-  "requires_image_rebuild": true
+  "requires_image_rebuild": false
 }


### PR DESCRIPTION
## Summary — first script-only release exercising the manifest gate

**Two-line diff that does a lot of work behind the scenes.**

| File | Change |
|---|---|
| `release-manifest.json` | `snapmulti_release: v0.7.7→v0.7.8`, `image_set: 0.7.7→0.7.7` (kept), `requires_image_rebuild: true→false` |
| `CHANGELOG.md` | `[Unreleased]` → `[0.7.8] — 2026-05-21` header, all 8 entries preserved |

## What this tag will do at build-push.yml time

When `git push v0.7.8` triggers the workflow:

1. The `gate` job (added in #447) reads `release-manifest.json`
2. Sees `requires_image_rebuild=false`
3. Runs `docker manifest inspect lollonet/snapmulti-{server,airplay,mpd,metadata,tidal}:0.7.7` against all 5 — already present (built when v0.7.7 was tagged)
4. **Skips the rebuild matrix entirely**
5. Total CI time: **~30 seconds** instead of the usual ~10 min

This is the **first end-to-end exercise of the decoupling system** designed in #433. Validates the architecture in production.

## What's in v0.7.8 (vs v0.7.7)

All host-side improvements, zero container changes:

| PR | Category | What |
|---|---|---|
| #447 (#433) | Added | Release-manifest decoupling — `SNAPMULTI_RELEASE` vs `SNAPMULTI_IMAGE_SET` + CI gate |
| #454 | Added | Acoustic smoke result cues — `device-smoke.sh --tone` |
| #450 | Fixed | Install TUI on `/dev/tty3` no longer stomped by `apt` / `update-initramfs` output |
| #451 | Fixed | `diagnostic.sh` meta.txt double-prefix |
| #451 | Fixed | `deploy.sh::persist_env_kv` sed metacharacter safety + atomicity |
| #453 | Fixed | `NetworkManager-wait-online.service` masked via kernel cmdline (75 s boot stall fix) |
| #448 | Docs | Audience clarification + non-goals + source-support tiers + governance |
| #449 | Docs | Hardware support policy (Validated / Expected / Experimental) |

## What users on existing v0.7.7 installs see

**Nothing.** `docker compose pull` finds the same `:0.7.7` images. The v0.7.8 value is in the SD-host scripts:
- Cleaner first-boot UX (no TUI stomp, no `degraded` status from NM-wait-online)
- Audible smoke result via `device-smoke.sh --tone`
- Better diagnostic bundles (correct meta.txt prefixes)
- Documented governance + audience expectations for Reddit launch

To get the v0.7.8 improvements, users reflash a fresh SD prepared from v0.7.8 source.

## Validation

**Done locally:**
- `jq . release-manifest.json` → valid, all 3 keys present
- `parse_release_manifest` returns `release=v0.7.8 / image_set=0.7.7 / rebuild=false`
- `tests/test_release_manifest_canonical.sh` → **10/10 PASS** (canonical-format invariant intact)
- Diff: 2 files, +6/-2 lines
- Pre-push hook (shellcheck + hadolint + python tests) → clean

**Post-merge sequence (the release-gate validation):**
1. Tag `v0.7.8` on the merge commit, push tag
2. Watch `build-push.yml` → expect ~30 s gate run, no Docker rebuild
3. Reflash `snapvideo` with v0.7.8 source (via `prepare-sd.sh` on this branch's content)
4. After firstboot reboot completes: run `sudo bash /opt/snapmulti/scripts/device-smoke.sh --both --tone` → expect PASS + ascending major triad through the DAC
5. Verify on snapvideo: `systemctl is-system-running` returns `running` (mask catches NM-wait-online), `/proc/cmdline` has `systemd.mask=NetworkManager-wait-online.service`
6. Verify `Release v0.7.8 (images 0.7.7)` displays in smoke `System` section
7. If all green → `gh release create v0.7.8` from CHANGELOG `[0.7.8]`
8. Reddit r/raspberry_pi launch

## Risk assessment

| Risk | Mitigation |
|---|---|
| Gate misjudges and rebuilds anyway | Acceptable degradation — wastes ~10 min CI, no correctness impact |
| Gate skips but Docker Hub `:0.7.7` images missing | Gate explicitly verifies with `docker manifest inspect` and fails with actionable error pointing at `workflow_dispatch.force_rebuild=true` |
| Cmdline mask doesn't survive overlayroot | Validated live on snapvideo: cmdline.txt is on FAT32 /boot/firmware, NOT covered by overlayroot. Verified network-online reaches active in 13.4 s post-reboot |
| Audio tones don't play through HiFiBerry DAC | Helper falls through silently if aplay missing; user manually verifies during reflash smoke step |

🤖 Generated with [Claude Code](https://claude.com/claude-code)