### PR TITLE
docs(ssot): add snapmulti-auto-boot-smoke.service to USAGE Systemd Units

### DIFF
--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -127,7 +127,7 @@ Dopo l'installazione systemd possiede il ciclo di vita dei container (ADR-005). 
 
 - Server: `snapmulti-server.service`, `snapmulti-status.timer`, `snapmulti-backup.timer`
 - Client: `snapclient.service`, `snapclient-discover.timer`, `snapclient-display.service` (solo client HDMI)
-- Tutti: `snapmulti-boot-tune.service`
+- Tutti: `snapmulti-boot-tune.service`, `snapmulti-auto-boot-smoke.service` (segnale audio del test di salute al boot — vedi [TROUBLESHOOTING.it.md](TROUBLESHOOTING.it.md#toni-test-salute) per vocabolario e opt-out)
 
 Ispeziona con `systemctl cat <unit>`. Path di deployment e strategie di aggiornamento: [ADVANCED.it.md](ADVANCED.it.md#deploy-senza-prepare-sd).
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -127,7 +127,7 @@ systemd owns container lifecycle after install (ADR-005). Docker `restart: unles
 
 - Server: `snapmulti-server.service`, `snapmulti-status.timer`, `snapmulti-backup.timer`
 - Client: `snapclient.service`, `snapclient-discover.timer`, `snapclient-display.service` (HDMI clients only)
-- All: `snapmulti-boot-tune.service`
+- All: `snapmulti-boot-tune.service`, `snapmulti-auto-boot-smoke.service` (acoustic post-boot health cue — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#health-check-tones) for cue vocabulary and opt-out)
 
 Inspect with `systemctl cat <unit>`. Deployment paths and update strategy: [ADVANCED.md](ADVANCED.md#deployment-without-prepare-sd).
 


### PR DESCRIPTION
Per CLAUDE.md SSOT table `USAGE.md` owns systemd-unit inventory. PR #463 documented the new `snapmulti-auto-boot-smoke.service` behaviour in `TROUBLESHOOTING.md` but missed the canonical USAGE list. One-line entry + cross-link to TROUBLESHOOTING (no description duplication).

EN + IT mirrors in sync.