### PR TITLE
docs: auto-boot tone is silent during active playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- **Auto-boot health cue is silent during active playback (known limitation)** — `docs/INSTALL.md` + IT mirror now state that `multi_out`'s direct `hw:` slave makes snapclient's stream exclusive, so post-reboot smoke tone is suppressed by ALSA when audio is already playing. Tracked for v0.7.9 (dmix slave / pause-snapclient / Snapcast-stream candidates).
+
 ## [0.7.8.1] — 2026-05-22
 
 > Patch release completing the acoustic-feedback contract started in v0.7.8: smoke result cues now fire automatically after every boot through the attached DAC, plus 7 cleanup fixes from the snapvideo+snapdigi deep audit. Script-only release — `image_set` stays at `0.7.7`, `requires_image_rebuild=false`. Validated live on snapvideo (both-mode Pi 4 8GB) via host-level patch + verified tone audible through HiFiBerry DAC.

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -360,6 +360,8 @@ Circa 3–4 minuti dopo l'inizio dell'installazione, dopo il rilevamento della s
 Se non lo senti, l'installazione prosegue comunque — ma controlla alimentazione, volume e cavi prima di provare a riprodurre musica più tardi. Per silenziare il tono (installazioni notturne, casse scollegate), imposta `TEST_TONE=false` in `install.conf` prima del primo boot.
 
 > Dopo l'install, un controllo opzionale `device-smoke.sh --tone` riproduce un segnale audio distintivo per risultato (PASS / WARN / FAIL). Vedi [TROUBLESHOOTING.it.md — Segnali audio del risultato](TROUBLESHOOTING.it.md#toni-test-salute).
+>
+> **Attenzione — il segnale post-boot è silente se c'è già audio.** snapMULTI lancia un test di salute dopo ogni riavvio. Se una sorgente sta già trasmettendo via Snapcast quando il test parte (autoplay, MPD che riprende), il DAC è in uso esclusivo dal player e ALSA sopprime il segnale. Il test viene comunque eseguito e il risultato è leggibile su `/status` o lanciando manualmente `device-smoke.sh --both --tone` ad audio fermo.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -358,6 +358,8 @@ Roughly 3–4 minutes into the install, after the audio hardware is detected, sn
 If you don't hear it, the install still continues — but check power, volume, and cables before trying to play music later. To suppress the tone (overnight installs, speakers disconnected), set `TEST_TONE=false` in `install.conf` before first boot.
 
 > After install, an optional `device-smoke.sh --tone` health check plays a distinctive cue per result (PASS / WARN / FAIL). See [TROUBLESHOOTING.md — Audible result cues](TROUBLESHOOTING.md#health-check-tones).
+>
+> **Heads up — auto-boot health cue is silent while audio plays.** snapMULTI fires a smoke check after every reboot. If any source is already streaming through Snapcast when the check runs (autoplay, MPD resume), the DAC is held exclusively by the player and the cue is suppressed by ALSA. The check itself still runs and you can read its result at `/status` or by running `device-smoke.sh --both --tone` manually when audio is paused.
 
 ---
 


### PR DESCRIPTION
Known limitation surfaced in INSTALL.md + IT mirror + CHANGELOG [Unreleased].

| Where | Why silent |
|-------|------------|
| `multi_out` asound.conf | uses `hw:sndrpihifiberry,0` direct (not dmix) |
| auto-boot timing | snapclient already streaming when smoke fires post-reboot |
| Result | `aplay` returns EBUSY, wrapper exits 0 — silent |

Fix candidates tracked for v0.7.9: dmix slave / pause-snapclient / Snapcast-stream.