### PR TITLE
fix(fb-display): pin localhost in both-mode + roll v0.7.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.6] — 2026-05-26
+
+> Script-only patch (image_set stays 0.7.7). Seventh consecutive script-only release. Fixes a both-mode display bug: fb-display fell back to mDNS discovery → connected to LAN IP instead of loopback, creating a permanent reconnect loop visible in logs. Now pinned to localhost in both-mode (same design choice as snapclient).
+
+### Fixed
+- **fb-display now pins to 127.0.0.1 in both-mode (no mDNS discovery fallback)** — at startup fb-display attempted `ws://127.0.0.1:8082`, failed 3× during the metadata-service startup race, then fell back to mDNS discovery and switched to the LAN IP permanently. Result: continuous discover/reconnect loop in logs + ugly LAN-loopback round-trip for what should be pure localhost. `INSTALL_TYPE=both` env var (written by `client/common/scripts/setup.sh` from `install.conf`) now triggers a both-mode shortcut that keeps retrying loopback indefinitely without discovery — matches `discover-server.sh`'s existing both-mode shortcut for snapclient.
+
 ## [0.7.8.5] — 2026-05-26
 
 > Script-only patch (image_set stays 0.7.7). Sixth consecutive script-only release in five days. Fixes a fresh-install UX bug: `/version` reported `update_available: true` on a freshly-reflashed device because `current` read the Docker image tag instead of the git tag.

--- a/client/common/docker-compose.yml
+++ b/client/common/docker-compose.yml
@@ -166,6 +166,8 @@ services:
       - METADATA_HTTP_PORT=8083
       - CLIENT_ID=${CLIENT_ID:?CLIENT_ID not set in .env}
       - APP_VERSION=${APP_VERSION:-}
+      # Both-mode: pin to 127.0.0.1 and never run mDNS discovery fallback (same design as snapclient).
+      - INSTALL_TYPE=${INSTALL_TYPE:-}
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "pidof python3 || exit 1"]

--- a/client/common/docker/fb-display/fb_display.py
+++ b/client/common/docker/fb-display/fb_display.py
@@ -37,6 +37,9 @@ METADATA_WS_PORT = int(os.environ.get("METADATA_WS_PORT", "8082"))
 METADATA_HTTP_PORT = int(os.environ.get("METADATA_HTTP_PORT", "8083"))
 CLIENT_ID = os.environ.get("CLIENT_ID", "")
 APP_VERSION = os.environ.get("APP_VERSION", "")
+# Both-mode pin: metadata-service is local to this Pi; never run mDNS discovery fallback (matches snapclient's discover-server.sh both-mode shortcut).
+INSTALL_TYPE = os.environ.get("INSTALL_TYPE", "").strip()
+LOCAL_METADATA_PIN = INSTALL_TYPE == "both"
 SPECTRUM_WS_PORT = int(os.environ.get("VISUALIZER_WS_PORT", "8081"))
 FB_DEVICE = "/dev/fb0"
 TARGET_FPS = 20
@@ -91,9 +94,7 @@ async def discover_snapservers(timeout: float = DISCOVERY_TIMEOUT) -> list[str]:
                 None,
             )
             if ipv4_bytes is None:
-                logger.debug(
-                    f"mDNS: skipping {name} (no IPv4 address in addresses)"
-                )
+                logger.debug(f"mDNS: skipping {name} (no IPv4 address in addresses)")
                 return
             ip = socket.inet_ntoa(ipv4_bytes)
             if ip not in servers:
@@ -1445,6 +1446,10 @@ async def metadata_ws_reader() -> None:
 
     On connection failure, retries the current server up to 3 times,
     then discovers alternative servers via mDNS and switches.
+
+    Both-mode exception: metadata-service is local to this Pi (loopback),
+    skip mDNS discovery — keep retrying loopback. Mirrors snapclient's
+    discover-server.sh both-mode shortcut so the topology stays loopback.
     """
     global metadata_host, snapserver_display, metadata_version
     consecutive_failures = 0
@@ -1463,6 +1468,11 @@ async def metadata_ws_reader() -> None:
         except Exception as e:
             consecutive_failures += 1
             logger.debug(f"Metadata WS error (attempt {consecutive_failures}): {e}")
+
+            if LOCAL_METADATA_PIN:
+                # Both-mode: never discover, just keep retrying loopback.
+                await asyncio.sleep(2)
+                continue
 
             if consecutive_failures >= MAX_RECONNECT_BEFORE_DISCOVERY:
                 logger.info("Discovering snapcast servers via mDNS...")

--- a/client/common/scripts/setup.sh
+++ b/client/common/scripts/setup.sh
@@ -1193,6 +1193,16 @@ update_env_var() {
 # discover-server.sh updates this at boot via mDNS.
 update_env_var "SNAPSERVER_HOST" "${snapserver_ip:-}"
 
+# Pass install-time profile to client containers (fb-display reads INSTALL_TYPE to pin localhost in both-mode and skip the mDNS discovery fallback). Read from install.conf since setup.sh is invoked via `bash` and doesn't inherit caller's env.
+_install_type=""
+for _conf in /boot/firmware/snapmulti/install.conf /boot/snapmulti/install.conf "$INSTALL_DIR/install.conf"; do
+    if [[ -f "$_conf" ]]; then
+        _install_type=$(grep -m1 '^INSTALL_TYPE=' "$_conf" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)
+        [[ -n "$_install_type" ]] && break
+    fi
+done
+update_env_var "INSTALL_TYPE" "$_install_type"
+
 # Update all environment variables
 declare -A env_vars=(
     ["CLIENT_ID"]="$CLIENT_ID"

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.5",
+  "snapmulti_release": "v0.7.8.6",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Fixes both-mode display bug: fb-display fell back to mDNS → switched permanently to LAN IP → continuous discover/reconnect loop.

| | |
|--|--|
| Was | startup race → 3× failures on 127.0.0.1 → mDNS discovery → switched to LAN IP forever |
| Is | INSTALL_TYPE=both pins loopback, never discovers |

Same design as snapclient's `discover-server.sh` both-mode shortcut. Live-validated on snapvideo (recreate fb-display → ws://127.0.0.1:8082 first try, zero discovery events).

Rolls into v0.7.8.6 script-only (image_set 0.7.7).