### PR TITLE
chore(release): roll [Unreleased] into v0.7.8.9 (audit sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.9] — 2026-05-26
+
+> Script-only patch (image_set stays 0.7.7). Pre-launch audit sweep — 5 findings (#489).
+
 ### Fixed
-- **AUDIO_HAT / AUDIO_INTERNAL_OUTPUT propagation** — The prepare-sd menu wrote `AUDIO_HAT` (e.g. `hifiberry-dac`, `internal-audio`) and `AUDIO_INTERNAL_OUTPUT` (`hdmi` / `jack`) to `install.conf`, but `firstboot.sh` never promoted them into `snapclient.conf`. Result: a user's explicit menu choice was silently dropped and `setup.sh` always fell back to autodetect. Now mirrored to `snapclient.conf` alongside `DISPLAY_MODE` / `SNAPSERVER_HOST` via a shared `_promote_to_conf` helper.
-- **`setup-zero2w.sh` honours operator HAT choice** — The script's `--help` advertised `[config_file]` as a positional arg but the parser dropped it on the floor; the script also always called `detect_hat` and ignored any explicit `AUDIO_HAT`. Now parses the positional arg with the same validation as `setup.sh` (no path traversal, charset whitelist), sources it, and skips autodetect when `AUDIO_HAT != auto`. Pi Zero 2W native installs now respect the prepare-sd menu the same way Docker-based clients do.
-- **`setup-zero2w.sh` install role + apt upgrade** — Called `install_dependencies` without exporting `INSTALL_ROLE`, falling back to `both` and pulling server-side packages (sysstat collector enabled, etc.) on a 512 MB Pi Zero where overlay tmpfs already sits at 71 % fresh. Also let `apt-get upgrade -y` run unbounded on first boot (SD-wear-heavy, long). Now pins `INSTALL_ROLE=client` and defaults `SKIP_UPGRADE=true` before the shared deps installer.
-- **`boot-tune.sh` MPD restart scope + format mismatch** — Restart-on-empty-library check ran for every install profile (streaming-only, local USB, NFS/SMB) and only matched `*.mp3` / `*.flac`. Libraries that were ogg / m4a / opus / wav / aac / wma-only triggered a bogus MPD restart and "library EMPTY" WARN line on every boot; streaming-only installs got the same treatment despite having no library on purpose. Now gated to NFS/SMB mounts (the only path that races docker startup) and matches the full format set from `mpd-entrypoint.sh` (mp3 flac m4a ogg wav aac opus wma).
-- **`snapmulti-boot-tune.service` ordering** — Unit had only `After=docker.service`; both `systemctl restart containerd` (Leases plugin self-heal) and `docker compose restart mpd` (post-mount race) inside the script could disrupt an already-starting audio stack. Added `Before=snapmulti-server.service snapclient.service` to guarantee the disruptive actions complete before the audio units come up.
+- **AUDIO_HAT / AUDIO_INTERNAL_OUTPUT propagation (#489)** — `firstboot.sh` promoted only `DISPLAY_MODE` / `SNAPSERVER_HOST` to `snapclient.conf`; operator HAT choice from prepare-sd menu was silently dropped. Now mirrored via shared `_promote_to_conf` helper.
+- **`setup-zero2w.sh` honours operator HAT choice (#489)** — `--help` advertised `[config_file]` but parser dropped the positional; `detect_hat` always ran. Now parses + sources with same validation as `setup.sh`, skips autodetect when `AUDIO_HAT != auto`.
+- **`setup-zero2w.sh` install role + apt upgrade (#489)** — Pinned `INSTALL_ROLE=client` and `SKIP_UPGRADE=true` before shared deps installer. Stops sysstat collector enable on Pi Zero (overlay tmpfs already at 71 %) and unbounded `apt-get upgrade -y` on first boot.
+- **`boot-tune.sh` MPD restart scope + format mismatch (#489)** — Gated restart-on-empty-library to NFS/SMB mounts only (streaming-only / USB don't race docker start). Format match expanded to mirror `mpd-entrypoint.sh` (mp3 flac m4a ogg wav aac opus wma).
+- **`snapmulti-boot-tune.service` ordering (#489)** — Added `Before=snapmulti-server.service snapclient.service` so containerd self-heal and MPD restart can't disrupt an already-starting audio stack.
+- **`test_firstboot_reboot.sh` padding fragility (#489)** — Switched URL assertions from `grep -qF` with fixed spaces to `grep -qE` with `[[:space:]]+`. Survives banner re-layout (PR #488 added "Start here" landing-page line that shifted columns).
 
 > Script-only patch (image_set stays 0.7.7). Ninth consecutive script-only release. UX polish from pre-launch endpoint review on snapvideo.
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.8",
+  "snapmulti_release": "v0.7.8.9",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Script-only release containing PR #489 (5 audit findings: AUDIO_HAT propagation, zero2w deps, boot-tune MPD scope + systemd ordering).

`image_set` stays at `0.7.7`. Manifest gate is no-op (validates `:0.7.7` exists, already live since v0.7.8.5).