### PR TITLE
fix(setup-zero2w): install auto-boot-smoke on Pi Zero (client-native)

### DIFF
--- a/client/common/scripts/setup-zero2w.sh
+++ b/client/common/scripts/setup-zero2w.sh
@@ -409,6 +409,15 @@ if ! systemctl restart snapclient.service; then
     warn "snapclient.service restart failed — diagnostics: journalctl -u snapclient -n 50"
 fi
 
+# ── Acoustic feedback — Pi Zero is the prime "headless in a closet" target ──
+# install_boot_tune_service in system-tune.sh is server-oriented (Docker driver,
+# CAKE, etc.) — for native we only need the smoke-tone assets + auto-boot-smoke
+# service so the post-reboot tone reaches the user.
+if _source_first_match "system-tune.sh"; then
+    install_smoke_tone_service
+    ok "Smoke-tone assets + auto-boot-smoke.service installed"
+fi
+
 # ── Verify ───────────────────────────────────────────────────────
 sleep 3
 if systemctl is-active --quiet snapclient.service; then

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -764,11 +764,27 @@ WantedBy=multi-user.target
 DEOF
     fi
 
-    # Acoustic smoke cues: WAV files + helper invoked by device-smoke.sh --tone.
-    # Lets headless server installs report PASS/WARN/FAIL/SKIP audibly through
-    # the attached DAC. Resolved relative to ${BASH_SOURCE[0]} so this works
-    # whether system-tune.sh was sourced from the server (scripts/common/) or
-    # client (client/common/scripts/common/) install tree.
+    install_smoke_tone_service
+
+    systemctl daemon-reload
+    systemctl enable snapmulti-boot-tune.service 2>/dev/null
+    systemctl enable snapmulti-docker-driver.service 2>/dev/null || true
+
+    # NetworkManager-wait-online.service is masked at kernel cmdline level
+    # (prepare-sd.sh writes systemd.mask=NetworkManager-wait-online.service
+    # to cmdline.txt) — survives overlayroot upper-layer wipes and is
+    # parsed before any unit starts. No systemctl mask needed here.
+
+    ok "Boot tuning service installed (CPU, USB, CAKE persist across reboots)"
+}
+
+# Install acoustic smoke assets (WAVs + play-smoke-tone helper + auto-boot-smoke service).
+# Callable from server's install_boot_tune_service AND from client-native's
+# setup-zero2w.sh — Pi Zero gets the post-reboot tone without the rest of
+# the boot-tune chain (no Docker, no compose, no docker-driver-reconcile).
+install_smoke_tone_service() {
+    # Resolved relative to ${BASH_SOURCE[0]} so this works whether system-tune.sh
+    # was sourced from the server (scripts/common/) or client (client/common/scripts/common/) tree.
     local _tune_dir audio_src
     _tune_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     audio_src="$_tune_dir/audio"
@@ -783,7 +799,6 @@ DEOF
         install -m 755 "$_tune_dir/play-smoke-tone.sh" /usr/local/bin/snapmulti-play-smoke-tone
     fi
 
-    # Auto-boot-smoke service — fires device-smoke.sh --tone after every boot so the appliance speaks its health.
     if [[ -f "$_tune_dir/auto-boot-smoke.sh" ]]; then
         install -m 755 "$_tune_dir/auto-boot-smoke.sh" /usr/local/bin/snapmulti-auto-boot-smoke
         cat > /etc/systemd/system/snapmulti-auto-boot-smoke.service <<'BSEOF'
@@ -803,17 +818,7 @@ StandardError=journal
 [Install]
 WantedBy=multi-user.target
 BSEOF
+        systemctl daemon-reload
+        systemctl enable snapmulti-auto-boot-smoke.service 2>/dev/null || true
     fi
-
-    systemctl daemon-reload
-    systemctl enable snapmulti-boot-tune.service 2>/dev/null
-    systemctl enable snapmulti-docker-driver.service 2>/dev/null || true
-    systemctl enable snapmulti-auto-boot-smoke.service 2>/dev/null || true
-
-    # NetworkManager-wait-online.service is masked at kernel cmdline level
-    # (prepare-sd.sh writes systemd.mask=NetworkManager-wait-online.service
-    # to cmdline.txt) — survives overlayroot upper-layer wipes and is
-    # parsed before any unit starts. No systemctl mask needed here.
-
-    ok "Boot tuning service installed (CPU, USB, CAKE persist across reboots)"
 }


### PR DESCRIPTION
**Pi Zero — the prime \"headless in a closet\" target — was the only profile NOT getting the post-boot acoustic tone.**

\`setup-zero2w.sh\` never sourced \`system-tune.sh\`, so the whole acoustic chain (WAVs + play-smoke-tone helper + auto-boot-smoke.service) was silently skipped on native installs.

| | |
|--|--|
| Extracted \`install_smoke_tone_service()\` from \`install_boot_tune_service()\` | scripts/common/system-tune.sh |
| Source + call from setup-zero2w.sh after enabling snapclient.service | client/common/scripts/setup-zero2w.sh |
| Live-validated on pizero: unit 16 s, smoke PASS, tone audible | InnoMaker DAC |

Tests 25/25 PASS.