### PR TITLE
release: v0.7.8.5 — /version fresh-install UX fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.5] — 2026-05-26
+
+> Script-only patch (image_set stays 0.7.7). Sixth consecutive script-only release in five days. Fixes a fresh-install UX bug: `/version` reported `update_available: true` on a freshly-reflashed device because `current` read the Docker image tag instead of the git tag.
+
 ### Fixed
-- **`/version` reports `snapmulti_release` as `current` (not `image_set`) (#483)** — was returning `{"current": "v0.7.7", "update_available": true}` on a freshly reflashed v0.7.8.4 device because `current` read `SNAPMULTI_VERSION` (image tag) instead of the git tag. Now reads `SNAPMULTI_RELEASE` and `SNAPMULTI_IMAGE_SET` env vars (written to `.env` by `deploy.sh` on every deploy from `release-manifest.json`) instead of the image-baked `SNAPMULTI_VERSION`. On dev clones or manual x86 deploys where `deploy.sh` hasn't run, both vars are empty and the service falls back to `SNAPMULTI_VERSION` (same behaviour as before). Adds `image_set` as separate field for transparency.
+- **`/version` reports `snapmulti_release` as `current` (not `image_set`) (#483)** — was returning `{"current": "v0.7.7", "update_available": true}` on a freshly reflashed v0.7.8.4 device because `current` read `SNAPMULTI_VERSION` (image tag) instead of the git tag. Now reads `SNAPMULTI_RELEASE` and `SNAPMULTI_IMAGE_SET` env vars (written to `.env` by `deploy.sh` on every deploy from `release-manifest.json`) instead of the image-baked `SNAPMULTI_VERSION`. On dev clones or manual x86 deploys where `deploy.sh` hasn't run, both vars are empty and the service falls back to `SNAPMULTI_VERSION` (same behaviour as before). Adds `image_set` as separate field for transparency. `current` / `latest` both normalised to v-stripped form for consistent JSON rendering.
 
 ## [0.7.8.4] — 2026-05-25
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.4",
+  "snapmulti_release": "v0.7.8.5",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Script-only patch. Sixth consecutive script-only release. Fixes the /version UX bug from #483 — was reporting `update_available: true` on a device freshly at the latest tag because `current` was reading Docker image tag instead of git tag.

`image_set` stays `0.7.7` (no container changes). Live-validated end-to-end on snapvideo.