### PR TITLE
release: v0.7.8.3 — MPD scan progress on /status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.3] — 2026-05-25
+
+> Script-only patch (image_set stays 0.7.7). Makes the first-boot FAIL on large NFS libraries self-explanatory: `/status` now shows the MPD scan progress and INSTALL.md tells users to check it. Closes the last UX surprise around the v0.7.8.x acoustic-feedback contract.
+
 ### Added
-- **MPD scan progress on `/status`** — Snapcast + MPD section now surfaces `MPD library scan in progress (#N)` when an `Updating DB` job is active. Makes the first-boot FAIL on a large NFS/SMB library self-explanatory instead of mysterious.
+- **MPD scan progress on `/status` (#479)** — Snapcast + MPD section now surfaces `MPD library scan in progress (#N)` when an `Updating DB` job is active. Makes the first-boot FAIL on a large NFS/SMB library self-explanatory instead of mysterious.
 
 ### Docs
-- **First-boot FAIL with large library is the MPD scan** — INSTALL.md (+ IT) explains the auto-boot tone may report FAIL while MPD scans the library for the first time and points at `/status` for confirmation. Next boot's tone is PASS.
+- **First-boot FAIL with large library is the MPD scan (#479)** — INSTALL.md (+ IT) explains the auto-boot tone may report FAIL while MPD scans the library for the first time and points at `/status` for confirmation. Next boot's tone is PASS.
 
 ## [0.7.8.2] — 2026-05-25
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.2",
+  "snapmulti_release": "v0.7.8.3",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Script-only patch. Closes the last UX surprise around v0.7.8.x acoustic feedback: when first-boot FAILs with a large NFS library, \`/status\` now tells you WHY (MPD is scanning) and INSTALL.md points users there.

| | |
|--|--|
| #479 | MPD scan progress on /status + INSTALL doc note |

\`image_set\` stays \`0.7.7\` (no container changes). Live-validated logic on snapvideo.