### PR TITLE
feat(status): show absolute snapshot timestamp on /status page

### DIFF
--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -19,6 +19,7 @@ import hashlib
 import html
 import ipaddress
 import json
+from datetime import datetime
 import logging
 import os
 import signal
@@ -2311,7 +2312,16 @@ def _status_to_html(data: dict | None, age_s: float | None) -> str:
             age_label = f"{int(age_s / 60)}m ago"
         else:
             age_label = f"{int(age_s / 3600)}h ago"
-        footer = f"Snapshot taken <strong>{age_label}</strong>. Refreshes every minute."
+        finished_at = (data or {}).get("finished_at", "")
+        if finished_at:
+            try:
+                ts = datetime.fromisoformat(finished_at.replace("Z", "+00:00")).astimezone()
+                abs_label = ts.strftime("%Y-%m-%d %H:%M %Z")
+                footer = f"Snapshot taken <strong>{abs_label}</strong> ({age_label}). Refreshes every minute."
+            except (ValueError, TypeError):
+                footer = f"Snapshot taken <strong>{age_label}</strong>. Refreshes every minute."
+        else:
+            footer = f"Snapshot taken <strong>{age_label}</strong>. Refreshes every minute."
     else:
         footer = ""
 

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2315,13 +2315,17 @@ def _status_to_html(data: dict | None, age_s: float | None) -> str:
         finished_at = (data or {}).get("finished_at", "")
         if finished_at:
             try:
-                ts = datetime.fromisoformat(finished_at.replace("Z", "+00:00")).astimezone()
+                ts = datetime.fromisoformat(
+                    finished_at.replace("Z", "+00:00")
+                ).astimezone()
                 abs_label = ts.strftime("%Y-%m-%d %H:%M %Z")
                 footer = f"Snapshot taken <strong>{abs_label}</strong> ({age_label}). Refreshes every minute."
             except (ValueError, TypeError):
                 footer = f"Snapshot taken <strong>{age_label}</strong>. Refreshes every minute."
         else:
-            footer = f"Snapshot taken <strong>{age_label}</strong>. Refreshes every minute."
+            footer = (
+                f"Snapshot taken <strong>{age_label}</strong>. Refreshes every minute."
+            )
     else:
         footer = ""
 


### PR DESCRIPTION
Footer was relative-only (\`3m ago\`). Adds local-tz absolute time:
| Was | Is |
|-----|-----|
| Snapshot taken **3m ago**. Refreshes every minute. | Snapshot taken **2026-05-25 14:31 CEST** (3m ago). Refreshes every minute. |

Reads from existing \`finished_at\` ISO field. Falls back gracefully if missing/malformed.