### PR TITLE
fix(/version): report snapmulti_release as current, not image_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **`/version` reports `snapmulti_release` as `current` (not `image_set`) (#483)** — was returning `{"current": "v0.7.7", "update_available": true}` on a freshly reflashed v0.7.8.4 device because `current` read `SNAPMULTI_VERSION` (image tag) instead of the git tag. Now bind-mounts `release-manifest.json` into the metadata container (read-only, `create_host_path: false` so non-Pi hosts don't get a spurious directory) and reads `snapmulti_release`. Adds `image_set` as separate field for transparency.
+- **`/version` reports `snapmulti_release` as `current` (not `image_set`) (#483)** — was returning `{"current": "v0.7.7", "update_available": true}` on a freshly reflashed v0.7.8.4 device because `current` read `SNAPMULTI_VERSION` (image tag) instead of the git tag. Now reads `SNAPMULTI_RELEASE` and `SNAPMULTI_IMAGE_SET` env vars (written to `.env` by `deploy.sh` on every deploy from `release-manifest.json`) instead of the image-baked `SNAPMULTI_VERSION`. On dev clones or manual x86 deploys where `deploy.sh` hasn't run, both vars are empty and the service falls back to `SNAPMULTI_VERSION` (same behaviour as before). Adds `image_set` as separate field for transparency.
 
 ## [0.7.8.4] — 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`/version` reports `snapmulti_release` as `current` (not `image_set`) (#483)** — was returning `{"current": "v0.7.7", "update_available": true}` on a freshly reflashed v0.7.8.4 device because `current` read `SNAPMULTI_VERSION` (image tag) instead of the git tag. Now bind-mounts `release-manifest.json` into the metadata container (read-only, `create_host_path: false` so non-Pi hosts don't get a spurious directory) and reads `snapmulti_release`. Adds `image_set` as separate field for transparency.
+
 ## [0.7.8.4] — 2026-05-25
 
 > Script-only patch (image_set stays 0.7.7). Closes the client-native gap in the acoustic-feedback contract: Pi Zero 2W — the prime "headless in a closet" target — was the only profile NOT getting the post-boot tone because `setup-zero2w.sh` never sourced `system-tune.sh`. Live-validated on pizero: 16 s unit run, tone audible through InnoMaker DAC. Five consecutive script-only releases now riding the manifest gate.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,7 +289,17 @@ services:
       # from image_set (Docker tag — e.g. 0.7.7) instead of showing the
       # image tag as `current` and triggering update_available=true on a
       # device that's actually up-to-date at the script layer.
-      - /boot/firmware/snapmulti/release-manifest.json:/release-manifest.json:ro
+      # create_host_path: false — on non-Pi hosts (x86 manual deploy) the
+      # source path doesn't exist; without this Docker would silently
+      # create a directory at /boot/firmware/snapmulti/release-manifest.json/
+      # polluting the host fs. With false: bind skipped if missing, Python
+      # falls back to image_set.
+      - type: bind
+        source: /boot/firmware/snapmulti/release-manifest.json
+        target: /release-manifest.json
+        read_only: true
+        bind:
+          create_host_path: false
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8083/health', timeout=3)"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,6 +284,12 @@ services:
       # "no snapshot available" failure verdict even when the host-side
       # timer is healthy (issue surfaced after v0.6.4 ship).
       - ./audio:/audio:ro
+      # Release manifest from the FAT32 boot partition (outside overlayroot).
+      # Lets /version distinguish snapmulti_release (git tag — e.g. v0.7.8.5)
+      # from image_set (Docker tag — e.g. 0.7.7) instead of showing the
+      # image tag as `current` and triggering update_available=true on a
+      # device that's actually up-to-date at the script layer.
+      - /boot/firmware/snapmulti/release-manifest.json:/release-manifest.json:ro
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8083/health', timeout=3)"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,13 +270,7 @@ services:
       # SNAPMULTI_VERSION is baked into the image at build time (see
       # Dockerfile.metadata + build-push.yml --build-arg), so /health and
       # /version always report the actually-running code's version.
-      # SNAPMULTI_RELEASE + SNAPMULTI_IMAGE_SET come from .env (written by
-      # deploy.sh from release-manifest.json on every deploy). Lets /version
-      # report the git tag as `current` (e.g. v0.7.8.5) distinct from the
-      # Docker image tag (e.g. 0.7.7) — without those, a script-only release
-      # shows update_available=true on a device that's actually up-to-date.
-      # Empty defaults so the container starts on dev clones / x86 manual
-      # deploys where deploy.sh hasn't written them yet.
+      # SNAPMULTI_RELEASE / SNAPMULTI_IMAGE_SET from .env let /version distinguish git tag from Docker tag; empty defaults so dev clones still start.
       - SNAPMULTI_RELEASE=${SNAPMULTI_RELEASE:-}
       - SNAPMULTI_IMAGE_SET=${SNAPMULTI_IMAGE_SET:-}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,6 +270,15 @@ services:
       # SNAPMULTI_VERSION is baked into the image at build time (see
       # Dockerfile.metadata + build-push.yml --build-arg), so /health and
       # /version always report the actually-running code's version.
+      # SNAPMULTI_RELEASE + SNAPMULTI_IMAGE_SET come from .env (written by
+      # deploy.sh from release-manifest.json on every deploy). Lets /version
+      # report the git tag as `current` (e.g. v0.7.8.5) distinct from the
+      # Docker image tag (e.g. 0.7.7) — without those, a script-only release
+      # shows update_available=true on a device that's actually up-to-date.
+      # Empty defaults so the container starts on dev clones / x86 manual
+      # deploys where deploy.sh hasn't written them yet.
+      - SNAPMULTI_RELEASE=${SNAPMULTI_RELEASE:-}
+      - SNAPMULTI_IMAGE_SET=${SNAPMULTI_IMAGE_SET:-}
     volumes:
       - ./artwork:/app/artwork
       # Bind-mount the renderer source so a fix lands without an image
@@ -284,22 +293,6 @@ services:
       # "no snapshot available" failure verdict even when the host-side
       # timer is healthy (issue surfaced after v0.6.4 ship).
       - ./audio:/audio:ro
-      # Release manifest from the FAT32 boot partition (outside overlayroot).
-      # Lets /version distinguish snapmulti_release (git tag — e.g. v0.7.8.5)
-      # from image_set (Docker tag — e.g. 0.7.7) instead of showing the
-      # image tag as `current` and triggering update_available=true on a
-      # device that's actually up-to-date at the script layer.
-      # create_host_path: false — on non-Pi hosts (x86 manual deploy) the
-      # source path doesn't exist; without this Docker would silently
-      # create a directory at /boot/firmware/snapmulti/release-manifest.json/
-      # polluting the host fs. With false: bind skipped if missing, Python
-      # falls back to image_set.
-      - type: bind
-        source: /boot/firmware/snapmulti/release-manifest.json
-        target: /release-manifest.json
-        read_only: true
-        bind:
-          create_host_path: false
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8083/health', timeout=3)"]
       interval: 30s

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2129,22 +2129,15 @@ async def handle_version(request: web.Request) -> web.Response:
     """Version check endpoint — returns current snapmulti_release, image_set, and latest from GitHub."""
     import time
 
-    # Prefer snapmulti_release from the release-manifest (the git tag deployed
-    # at the script layer); fall back to SNAPMULTI_VERSION baked into the
-    # image. Without this, a script-only release leaves `current` reading
-    # image_set and update_available=true on a device that's actually up to date.
-    image_set = os.environ.get("SNAPMULTI_VERSION", "unknown")
-    current = image_set
-    try:
-        with open("/release-manifest.json", encoding="utf-8") as f:
-            manifest = json.load(f)
-        # isinstance guard — a truncated write may leave the root as null/[]/scalar; manifest.get() on a non-dict raises AttributeError outside the (OSError, ValueError) catch. `or ""` handles `"snapmulti_release": null` (None.strip() would crash).
-        if isinstance(manifest, dict):
-            manifest_release = str(manifest.get("snapmulti_release") or "").strip()
-            if manifest_release:
-                current = manifest_release
-    except (OSError, ValueError):
-        pass
+    # SNAPMULTI_RELEASE = git tag from release-manifest.json (deploy.sh writes
+    # it to .env on every deploy); SNAPMULTI_IMAGE_SET = Docker tag (same
+    # source). SNAPMULTI_VERSION is the image-baked version (final fallback
+    # for image_set when .env hasn't been written, e.g. dev clones).
+    snapmulti_release = os.environ.get("SNAPMULTI_RELEASE", "").strip()
+    image_set = os.environ.get("SNAPMULTI_IMAGE_SET", "").strip() or os.environ.get(
+        "SNAPMULTI_VERSION", "unknown"
+    )
+    current = snapmulti_release or image_set
 
     cache_ttl = 86400  # 24 hours
     latest = _latest_version_cache.get("version", "")

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2126,18 +2126,29 @@ _latest_version_cache: dict[str, str | float] = {"version": "", "checked_at": 0.
 
 
 async def handle_version(request: web.Request) -> web.Response:
-    """Version check endpoint — returns current and latest version."""
+    """Version check endpoint — returns current snapmulti_release, image_set, and latest from GitHub."""
     import time
 
-    current = os.environ.get("SNAPMULTI_VERSION", "unknown")
-    cache_ttl = 86400  # 24 hours
+    # Prefer snapmulti_release from the release-manifest (the git tag deployed
+    # at the script layer); fall back to SNAPMULTI_VERSION baked into the
+    # image. Without this, a script-only release leaves `current` reading
+    # image_set and update_available=true on a device that's actually up to date.
+    image_set = os.environ.get("SNAPMULTI_VERSION", "unknown")
+    current = image_set
+    try:
+        with open("/release-manifest.json", encoding="utf-8") as f:
+            manifest = json.load(f)
+        manifest_release = manifest.get("snapmulti_release", "").strip()
+        if manifest_release:
+            current = manifest_release
+    except (OSError, ValueError):
+        pass
 
-    # Check GitHub for latest release (cached)
+    cache_ttl = 86400  # 24 hours
     latest = _latest_version_cache.get("version", "")
     checked_at = float(_latest_version_cache.get("checked_at", 0))
 
     if time.time() - checked_at > cache_ttl:
-        # Claim the slot before await to prevent concurrent API calls (TOCTOU)
         _latest_version_cache["checked_at"] = time.time()
         try:
             import aiohttp as _aiohttp
@@ -2158,7 +2169,7 @@ async def handle_version(request: web.Request) -> web.Response:
                         _latest_version_cache["checked_at"] = 0.0
         except Exception as exc:
             logger.debug("Version check failed: %s", exc)
-            _latest_version_cache["checked_at"] = 0.0  # reset so next call retries
+            _latest_version_cache["checked_at"] = 0.0
 
     current_clean = current.lstrip("v")
     update_available = bool(latest and latest != current_clean)
@@ -2166,6 +2177,7 @@ async def handle_version(request: web.Request) -> web.Response:
     return web.json_response(
         {
             "current": current,
+            "image_set": image_set,
             "latest": latest or current,
             "update_available": update_available,
         },

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2168,7 +2168,9 @@ async def handle_version(request: web.Request) -> web.Response:
                         logger.debug(
                             "GitHub API returned %d for version check", resp.status
                         )
-                        _latest_version_cache["checked_at"] = 0.0  # reset so next call retries
+                        _latest_version_cache["checked_at"] = (
+                            0.0  # reset so next call retries
+                        )
         except Exception as exc:
             logger.debug("Version check failed: %s", exc)
             _latest_version_cache["checked_at"] = 0.0  # reset so next call retries

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2168,10 +2168,10 @@ async def handle_version(request: web.Request) -> web.Response:
                         logger.debug(
                             "GitHub API returned %d for version check", resp.status
                         )
-                        _latest_version_cache["checked_at"] = 0.0
+                        _latest_version_cache["checked_at"] = 0.0  # reset so next call retries
         except Exception as exc:
             logger.debug("Version check failed: %s", exc)
-            _latest_version_cache["checked_at"] = 0.0
+            _latest_version_cache["checked_at"] = 0.0  # reset so next call retries
 
     current_clean = current.lstrip("v")
     update_available = bool(latest and latest != current_clean)

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2138,7 +2138,8 @@ async def handle_version(request: web.Request) -> web.Response:
     try:
         with open("/release-manifest.json", encoding="utf-8") as f:
             manifest = json.load(f)
-        manifest_release = manifest.get("snapmulti_release", "").strip()
+        # `or ""` handles `"snapmulti_release": null` — `.get(key, "")` only falls back on missing keys, not null values, so `None.strip()` would crash.
+        manifest_release = str(manifest.get("snapmulti_release") or "").strip()
         if manifest_release:
             current = manifest_release
     except (OSError, ValueError):
@@ -2149,6 +2150,7 @@ async def handle_version(request: web.Request) -> web.Response:
     checked_at = float(_latest_version_cache.get("checked_at", 0))
 
     if time.time() - checked_at > cache_ttl:
+        # Claim the slot before await to prevent concurrent API calls (TOCTOU).
         _latest_version_cache["checked_at"] = time.time()
         try:
             import aiohttp as _aiohttp

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2169,14 +2169,16 @@ async def handle_version(request: web.Request) -> web.Response:
             logger.debug("Version check failed: %s", exc)
             _latest_version_cache["checked_at"] = 0.0  # reset so next call retries
 
+    # Strip "v" prefix uniformly — `latest` comes from GitHub API already stripped, `current` from .env arrives with the prefix. Returning both un-prefixed avoids mismatched-string rendering on clients displaying both fields side-by-side.
     current_clean = current.lstrip("v")
+    latest_clean = (latest or current).lstrip("v")
     update_available = bool(latest and latest != current_clean)
 
     return web.json_response(
         {
-            "current": current,
+            "current": current_clean,
             "image_set": image_set,
-            "latest": latest or current,
+            "latest": latest_clean,
             "update_available": update_available,
         },
         headers={"Access-Control-Allow-Origin": "*"},

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2129,10 +2129,7 @@ async def handle_version(request: web.Request) -> web.Response:
     """Version check endpoint — returns current snapmulti_release, image_set, and latest from GitHub."""
     import time
 
-    # SNAPMULTI_RELEASE = git tag from release-manifest.json (deploy.sh writes
-    # it to .env on every deploy); SNAPMULTI_IMAGE_SET = Docker tag (same
-    # source). SNAPMULTI_VERSION is the image-baked version (final fallback
-    # for image_set when .env hasn't been written, e.g. dev clones).
+    # SNAPMULTI_RELEASE is the git tag; SNAPMULTI_IMAGE_SET is the Docker tag; falls back to SNAPMULTI_VERSION on dev clones.
     snapmulti_release = os.environ.get("SNAPMULTI_RELEASE", "").strip()
     image_set = os.environ.get("SNAPMULTI_IMAGE_SET", "").strip() or os.environ.get(
         "SNAPMULTI_VERSION", "unknown"

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2169,7 +2169,7 @@ async def handle_version(request: web.Request) -> web.Response:
             logger.debug("Version check failed: %s", exc)
             _latest_version_cache["checked_at"] = 0.0  # reset so next call retries
 
-    # Strip "v" prefix uniformly — `latest` comes from GitHub API already stripped, `current` from .env arrives with the prefix. Returning both un-prefixed avoids mismatched-string rendering on clients displaying both fields side-by-side.
+    # "v" stripped uniformly: current arrives from .env with prefix, latest from GitHub without.
     current_clean = current.lstrip("v")
     latest_clean = (latest or current).lstrip("v")
     update_available = bool(latest and latest != current_clean)

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2138,10 +2138,11 @@ async def handle_version(request: web.Request) -> web.Response:
     try:
         with open("/release-manifest.json", encoding="utf-8") as f:
             manifest = json.load(f)
-        # `or ""` handles `"snapmulti_release": null` — `.get(key, "")` only falls back on missing keys, not null values, so `None.strip()` would crash.
-        manifest_release = str(manifest.get("snapmulti_release") or "").strip()
-        if manifest_release:
-            current = manifest_release
+        # isinstance guard — a truncated write may leave the root as null/[]/scalar; manifest.get() on a non-dict raises AttributeError outside the (OSError, ValueError) catch. `or ""` handles `"snapmulti_release": null` (None.strip() would crash).
+        if isinstance(manifest, dict):
+            manifest_release = str(manifest.get("snapmulti_release") or "").strip()
+            if manifest_release:
+                current = manifest_release
     except (OSError, ValueError):
         pass
 


### PR DESCRIPTION
Fresh-install UX bug: \`/version\` on a v0.7.8.4 device reported \`update_available: true\` because \`current\` was reading SNAPMULTI_VERSION (image tag, 0.7.7) instead of the git tag.

| | |
|--|--|
| **Was** | \`{\"current\": \"v0.7.7\", \"latest\": \"0.7.8.4\", \"update_available\": true}\` |
| **Is** | \`{\"current\": \"v0.7.8.4\", \"image_set\": \"v0.7.7\", \"latest\": \"0.7.8.4\", \"update_available\": false}\` |

Bind-mount \`/boot/firmware/snapmulti/release-manifest.json:/release-manifest.json:ro\` so the metadata container can read \`snapmulti_release\` for \`current\`. \`image_set\` exposed as separate field for transparency.

Live-validated on snapvideo (recreated metadata container, /version now correct).