### PR TITLE
release: v0.7.8.4 — Pi Zero auto-boot tone + MEDIUM fix from #481 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.4] — 2026-05-25
+
+> Script-only patch (image_set stays 0.7.7). Closes the client-native gap in the acoustic-feedback contract: Pi Zero 2W — the prime "headless in a closet" target — was the only profile NOT getting the post-boot tone because `setup-zero2w.sh` never sourced `system-tune.sh`. Live-validated on pizero: 16 s unit run, tone audible through InnoMaker DAC. Five consecutive script-only releases now riding the manifest gate.
+
+### Fixed
+- **`snapmulti-auto-boot-smoke.service` not installed on Pi Zero (client-native) (#481)** — `setup-zero2w.sh` never sourced `system-tune.sh`, so the smoke-tone WAVs + helper + auto-boot service were silently skipped. Pi Zero (the most-headless device, prime use case for acoustic feedback) was the only profile without it. Extracted `install_smoke_tone_service()` from `install_boot_tune_service()` so it can be called from the native path without dragging in Docker/CAKE/boot-tune machinery.
+- **Pi Zero unit no longer references `docker.service`** — `install_smoke_tone_service "client"` now writes a stripped unit (no `Wants=docker.service`, no `After=docker.service`/`snapmulti-server.service`) so the journal stays clean on Docker-less Pi Zero installs. Server/both mode unit unchanged.
+
 ## [0.7.8.3] — 2026-05-25
 
 > Script-only patch (image_set stays 0.7.7). Makes the first-boot FAIL on large NFS libraries self-explanatory: `/status` now shows the MPD scan progress and INSTALL.md tells users to check it. Closes the last UX surprise around the v0.7.8.x acoustic-feedback contract.

--- a/client/common/scripts/setup-zero2w.sh
+++ b/client/common/scripts/setup-zero2w.sh
@@ -414,7 +414,7 @@ fi
 # CAKE, etc.) — for native we only need the smoke-tone assets + auto-boot-smoke
 # service so the post-reboot tone reaches the user.
 if _source_first_match "system-tune.sh"; then
-    install_smoke_tone_service
+    install_smoke_tone_service "client"
     ok "Smoke-tone assets + auto-boot-smoke.service installed"
 fi
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.3",
+  "snapmulti_release": "v0.7.8.4",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -782,7 +782,9 @@ DEOF
 # Callable from server's install_boot_tune_service AND from client-native's
 # setup-zero2w.sh — Pi Zero gets the post-reboot tone without the rest of
 # the boot-tune chain (no Docker, no compose, no docker-driver-reconcile).
+# Arg 1: "server" (default) or "client" — drives whether the unit Wants/After docker.service.
 install_smoke_tone_service() {
+    local _mode="${1:-server}"
     # Resolved relative to ${BASH_SOURCE[0]} so this works whether system-tune.sh
     # was sourced from the server (scripts/common/) or client (client/common/scripts/common/) tree.
     local _tune_dir audio_src
@@ -801,7 +803,25 @@ install_smoke_tone_service() {
 
     if [[ -f "$_tune_dir/auto-boot-smoke.sh" ]]; then
         install -m 755 "$_tune_dir/auto-boot-smoke.sh" /usr/local/bin/snapmulti-auto-boot-smoke
-        cat > /etc/systemd/system/snapmulti-auto-boot-smoke.service <<'BSEOF'
+        # Client-native (Pi Zero) has no Docker → omit Wants=docker.service to avoid `Unit docker.service not found` journal noise on every boot.
+        if [[ "$_mode" == "client" ]]; then
+            cat > /etc/systemd/system/snapmulti-auto-boot-smoke.service <<'BSEOF'
+[Unit]
+Description=snapMULTI auto boot smoke (acoustic health cue)
+After=multi-user.target snapclient.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/snapmulti-auto-boot-smoke
+TimeoutStartSec=240
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+BSEOF
+        else
+            cat > /etc/systemd/system/snapmulti-auto-boot-smoke.service <<'BSEOF'
 [Unit]
 Description=snapMULTI auto boot smoke (acoustic health cue)
 After=multi-user.target docker.service snapmulti-server.service snapclient.service
@@ -818,6 +838,7 @@ StandardError=journal
 [Install]
 WantedBy=multi-user.target
 BSEOF
+        fi
         systemctl daemon-reload
         systemctl enable snapmulti-auto-boot-smoke.service 2>/dev/null || true
     fi

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -764,7 +764,7 @@ WantedBy=multi-user.target
 DEOF
     fi
 
-    install_smoke_tone_service
+    install_smoke_tone_service "server"
 
     systemctl daemon-reload
     systemctl enable snapmulti-boot-tune.service 2>/dev/null


### PR DESCRIPTION
Script-only patch. Closes the client-native gap in the acoustic-feedback contract + addresses the claude-review MEDIUM finding on #481 BEFORE shipping.

| | |
|--|--|
| #481 | Pi Zero (client-native) now gets auto-boot tone |
| MEDIUM fix | Pi Zero unit stripped of \`Wants=docker.service\` — no more \`Unit docker.service not found\` journal spam |

\`image_set\` stays \`0.7.7\` (no container changes). Live-validated on pizero (16 s unit, 0 docker.service-not-found mentions).