### PR TITLE
feat(smoke): MPD scan progress on /status + doc first-boot caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MPD scan progress on `/status`** — Snapcast + MPD section now surfaces `MPD library scan in progress (#N)` when an `Updating DB` job is active. Makes the first-boot FAIL on a large NFS/SMB library self-explanatory instead of mysterious.
+
+### Docs
+- **First-boot FAIL with large library is the MPD scan** — INSTALL.md (+ IT) explains the auto-boot tone may report FAIL while MPD scans the library for the first time and points at `/status` for confirmation. Next boot's tone is PASS.
+
 ## [0.7.8.2] — 2026-05-25
 
 > Patch release fixing two end-to-end gaps in v0.7.8.1's auto-boot acoustic feedback: the unit timed out on real-world NFS libraries (large MPD scan blocked the wait) and the tone itself was silent under `Type=oneshot` (backgrounded `aplay` got SIGTERM at cgroup close). Both fixes live-validated on snapvideo (both-mode Pi 4 8GB). Script-only release — `image_set` stays at `0.7.7`, `requires_image_rebuild=false`.

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -362,6 +362,8 @@ Se non lo senti, l'installazione prosegue comunque — ma controlla alimentazion
 > Dopo l'install, un controllo opzionale `device-smoke.sh --tone` riproduce un segnale audio distintivo per risultato (PASS / WARN / FAIL). Vedi [TROUBLESHOOTING.it.md — Segnali audio del risultato](TROUBLESHOOTING.it.md#toni-test-salute).
 >
 > **Attenzione — il segnale post-boot è silente se c'è già audio.** snapMULTI lancia un test di salute dopo ogni riavvio. Se una sorgente sta già trasmettendo via Snapcast quando il test parte (autoplay, MPD che riprende), il DAC è in uso esclusivo dal player e ALSA sopprime il segnale. Il test viene comunque eseguito e il risultato è leggibile su `/status` o lanciando manualmente `device-smoke.sh --both --tone` ad audio fermo.
+>
+> **FAIL al primo boot con libreria musicale ampia?** Al primissimo boot dopo l'install (o dopo cambiamenti rilevanti alla libreria), MPD scansiona l'intera collezione. Su librerie NFS/SMB con molte migliaia di brani può richiedere ore. In quella finestra il test post-boot può segnalare FAIL perché `mpd` è ancora in stato `starting`. Apri `http://<hostname>.local:8083/status` — se vedi "MPD library scan in progress (#N)" nella sezione Snapcast + MPD, basta aspettare che finisca. Al boot successivo il tono sarà PASS.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -360,6 +360,8 @@ If you don't hear it, the install still continues — but check power, volume, a
 > After install, an optional `device-smoke.sh --tone` health check plays a distinctive cue per result (PASS / WARN / FAIL). See [TROUBLESHOOTING.md — Audible result cues](TROUBLESHOOTING.md#health-check-tones).
 >
 > **Heads up — auto-boot health cue is silent while audio plays.** snapMULTI fires a smoke check after every reboot. If any source is already streaming through Snapcast when the check runs (autoplay, MPD resume), the DAC is held exclusively by the player and the cue is suppressed by ALSA. The check itself still runs and you can read its result at `/status` or by running `device-smoke.sh --both --tone` manually when audio is paused.
+>
+> **First-boot FAIL with a large music library?** On the very first boot after a fresh install (or after a major library change), MPD scans the whole collection. On NFS/SMB libraries with many thousands of tracks this can take hours. During that window the auto-boot smoke may report FAIL because `mpd` is still in the `starting` healthcheck state. Open `http://<hostname>.local:8083/status` — if you see "MPD library scan in progress (#N)" in the Snapcast + MPD section, just let it finish. The next boot's tone will be PASS.
 
 ---
 

--- a/scripts/smoke/check_snapcast.sh
+++ b/scripts/smoke/check_snapcast.sh
@@ -137,4 +137,11 @@ check_snapcast() {
         state=${state:-unknown}
         pass_check "MPD reachable, state: $state"
     fi
+
+    # MPD scan progress — large NFS libraries take hours on first boot. Surface as INFO so users know the FAIL on `mpd: starting` healthcheck is expected during this window (not a real problem).
+    if grep -qE "^Updating DB" <<<"$mpc_out"; then
+        local job
+        job=$(grep -oE 'Updating DB \(#[0-9]+\)' <<<"$mpc_out" | head -1)
+        info "MPD library scan in progress ($job) — large libraries can take hours; transient FAIL on 'mpd: starting' healthcheck is expected during this window"
+    fi
 }


### PR DESCRIPTION
Two pieces addressing the \"first-boot FAIL with big library\" footgun:

| What | Where |
|------|-------|
| INFO line on /status when MPD scan active | scripts/smoke/check_snapcast.sh |
| Doc note: if FAIL right after install with large library, check /status | docs/INSTALL.md + .it.md |

When `mpc status` output includes \`Updating DB (#N)\`, the smoke shows:
> [INFO] MPD library scan in progress (Updating DB (#3)) — large libraries can take hours; transient FAIL on 'mpd: starting' healthcheck is expected during this window

So the user immediately sees WHY the auto-boot tone was FAIL.