### PR TITLE
fix(ci): gate build-client too (was missed in #447 refactor)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -284,6 +284,8 @@ jobs:
 
   # Client images — ARM only (built on Mac runner)
   build-client:
+    needs: gate
+    if: needs.gate.outputs.should_rebuild == 'true'
     runs-on: [self-hosted, macOS, ARM64]
     permissions:
       contents: read
@@ -305,17 +307,27 @@ jobs:
         id: version
         env:
           USE_SANTCASP: ${{ inputs.use_santcasp }}
+          # Image tag for tagged releases comes from the gate's manifest
+          # read — NOT github.ref_name — so a script-only release tagged
+          # vX.Y.Z+1 with image_set=X.Y.Z keeps publishing X.Y.Z client
+          # images (parity with the server build job).
+          GATE_IMAGE_SET: ${{ needs.gate.outputs.image_set }}
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-            echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "label=latest" >> "$GITHUB_OUTPUT"
+            {
+              echo "tag=$GATE_IMAGE_SET"
+              echo "label=latest"
+            } >> "$GITHUB_OUTPUT"
           elif [[ "$USE_SANTCASP" == "true" ]]; then
-            echo "tag=" >> "$GITHUB_OUTPUT"
-            echo "label=dev" >> "$GITHUB_OUTPUT"
+            {
+              echo "tag="
+              echo "label=dev"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "tag=" >> "$GITHUB_OUTPUT"
-            echo "label=manual" >> "$GITHUB_OUTPUT"
+            {
+              echo "tag="
+              echo "label=manual"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Determine snapcast source

--- a/tests/test_build_push_manifest_gate.sh
+++ b/tests/test_build_push_manifest_gate.sh
@@ -106,6 +106,21 @@ assert "grep -qE 'GATE_IMAGE_SET.*needs.gate.outputs.image_set' '$WF'" \
 assert "grep -qE 'tag=\\\$GATE_IMAGE_SET' '$WF'" \
     "tagged-release branch uses GATE_IMAGE_SET for the published tag"
 
+# build-client also wired to gate (was missed in the original #447 refactor;
+# fixed in the follow-up — script-only releases must also skip the client
+# image rebuild, not just the server matrix). Scope to the build-client
+# section by line range (build-client at line ~286, next job 'manifest'
+# at line ~388 — see grep '^  [a-z].*:' in build-push.yml).
+client_section=$(awk '/^  build-client:/{found=1} found{print} /^  manifest:/{if (found) {found=0}}' "$WF")
+assert "printf '%s' \"\$client_section\" | grep -qE '^    needs: gate'" \
+    "build-client job has needs: gate"
+
+assert "printf '%s' \"\$client_section\" | grep -qE \"needs.gate.outputs.should_rebuild == 'true'\"" \
+    "build-client job conditioned on gate.outputs.should_rebuild=='true'"
+
+assert "printf '%s' \"\$client_section\" | grep -q 'GATE_IMAGE_SET'" \
+    "build-client derives image tag from gate.outputs.image_set (parity with server build)"
+
 echo
 echo "## Summary"
 echo "  Passed: $pass"


### PR DESCRIPTION
## Summary

Closes the gap surfaced by the v0.7.8 release attempt: the manifest gate from #447 (#433) correctly skipped the server `build` matrix on the script-only v0.7.8 tag, but `build-client` was never refactored to respect the gate and fired unconditionally → hit Docker Desktop down on the Mac runner → failed.

## Observed live on v0.7.8 (2026-05-21, tag now deleted for re-tag)

| Job | Result | What we wanted |
|---|---|---|
| `gate` | ✅ SUCCESS in 9 s | ✓ |
| `build` (server matrix) | ✅ skipped (`if: needs.gate.outputs.should_rebuild == 'true'`) | ✓ |
| `build-client` (Mac runner) | ❌ FAILED — not gated, tried to build, Docker Desktop down | should have been skipped same as `build` |

Functional outcome was actually correct (all `lollonet/snapclient-pi:0.7.7` images already on Hub from the v0.7.7 build), but the workflow showed red.

## Fix

`.github/workflows/build-push.yml::build-client`:

```yaml
  build-client:
+   needs: gate
+   if: needs.gate.outputs.should_rebuild == 'true'
    runs-on: [self-hosted, macOS, ARM64]
    ...
    steps:
      ...
      - name: Determine image label
        env:
          USE_SANTCASP: ${{ inputs.use_santcasp }}
+         GATE_IMAGE_SET: ${{ needs.gate.outputs.image_set }}
        run: |
          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-           VERSION="${GITHUB_REF#refs/tags/v}"
-           echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+           {
+             echo "tag=$GATE_IMAGE_SET"
+             echo "label=latest"
+           } >> "$GITHUB_OUTPUT"
            ...
```

Two changes:

1. **Gate predicate** — `needs: gate` + `if:` clause matches the existing `build` job pattern from #447
2. **Tag derivation** — uses `GATE_IMAGE_SET` not `GITHUB_REF`, same fix #447 applied to the server build. Without this, a `force_rebuild` of a script-only release would publish `snapclient-pi:vX.Y.Z+1` when the manifest says `image_set=X.Y.Z`

## Validation

- `tests/test_build_push_manifest_gate.sh` extended with 3 new assertions covering build-client gate wiring + GATE_IMAGE_SET usage → **24/24 PASS**
- `actionlint` clean on the new directives (pre-existing SC2129 + `format()` warnings on unchanged lines remain — not introduced here)

## Post-merge sequence (closing the v0.7.8 loop)

1. Merge this PR → main has the gated build-client
2. Re-tag `v0.7.8` on the new main HEAD (original tag was deleted for this purpose, zero external consumption had happened — no Release published, no Hub `:0.7.8` images, ~5 min of tag existence)
3. Push tag → workflow runs:
   - `gate` → reads manifest, decides skip
   - `build` → skipped
   - `build-client` → **now skipped too** (this PR's fix)
   - `manifest` → skipped (depends on build)
4. Total CI: ~30 s, all green
5. `gh release create v0.7.8` from CHANGELOG `[0.7.8]`
6. Reflash snapvideo from v0.7.8 source, smoke `--both --tone`, hear the ascending major triad through the DAC
7. Reddit launch

## Why this wasn't caught in #447

The #447 design + tests focused on the 5 server images via `docker manifest inspect lollonet/snapmulti-{server,airplay,mpd,metadata,tidal}`. The 3 client images (`snapclient-pi*`) live in a different namespace and historically built on a different runner. The build-client job was correctly preserved by the #447 refactor (no breakage) but not modernized to share the gate. v0.7.8's first script-only release surfaced the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)