### PR TITLE
feat(audio): auto-boot-smoke service + #458/#459/#461 cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **4K @ 60Hz HDMI on Pi 4 client displays (#461/#463)** — `docs/ADVANCED.md` (+ IT mirror) documents `hdmi_enable_4kp60=1` in `/boot/firmware/config.txt`, with live-validated procedure (no `ro-mode disable` dance — `/boot/firmware` is FAT32 outside overlayroot). Validated on snapdigi (Pi 4 2GB + LG 50" 4K TV).
 - **`docs/INSTALL.md` + `.it.md` — audible-feedback contract for first-time users (#462)** — adds `## Before you start: turn the speakers on` callout before Step 1, `### What you'll hear` (440 Hz post-HAT tone) and `### Health-check tones (manual, optional)` (the four `device-smoke.sh --tone` cues) inside Step 5. IT mirror uses glossary terms (`test di salute`, `casse`, DO–MI–SOL).
 
-### Docs
-- **`docs/INSTALL.md` + `.it.md` — audible-feedback contract for first-time users (#462)** — adds `## Before you start: turn the speakers on` callout before Step 1, `### What you'll hear` (440 Hz post-HAT tone) and `### Health-check tones (manual, optional)` (the four `device-smoke.sh --tone` cues) inside Step 5. IT mirror uses glossary terms (`test di salute`, `casse`, DO–MI–SOL).
-
 ## [0.7.8] — 2026-05-21
 
 > First release exercising the manifest gate end-to-end as a **script-only release**: `image_set` stays at `0.7.7`, `requires_image_rebuild=false`. The `build-push.yml` gate verifies the 5 production images already exist on Docker Hub at `:0.7.7` and skips the rebuild matrix (~30 s CI vs 10+ min on a normal tag).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`snapmulti-auto-boot-smoke.service` — Pi speaks its post-boot health audibly (#463)** — new systemd oneshot fires `device-smoke.sh --tone` after every boot once Docker + Snapcast are healthy. INSTALL_TYPE dispatch (`--server` / `--client` / `--both`). `device-smoke.sh` + `smoke/` checks now staged on client paths too so pizero + snapdigi participate. Closes the v0.7.8 "manual `--tone` only" foundation gap — completes the acoustic-feedback contract introduced in #454.
+
 ### Fixed
 - **`device-smoke.sh --tone` was silent on both-mode hosts (#462)** — smoke WAVs regenerated at 44100 Hz mono (PCM5122 native rate). No rate conversion required, so the spectrum-analyzer `multi_out` default chain plays them even when `libasound2-plugins` is absent on the host.
+- **`50-usb-no-autosuspend.rules` udev failures every boot on Pi 4 (#458/#463)** — rule scoped via `TEST=="power/autosuspend"`, so hub interfaces that don't expose the attribute no longer emit "Failed to write … No such file" warnings. Functional behaviour unchanged (host-wide `usbcore.autosuspend=-1` was already set in boot-tune).
+- **`snapmulti-status.service` ignored `RuntimeMaxSec` warning (#459/#463)** — `RuntimeMaxSec` has no effect on `Type=oneshot` and was logged as ignored at every boot. Dropped — `TimeoutStartSec=120` (already present) provides the same runaway-kill semantics.
+
+### Docs
+- **4K @ 60Hz HDMI on Pi 4 client displays (#461/#463)** — `docs/ADVANCED.md` (+ IT mirror) documents `hdmi_enable_4kp60=1` in `/boot/firmware/config.txt`, with live-validated procedure (no `ro-mode disable` dance — `/boot/firmware` is FAT32 outside overlayroot). Validated on snapdigi (Pi 4 2GB + LG 50" 4K TV).
+- **`docs/INSTALL.md` + `.it.md` — audible-feedback contract for first-time users (#462)** — adds `## Before you start: turn the speakers on` callout before Step 1, `### What you'll hear` (440 Hz post-HAT tone) and `### Health-check tones (manual, optional)` (the four `device-smoke.sh --tone` cues) inside Step 5. IT mirror uses glossary terms (`test di salute`, `casse`, DO–MI–SOL).
 
 ### Docs
 - **`docs/INSTALL.md` + `.it.md` — audible-feedback contract for first-time users (#462)** — adds `## Before you start: turn the speakers on` callout before Step 1, `### What you'll hear` (440 Hz post-HAT tone) and `### Health-check tones (manual, optional)` (the four `device-smoke.sh --tone` cues) inside Step 5. IT mirror uses glossary terms (`test di salute`, `casse`, DO–MI–SOL).

--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -353,3 +353,31 @@ tc qdisc add dev eth0 root cake bandwidth 100mbit
 ```
 
 Si può disabilitare o modulare via `.env` (`QOS_ENABLE=false`). Su una LAN domestica tranquilla l'effetto non si nota; sotto trasferimenti paralleli pesanti è la differenza fra audio senza glitch e dropout.
+
+## 4K @ 60Hz HDMI su display client Pi 4
+
+Pi 4 ha di default un clock GPU conservativo che si ferma a 4K @ 30Hz. Quando il Pi client pilota una TV/monitor 4K, il kernel logga:
+
+```
+vc4-drm gpu: [drm] The core clock cannot reach frequencies high enough to support 4k @ 60Hz.
+vc4-drm gpu: [drm] Please change your config.txt file to add hdmi_enable_4kp60.
+```
+
+Il container `fb-display` di snapMULTI funziona a qualsiasi modalità HDMI — il frame rate non influisce sul contenuto renderizzato. Ma la TV 4K mostra un segnale degradato 1080p @ 60Hz o 4K @ 30Hz finché non abiliti il boost del clock GPU.
+
+### Fix (niente dance overlayroot — `/boot/firmware` è FAT32, fuori da overlayroot)
+
+```bash
+ssh <client-host>
+sudo mount -o remount,rw /boot/firmware
+sudo sh -c 'echo "hdmi_enable_4kp60=1" >> /boot/firmware/config.txt'
+sudo mount -o remount,ro /boot/firmware
+sudo reboot
+```
+
+Dopo il reboot:
+- Warning `vc4-drm` spariti da `journalctl -p warning`
+- Framebuffer riporta `3840x2160`
+- Temperatura SoC sale di ~1-2 °C a regime (dentro la finestra termica del Pi 4)
+
+Validato su snapdigi (Pi 4 2GB + TV LG 50" 4K) il 2026-05-21.

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -352,4 +352,32 @@ For congested networks or installs where the same Pi sees bulk file transfers, `
 tc qdisc add dev eth0 root cake bandwidth 100mbit
 ```
 
+## 4K @ 60Hz HDMI on Pi 4 client displays
+
+Pi 4 ships with a conservative GPU clock that maxes out at 4K @ 30Hz. When the client Pi drives a 4K-capable TV/monitor, the kernel logs:
+
+```
+vc4-drm gpu: [drm] The core clock cannot reach frequencies high enough to support 4k @ 60Hz.
+vc4-drm gpu: [drm] Please change your config.txt file to add hdmi_enable_4kp60.
+```
+
+snapMULTI's `fb-display` container works at any HDMI mode — frame rate doesn't affect rendered content. But the 4K TV will show a degraded 1080p @ 60Hz or 4K @ 30Hz signal until the GPU clock boost is enabled.
+
+### Fix (no overlayroot dance — `/boot/firmware` is FAT32, outside overlayroot)
+
+```bash
+ssh <client-host>
+sudo mount -o remount,rw /boot/firmware
+sudo sh -c 'echo "hdmi_enable_4kp60=1" >> /boot/firmware/config.txt'
+sudo mount -o remount,ro /boot/firmware
+sudo reboot
+```
+
+After reboot:
+- `vc4-drm` warnings gone from `journalctl -p warning`
+- Framebuffer reports `3840x2160`
+- SoC temperature rises ~1-2 °C steady-state (within Pi 4 thermal envelope)
+
+Validated on snapdigi (Pi 4 2GB + LG 50" 4K TV) 2026-05-21.
+
 You can disable or tune via `.env` (`QOS_ENABLE=false`). On a quiet home LAN the effect is undetectable; under heavy parallel transfers it's the difference between glitch-free audio and dropouts.

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -352,6 +352,8 @@ For congested networks or installs where the same Pi sees bulk file transfers, `
 tc qdisc add dev eth0 root cake bandwidth 100mbit
 ```
 
+You can disable or tune via `.env` (`QOS_ENABLE=false`). On a quiet home LAN the effect is undetectable; under heavy parallel transfers it's the difference between glitch-free audio and dropouts.
+
 ## 4K @ 60Hz HDMI on Pi 4 client displays
 
 Pi 4 ships with a conservative GPU clock that maxes out at 4K @ 30Hz. When the client Pi drives a 4K-capable TV/monitor, the kernel logs:
@@ -379,5 +381,3 @@ After reboot:
 - SoC temperature rises ~1-2 °C steady-state (within Pi 4 thermal envelope)
 
 Validated on snapdigi (Pi 4 2GB + LG 50" 4K TV) 2026-05-21.
-
-You can disable or tune via `.env` (`QOS_ENABLE=false`). On a quiet home LAN the effect is undetectable; under heavy parallel transfers it's the difference between glitch-free audio and dropouts.

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -45,7 +45,7 @@ snapMULTI ti comunica che funziona attraverso l'audio. Durante l'installazione s
 Prima di iniziare l'installazione:
 
 - Accendi l'amplificatore o le casse attive
-- Imposta il volume a un livello moderato
+- Imposta il volume a un **livello moderato** — snapMULTI riproduce anche un breve segnale audio del test di salute a ogni boot/reboot, non solo all'installazione; tieni un volume confortevole per un suono che parte senza presidio (es. dopo un blackout di notte)
 - Verifica che i cavi siano collegati dall'uscita del DAC all'ingresso dell'amplificatore
 - Se hai cuffie nel jack 3.5 mm del Pi, l'audio uscirà da lì invece che dalla HAT — scollegale se vuoi l'uscita dalla HAT
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -45,7 +45,7 @@ snapMULTI tells you it's alive through audio. During install you'll hear a 1-sec
 Before starting the install:
 
 - Power on the amplifier or active speakers
-- Set the volume to a moderate level
+- Set the volume to a **moderate level** — snapMULTI also plays a short health-check tone at every boot/reboot, not just at install; keep the volume comfortable for a sound that fires unattended (e.g. after a power cut at night)
 - Confirm cables are connected from the DAC output to the amplifier input
 - If headphones are plugged into the Pi's 3.5 mm jack, audio will route there instead of the HAT — unplug them if you want HAT output
 

--- a/docs/TROUBLESHOOTING.it.md
+++ b/docs/TROUBLESHOOTING.it.md
@@ -51,7 +51,9 @@ sudo bash /opt/snapmulti/scripts/device-smoke.sh --both --tone
 | Bitono discendente | Uno o più controlli falliti |
 | Singolo cinguettio basso | Boot ancora in stabilizzazione, riprova fra un minuto |
 
-I segnali sono opt-in: in v0.7.8 NON si attivano automaticamente al boot (previsto per una versione futura). Regole di silenziamento rispettate: `TEST_TONE=false` in `install.conf`, `SNAPMULTI_BOOT_SMOKE_TONES=off` in `.env`, e mai sopra uno stream Snapcast attivo.
+I segnali si attivano anche automaticamente dopo ogni boot (`snapmulti-auto-boot-smoke.service`), così un Pi senza presidio segnala l'esito del riavvio in modo udibile. Tieni il volume moderato — il segnale si ripete a ogni accensione.
+
+**Opt-out multi-stanza:** sentire 5 stanze in sequenza al boot è una pessima UX. Imposta `SNAPMULTI_BOOT_SMOKE_TONES=off` in `/opt/snapmulti/.env` (server) o `/opt/snapclient/.env` (client) per silenziare il tono al boot mantenendo `--tone` manuale funzionante. `TEST_TONE=false` in `install.conf` silenzia tutto (tono di installazione + tono di boot + manuale). I segnali non si attivano mai sopra uno stream Snapcast attivo.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -51,7 +51,9 @@ sudo bash /opt/snapmulti/scripts/device-smoke.sh --both --tone
 | Descending two-note tone | One or more checks failed |
 | Single low chirp | Boot still settling, retry in a minute |
 
-The cues are opt-in: not played automatically at boot in v0.7.8 (planned for a future release). Suppression rules honoured: `TEST_TONE=false` in `install.conf`, `SNAPMULTI_BOOT_SMOKE_TONES=off` in `.env`, and never plays over an active Snapcast stream.
+The cues also fire automatically after every boot (`snapmulti-auto-boot-smoke.service`), so an unattended Pi reports its post-reboot health audibly. Keep volume moderate — the tone repeats at every power-up.
+
+**Multi-room opt-out:** hearing 5 rooms chime in sequence at boot is bad UX. Set `SNAPMULTI_BOOT_SMOKE_TONES=off` in `/opt/snapmulti/.env` (server) or `/opt/snapclient/.env` (client) to silence the auto-boot tone while keeping the manual `--tone` invocation working. `TEST_TONE=false` in `install.conf` silences everything (install-time tone + boot tone + manual). Tones never play over an active Snapcast stream.
 
 ---
 

--- a/scripts/common/auto-boot-smoke.sh
+++ b/scripts/common/auto-boot-smoke.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Wrapper invoked by snapmulti-auto-boot-smoke.service: runs device-smoke.sh --tone for the host's install role.
 
+# No -e: every branch exits 0 explicitly. Failure to fire the tone must NEVER fail boot.
 set -uo pipefail
 
 CONF=/opt/snapmulti/install.conf
@@ -30,4 +31,4 @@ fi
 
 sleep 3   # container-metric settle window
 
-exec "$SMOKE" "$MODE" --tone >/dev/null 2>&1
+exec "$SMOKE" "$MODE" --tone >/dev/null

--- a/scripts/common/auto-boot-smoke.sh
+++ b/scripts/common/auto-boot-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Wrapper invoked by snapmulti-auto-boot-smoke.service: runs device-smoke.sh --tone for the host's install role.
+
+set -uo pipefail
+
+CONF=/opt/snapmulti/install.conf
+[[ -f "$CONF" ]] || CONF=/opt/snapclient/install.conf
+[[ -f "$CONF" ]] || CONF=/boot/firmware/install.conf
+[[ -f "$CONF" ]] || exit 0
+
+INSTALL_TYPE=$(grep -m1 '^INSTALL_TYPE=' "$CONF" 2>/dev/null | cut -d= -f2- | tr -d '\r[:space:]')
+
+case "$INSTALL_TYPE" in
+    server)              MODE=--server; SMOKE=/opt/snapmulti/scripts/device-smoke.sh ;;
+    client|client-native) MODE=--client; SMOKE=/opt/snapclient/scripts/device-smoke.sh ;;
+    both)                MODE=--both;   SMOKE=/opt/snapmulti/scripts/device-smoke.sh ;;
+    *) exit 0 ;;
+esac
+
+[[ -x "$SMOKE" ]] || exit 0
+
+# Wait up to 90 s for Snapcast healthy — avoid false-positive FAIL during slow container startup.
+if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
+    for _ in $(seq 1 45); do
+        curl -s --max-time 2 -d '{"id":1,"jsonrpc":"2.0","method":"Server.GetStatus"}' \
+            http://localhost:1780/jsonrpc 2>/dev/null | grep -q '"streams"' && break
+        sleep 2
+    done
+fi
+
+sleep 3   # container-metric settle window
+
+exec "$SMOKE" "$MODE" --tone >/dev/null 2>&1

--- a/scripts/common/snapmulti-status.service
+++ b/scripts/common/snapmulti-status.service
@@ -9,12 +9,8 @@ StartLimitBurst=5
 
 [Service]
 Type=oneshot
-# Concurrency guard: flock-based, so two timer firings can't write the
-# JSON file at once (Pi Zero 2W on a slow SD can have smoke runs > 60s).
-# `flock --nonblock` exits immediately if another instance holds the lock.
-# RuntimeMaxSec also kills runaway runs that would block the next timer.
-RuntimeMaxSec=120
-TimeoutStartSec=130
+# TimeoutStartSec kills runaway runs that would block the next timer (RuntimeMaxSec has no effect on Type=oneshot).
+TimeoutStartSec=120
 KillMode=mixed
 # `flock --nonblock` exits 1 when the lock is busy (concurrent run). That's
 # the intended "skip this firing" behaviour, not a failure — tell systemd so

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -98,7 +98,7 @@ tune_usb_autosuspend() {
 
     if echo -1 > /sys/module/usbcore/parameters/autosuspend 2>/dev/null; then
         if mkdir -p /etc/udev/rules.d 2>/dev/null; then
-            if ! echo 'ACTION=="add", SUBSYSTEM=="usb", ATTR{power/autosuspend}="-1"' \
+            if ! echo 'ACTION=="add", SUBSYSTEM=="usb", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"' \
                 > /etc/udev/rules.d/50-usb-no-autosuspend.rules 2>/dev/null; then
                 is_overlayroot && warn "USB autosuspend: udev rule skipped (overlayroot)"
             fi

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -783,9 +783,31 @@ DEOF
         install -m 755 "$_tune_dir/play-smoke-tone.sh" /usr/local/bin/snapmulti-play-smoke-tone
     fi
 
+    # Auto-boot-smoke service — fires device-smoke.sh --tone after every boot so the appliance speaks its health.
+    if [[ -f "$_tune_dir/auto-boot-smoke.sh" ]]; then
+        install -m 755 "$_tune_dir/auto-boot-smoke.sh" /usr/local/bin/snapmulti-auto-boot-smoke
+        cat > /etc/systemd/system/snapmulti-auto-boot-smoke.service <<'BSEOF'
+[Unit]
+Description=snapMULTI auto boot smoke (acoustic health cue)
+After=multi-user.target docker.service snapmulti-server.service snapclient.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/snapmulti-auto-boot-smoke
+TimeoutStartSec=180
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+BSEOF
+    fi
+
     systemctl daemon-reload
     systemctl enable snapmulti-boot-tune.service 2>/dev/null
     systemctl enable snapmulti-docker-driver.service 2>/dev/null || true
+    systemctl enable snapmulti-auto-boot-smoke.service 2>/dev/null || true
 
     # NetworkManager-wait-online.service is masked at kernel cmdline level
     # (prepare-sd.sh writes systemd.mask=NetworkManager-wait-online.service

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -612,6 +612,9 @@ if is_client_install; then
         }
         cp -r "$SNAP_BOOT/client/".??* "$CLIENT_DIR/" 2>/dev/null || true
     fi
+    # Stage device-smoke.sh + smoke checks on client too — auto-boot-smoke.service needs them.
+    cp "$SNAP_BOOT/server/device-smoke.sh" "$CLIENT_DIR/scripts/" 2>/dev/null || true
+    [[ -d "$SNAP_BOOT/server/smoke" ]] && cp -r "$SNAP_BOOT/server/smoke" "$CLIENT_DIR/scripts/" 2>/dev/null || true
     local_missing=()
     [[ -f "$CLIENT_DIR/docker-compose.yml" ]] || local_missing+=("docker-compose.yml")
     [[ -f "$CLIENT_DIR/scripts/setup.sh" ]] || local_missing+=("scripts/setup.sh")

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -137,6 +137,7 @@ function Assert-PreparedSdCard {
         'common/systemd-snippets.sh',
         'common/release-manifest.sh',
         'common/play-smoke-tone.sh',
+        'common/auto-boot-smoke.sh',
         'common/audio/smoke-pass.wav',
         'common/audio/smoke-warn.wav',
         'common/audio/smoke-fail.wav',

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -1002,7 +1002,7 @@ VERIFY_ERRORS=0
 # -- snapMULTI files --
 echo ""
 echo "--- snapMULTI files ---"
-for f in install.conf firstboot.sh release-manifest.json common/progress.sh common/logging.sh common/unified-log.sh common/sanitize.sh common/system-tune.sh common/install-docker.sh common/install-deps.sh common/setup-docker.sh common/wait-network.sh common/mount-music.sh common/systemd-snippets.sh common/release-manifest.sh common/play-smoke-tone.sh common/audio/smoke-pass.wav common/audio/smoke-warn.wav common/audio/smoke-fail.wav common/audio/smoke-skip.wav; do
+for f in install.conf firstboot.sh release-manifest.json common/progress.sh common/logging.sh common/unified-log.sh common/sanitize.sh common/system-tune.sh common/install-docker.sh common/install-deps.sh common/setup-docker.sh common/wait-network.sh common/mount-music.sh common/systemd-snippets.sh common/release-manifest.sh common/play-smoke-tone.sh common/auto-boot-smoke.sh common/audio/smoke-pass.wav common/audio/smoke-warn.wav common/audio/smoke-fail.wav common/audio/smoke-skip.wav; do
     if [[ -f "$DEST/$f" ]]; then
         echo "  [OK] snapmulti/$f"
     else

--- a/tests/test_auto_boot_smoke.sh
+++ b/tests/test_auto_boot_smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Static checks for scripts/common/auto-boot-smoke.sh + the systemd unit
+# installed by install_boot_tune_service in scripts/common/system-tune.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+
+pass=0
+fail=0
+
+assert() {
+    local cond="$1" desc="$2"
+    if eval "$cond"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "## auto-boot-smoke wrapper"
+
+WRAP="$ROOT/scripts/common/auto-boot-smoke.sh"
+assert "[[ -f '$WRAP' ]]"                  "wrapper exists"
+assert "[[ -x '$WRAP' ]]"                  "wrapper is executable"
+assert "head -1 '$WRAP' | grep -q '^#!/usr/bin/env bash'"  "shebang env bash"
+assert "grep -q 'set -uo pipefail' '$WRAP'" "set -uo pipefail (no -e — best-effort)"
+assert "grep -q 'INSTALL_TYPE=' '$WRAP'"   "reads INSTALL_TYPE from install.conf"
+assert "grep -qE 'server\\)|client\\)|both\\)' '$WRAP'" "dispatches on install role"
+assert "grep -q '/opt/snapmulti/scripts/device-smoke.sh' '$WRAP'" "calls server smoke path"
+assert "grep -q '/opt/snapclient/scripts/device-smoke.sh' '$WRAP'" "calls client smoke path"
+assert "grep -q -- '--tone' '$WRAP'"       "invokes device-smoke.sh with --tone"
+assert "grep -q 'Server.GetStatus' '$WRAP'" "waits for Snapcast healthy before firing (server/both)"
+assert "grep -q 'exit 0' '$WRAP'"          "exits 0 on no-op paths (best-effort)"
+
+echo
+echo "## install_boot_tune_service installs the auto-boot-smoke unit"
+
+TUNE="$ROOT/scripts/common/system-tune.sh"
+assert "grep -q 'auto-boot-smoke.sh' '$TUNE'"                      "system-tune.sh references the wrapper"
+assert "grep -q 'snapmulti-auto-boot-smoke.service' '$TUNE'"       "writes the systemd unit"
+assert "grep -q 'snapmulti-auto-boot-smoke' '$TUNE'"               "installs helper to /usr/local/bin/snapmulti-auto-boot-smoke"
+assert "grep -q 'systemctl enable snapmulti-auto-boot-smoke' '$TUNE'" "enables the unit"
+assert "grep -A20 'snapmulti-auto-boot-smoke.service <<' '$TUNE' | grep -q 'After=multi-user.target'" "unit ordered After=multi-user.target"
+assert "grep -A20 'snapmulti-auto-boot-smoke.service <<' '$TUNE' | grep -q 'Type=oneshot'"             "unit Type=oneshot"
+assert "grep -A20 'snapmulti-auto-boot-smoke.service <<' '$TUNE' | grep -q 'WantedBy=multi-user.target'" "unit WantedBy=multi-user.target"
+
+echo
+echo "## SD-prep staging lists the wrapper"
+
+assert "grep -q 'common/auto-boot-smoke.sh' '$ROOT/scripts/prepare-sd.sh'"  "prepare-sd.sh stages wrapper"
+assert "grep -q 'common/auto-boot-smoke.sh' '$ROOT/scripts/prepare-sd.ps1'" "prepare-sd.ps1 stages wrapper"
+
+echo
+echo "## Summary"
+echo "  Passed: $pass"
+echo "  Failed: $fail"
+
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Headline: Pi speaks its post-boot health audibly through the attached DAC. Closes the v0.7.8 "manual --tone only" foundation gap and bundles 3 small launch-prep cleanups.

## Changes

| Concern | File | LOC |
|---|---|---|
| auto-boot-smoke wrapper | `scripts/common/auto-boot-smoke.sh` (new) | +37 |
| systemd unit installer | `scripts/common/system-tune.sh` | +22 |
| stage `device-smoke.sh` on client too | `scripts/firstboot.sh` | +3 |
| SD-prep staging lists wrapper | `scripts/prepare-sd.sh` + `.ps1` | +2 |
| volume warning + multi-room opt-out | `docs/INSTALL.md` + `.it.md` + `docs/TROUBLESHOOTING.md` + `.it.md` | +6 |
| static tests | `tests/test_auto_boot_smoke.sh` (new) | +60 |
| #458 udev `TEST==power/autosuspend` | `scripts/common/system-tune.sh` | ~1 |
| #459 drop `RuntimeMaxSec` on oneshot | `scripts/common/snapmulti-status.service` | ~5 |
| #461 4K@60Hz docs | `docs/ADVANCED.md` + `.it.md` | +56 |

## Tests

`tests/test_auto_boot_smoke.sh`: 20/20 ✓
`tests/test_smoke_tones.sh`: 49/49 ✓

## Validation

Done locally: shellcheck clean, EN+IT mirrors in sync, unit static-asserts cover After/Type/WantedBy/dispatch.
Deferred to release-gate: reflash snapvideo + snapdigi, confirm tone fires automatically on every boot.