### PR TITLE
fix(release): consolidate release identity to single SSOT (release-manifest.json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Release identity SSOT consolidated to `release-manifest.json`** — `install.conf` no longer carries `SNAPMULTI_RELEASE` / `SNAPMULTI_IMAGE_SET`. They were duplicating the manifest and could shadow it if `prepare-sd.sh` ran twice across a tag bump (observed: snapvideo stuck on v0.7.8.8 install.conf while SD release-manifest.json said v0.7.8.9). `IMAGE_TAG` remains the legitimate operator override channel (pin to `:dev` etc.). `prepare-sd.sh`, `prepare-sd.ps1` and `firstboot.sh` updated.
+
 ## [0.7.8.9] — 2026-05-26
 
 > Script-only patch (image_set stays 0.7.7). Pre-launch audit sweep — 5 findings (#489).

--- a/install.conf.template
+++ b/install.conf.template
@@ -1,28 +1,10 @@
 # snapMULTI Installation Configuration
 # Written by prepare-sd.sh on first use.
 #
-# Release identity — three machine-readable fields consumed by
-# firstboot, deploy, setup, and the smoke check (precedence chains
-# documented in scripts/common/release-manifest.sh):
-#
-#   SNAPMULTI_RELEASE   — git tag of the release this SD was prepared
-#                          from (e.g. v0.7.7). Surfaced by smoke and
-#                          diagnostic for traceability.
-#   SNAPMULTI_IMAGE_SET — Docker image tag this release pins to (e.g.
-#                          0.7.7). Decoupled from SNAPMULTI_RELEASE so
-#                          a script-only release (CHANGELOG, docs,
-#                          installer scripts) does not require a fresh
-#                          image rebuild — it ships the previously
-#                          published image set.
-#   IMAGE_TAG           — operator override. Takes precedence over
-#                          SNAPMULTI_IMAGE_SET. Set to 'dev' for
-#                          development builds, leave blank to use
-#                          SNAPMULTI_IMAGE_SET, or pin to an arbitrary
-#                          Docker tag.
-#
-# Leave empty for prepare-sd.sh to populate from release-manifest.json.
-SNAPMULTI_RELEASE=
-SNAPMULTI_IMAGE_SET=
+# Release identity lives in release-manifest.json on the SD card (single
+# SSOT). Setting SNAPMULTI_RELEASE / SNAPMULTI_IMAGE_SET here has no
+# effect — they were removed from this template to avoid silent no-ops.
+# IMAGE_TAG below is the one legitimate operator override.
 #
 # INSTALL_TYPE controls what gets installed on first boot:
 #   client  -- Audio Player (snapclient, optional display)

--- a/scripts/common/release-manifest.sh
+++ b/scripts/common/release-manifest.sh
@@ -16,16 +16,17 @@
 #
 # Precedence chains — the SINGLE source of truth for every consumer:
 #
-#   (A) IMAGE_TAG     = install.conf IMAGE_TAG
-#                     > install.conf SNAPMULTI_IMAGE_SET
+#   (A) IMAGE_TAG     = install.conf IMAGE_TAG (operator override)
 #                     > manifest image_set
 #                     > "latest"
-#   (B) SNAPMULTI_RELEASE   = install.conf SNAPMULTI_RELEASE
-#                           > manifest snapmulti_release
+#   (B) SNAPMULTI_RELEASE   = manifest snapmulti_release
 #                           > ""
-#   (C) SNAPMULTI_IMAGE_SET = install.conf SNAPMULTI_IMAGE_SET
-#                           > manifest image_set
+#   (C) SNAPMULTI_IMAGE_SET = manifest image_set
 #                           > ""
+#
+# Chains B/C have no install.conf step (since fix/release-identity-ssot):
+# release-manifest.json on the SD is the single SSOT. Only IMAGE_TAG keeps
+# an install.conf override channel for pinning to :dev / arbitrary tags.
 #
 # Every consumer (prepare-sd, firstboot, deploy, setup) implements
 # precedence (A) via derive_image_tag().

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -117,34 +117,28 @@ if [[ -f "$SNAP_BOOT/install.conf" ]]; then
     unset local_val
 fi
 
-# ── Release identity (manifest + install.conf precedence chains) ───
-# Precedence — see scripts/common/release-manifest.sh header for the
-# formal chain definition:
-#   (A) IMAGE_TAG           = install.conf IMAGE_TAG
-#                           > install.conf SNAPMULTI_IMAGE_SET
-#                           > manifest image_set > 'latest'
-#   (B) SNAPMULTI_RELEASE   = install.conf SNAPMULTI_RELEASE
-#                           > manifest snapmulti_release > ''
-#   (C) SNAPMULTI_IMAGE_SET = install.conf SNAPMULTI_IMAGE_SET
-#                           > manifest image_set > ''
+# ── Release identity (release-manifest.json on SD is the single SSOT) ──
+# release-manifest.json is the only source of SNAPMULTI_RELEASE and
+# SNAPMULTI_IMAGE_SET — install.conf no longer carries them (operator
+# choices live there; release identity follows the staged manifest).
+# IMAGE_TAG is the one legitimate operator override (pin to :dev or a
+# specific tag); when unset, derive_image_tag falls back to manifest
+# image_set automatically.
 #
 # Guarded source: a custom-built SD without the helper falls through to
-# the legacy IMAGE_TAG path (install.conf > 'latest'), exactly today's
-# behaviour. The inline fallback covers test rigs that stage firstboot
-# without the common/ tree.
+# the legacy IMAGE_TAG path (install.conf > 'latest'). The inline fallback
+# covers test rigs that stage firstboot without the common/ tree.
 SNAPMULTI_RELEASE=""
 SNAPMULTI_IMAGE_SET=""
 if [[ -f "$SNAP_BOOT/common/release-manifest.sh" ]]; then
     # shellcheck source=common/release-manifest.sh
     source "$SNAP_BOOT/common/release-manifest.sh"
     parse_release_manifest "$SNAP_BOOT/release-manifest.json"
-    _explicit_release=$(read_install_conf_key "$SNAP_BOOT/install.conf" SNAPMULTI_RELEASE)
-    _explicit_image_set=$(read_install_conf_key "$SNAP_BOOT/install.conf" SNAPMULTI_IMAGE_SET)
     _explicit_image_tag=$(read_install_conf_key "$SNAP_BOOT/install.conf" IMAGE_TAG)
-    SNAPMULTI_RELEASE="${_explicit_release:-$MANIFEST_RELEASE}"
-    SNAPMULTI_IMAGE_SET="${_explicit_image_set:-$MANIFEST_IMAGE_SET}"
+    SNAPMULTI_RELEASE="$MANIFEST_RELEASE"
+    SNAPMULTI_IMAGE_SET="$MANIFEST_IMAGE_SET"
     IMAGE_TAG=$(derive_image_tag "$_explicit_image_tag" "$SNAPMULTI_IMAGE_SET")
-    unset _explicit_release _explicit_image_set _explicit_image_tag
+    unset _explicit_image_tag
 else
     # Inline fallback — legacy IMAGE_TAG path only.
     if [[ -f "$SNAP_BOOT/install.conf" ]]; then

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -860,9 +860,8 @@ SMB_SHARE=$SmbShare
 # Audio output (client/both only — server installs ignore these)
 AUDIO_HAT=$AudioHat
 AUDIO_INTERNAL_OUTPUT=$AudioInternalOutput
-# Release identity (machine-readable, consumed by firstboot + deploy + smoke)
-SNAPMULTI_RELEASE=$ManifestRelease
-SNAPMULTI_IMAGE_SET=$ManifestImageSet
+# Release identity comes from release-manifest.json on the SD (single SSOT,
+# staged below). Do not duplicate SNAPMULTI_RELEASE / SNAPMULTI_IMAGE_SET here.
 # Advanced options
 # (PowerShell prep currently uses defaults — the bash side has an
 # interactive Advanced menu that lets the user toggle these. Parity

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -752,17 +752,16 @@ SMB_SHARE=$SMB_SHARE
 #   jack → bind to "Headphones" card (Pi 3/4 only — Pi 5 falls back to HDMI)
 AUDIO_HAT=$AUDIO_HAT
 AUDIO_INTERNAL_OUTPUT=$AUDIO_INTERNAL_OUTPUT
-# Release identity (machine-readable, consumed by firstboot + deploy + smoke)
-#   SNAPMULTI_RELEASE  — git tag of the release this SD was prepared from
-#   SNAPMULTI_IMAGE_SET — Docker image tag (image_set in release-manifest.json)
-#   IMAGE_TAG          — operator override, takes precedence over the
-#                         manifest image_set (see precedence chain (A) in
-#                         scripts/common/release-manifest.sh)
-SNAPMULTI_RELEASE=$MANIFEST_RELEASE
-SNAPMULTI_IMAGE_SET=$MANIFEST_IMAGE_SET
+# Release identity comes from release-manifest.json on the SD (single SSOT,
+# staged below). SNAPMULTI_RELEASE / SNAPMULTI_IMAGE_SET are deliberately NOT
+# written here — duplicating them in install.conf shadows the manifest and
+# diverges if prepare-sd.sh runs twice across a tag bump.
 # Advanced options
 ENABLE_READONLY=$ADV_READONLY
 SKIP_UPGRADE=$ADV_SKIP_UPGRADE
+# IMAGE_TAG is a legitimate operator override (pin to :dev or a specific tag
+# while keeping the manifest pinned to a different version). When unset, the
+# precedence chain falls back to manifest image_set automatically.
 IMAGE_TAG=$ADV_IMAGE_TAG
 VERBOSE_INSTALL=$ADV_VERBOSE_INSTALL
 TEST_TONE=true
@@ -1070,8 +1069,8 @@ esac
 
 echo "  install.conf -> INSTALL_TYPE=$(grep '^INSTALL_TYPE=' "$DEST/install.conf" | cut -d= -f2)"
 echo "  install.conf -> MUSIC_SOURCE=$(grep '^MUSIC_SOURCE=' "$DEST/install.conf" | cut -d= -f2)"
-echo "  install.conf -> SNAPMULTI_RELEASE=$(grep '^SNAPMULTI_RELEASE=' "$DEST/install.conf" | cut -d= -f2)"
-echo "  install.conf -> SNAPMULTI_IMAGE_SET=$(grep '^SNAPMULTI_IMAGE_SET=' "$DEST/install.conf" | cut -d= -f2)"
+echo "  release-manifest -> SNAPMULTI_RELEASE=$MANIFEST_RELEASE (SSOT on SD)"
+echo "  release-manifest -> SNAPMULTI_IMAGE_SET=$MANIFEST_IMAGE_SET (SSOT on SD)"
 echo "  install.conf -> ENABLE_READONLY=$(grep '^ENABLE_READONLY=' "$DEST/install.conf" | cut -d= -f2)"
 echo "  install.conf -> SKIP_UPGRADE=$(grep '^SKIP_UPGRADE=' "$DEST/install.conf" | cut -d= -f2)"
 echo "  install.conf -> IMAGE_TAG=$(grep '^IMAGE_TAG=' "$DEST/install.conf" | cut -d= -f2)"

--- a/tests/test_firstboot_image_tag_derivation.sh
+++ b/tests/test_firstboot_image_tag_derivation.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Regression test for firstboot.sh's release-identity precedence chains.
-# 6 scenarios from the iter-2 plan that protect the BLOCKER fix
-# (install.conf SNAPMULTI_IMAGE_SET in the IMAGE_TAG chain) and the
-# critical backward-compat invariant (legacy IMAGE_TAG-only installs
-# continue to work unchanged).
+# Regression test for firstboot.sh's release-identity precedence.
+#
+# As of fix/release-identity-ssot, release-manifest.json on the SD is the
+# only source for SNAPMULTI_RELEASE + SNAPMULTI_IMAGE_SET. install.conf no
+# longer carries those keys. IMAGE_TAG keeps install.conf as its operator-
+# override channel (e.g. pin to :dev while the manifest stays on a release
+# tag); when unset, it falls back to manifest image_set, then 'latest'.
 #
 # This test exercises the parser library directly with synthetic
 # install.conf + release-manifest.json combinations, then asserts the
@@ -37,16 +39,16 @@ assert() {
 }
 
 # Reproduce firstboot.sh's chain logic in a single function so test
-# cases stay one-liner / readable. Mirrors firstboot.sh:s7 exactly.
+# cases stay one-liner / readable. Mirrors firstboot.sh post fix/release-
+# identity-ssot: release identity from manifest only; install.conf carries
+# only the IMAGE_TAG operator override.
 derive_for_test() {
     local boot="$1"
     parse_release_manifest "$boot/release-manifest.json"
-    local _explicit_release _explicit_image_set _explicit_image_tag
-    _explicit_release=$(read_install_conf_key "$boot/install.conf" SNAPMULTI_RELEASE)
-    _explicit_image_set=$(read_install_conf_key "$boot/install.conf" SNAPMULTI_IMAGE_SET)
+    local _explicit_image_tag
     _explicit_image_tag=$(read_install_conf_key "$boot/install.conf" IMAGE_TAG)
-    SNAPMULTI_RELEASE="${_explicit_release:-$MANIFEST_RELEASE}"
-    SNAPMULTI_IMAGE_SET="${_explicit_image_set:-$MANIFEST_IMAGE_SET}"
+    SNAPMULTI_RELEASE="$MANIFEST_RELEASE"
+    SNAPMULTI_IMAGE_SET="$MANIFEST_IMAGE_SET"
     IMAGE_TAG=$(derive_image_tag "$_explicit_image_tag" "$SNAPMULTI_IMAGE_SET")
 }
 
@@ -72,28 +74,28 @@ EOF
 derive_for_test "$TMP/b"
 assert "[[ '$IMAGE_TAG' == 'latest' ]]" "(b) legacy IMAGE_TAG=latest only → IMAGE_TAG=latest"
 
-# Case (c) — BLOCKER FIX: install.conf SNAPMULTI_IMAGE_SET=0.7.5,
-# no IMAGE_TAG, no manifest → IMAGE_TAG=0.7.5 (the new chain (A) step)
+# Case (c) — install.conf SNAPMULTI_IMAGE_SET is now IGNORED (key dropped
+# from install.conf SSOT cleanup). With no manifest, IMAGE_TAG falls back
+# to 'latest'.
 mkdir -p "$TMP/c"
 cat > "$TMP/c/install.conf" <<'EOF'
 INSTALL_TYPE=server
 SNAPMULTI_IMAGE_SET=0.7.5
 EOF
 derive_for_test "$TMP/c"
-assert "[[ '$IMAGE_TAG' == '0.7.5' ]]" "(c) BLOCKER: install.conf SNAPMULTI_IMAGE_SET=0.7.5 → IMAGE_TAG=0.7.5"
-assert "[[ '$SNAPMULTI_IMAGE_SET' == '0.7.5' ]]" "(c) install.conf SNAPMULTI_IMAGE_SET propagated"
+assert "[[ '$IMAGE_TAG' == 'latest' ]]" "(c) install.conf SNAPMULTI_IMAGE_SET ignored → IMAGE_TAG=latest (no manifest)"
+assert "[[ -z '$SNAPMULTI_IMAGE_SET' ]]" "(c) install.conf SNAPMULTI_IMAGE_SET ignored → empty (manifest is SSOT)"
 
-# Case (d): install.conf SNAPMULTI_IMAGE_SET=0.7.5 + IMAGE_TAG=dev
-# → IMAGE_TAG=dev (operator override wins over image_set)
+# Case (d): install.conf IMAGE_TAG=dev — operator override wins. SNAPMULTI_
+# IMAGE_SET still from manifest (here absent → empty).
 mkdir -p "$TMP/d"
 cat > "$TMP/d/install.conf" <<'EOF'
 INSTALL_TYPE=server
-SNAPMULTI_IMAGE_SET=0.7.5
 IMAGE_TAG=dev
 EOF
 derive_for_test "$TMP/d"
-assert "[[ '$IMAGE_TAG' == 'dev' ]]" "(d) IMAGE_TAG=dev wins over SNAPMULTI_IMAGE_SET=0.7.5"
-assert "[[ '$SNAPMULTI_IMAGE_SET' == '0.7.5' ]]" "(d) SNAPMULTI_IMAGE_SET=0.7.5 still surfaced separately"
+assert "[[ '$IMAGE_TAG' == 'dev' ]]" "(d) IMAGE_TAG=dev (operator override) preserved"
+assert "[[ -z '$SNAPMULTI_IMAGE_SET' ]]" "(d) no manifest → SNAPMULTI_IMAGE_SET empty"
 
 # Case (e): install.conf absent, manifest absent → IMAGE_TAG=latest
 mkdir -p "$TMP/e"
@@ -111,11 +113,12 @@ cat > "$TMP/f/release-manifest.json" <<'EOF'
 }
 EOF
 derive_for_test "$TMP/f"
-assert "[[ '$IMAGE_TAG' == '0.7.7' ]]" "(f) manifest only → IMAGE_TAG=0.7.7 (chain A fallback)"
+assert "[[ '$IMAGE_TAG' == '0.7.7' ]]" "(f) manifest only → IMAGE_TAG=0.7.7"
 assert "[[ '$SNAPMULTI_RELEASE' == 'v0.7.7' ]]" "(f) manifest only → SNAPMULTI_RELEASE=v0.7.7"
 assert "[[ '$SNAPMULTI_IMAGE_SET' == '0.7.7' ]]" "(f) manifest only → SNAPMULTI_IMAGE_SET=0.7.7"
 
-# Bonus: install.conf SNAPMULTI_RELEASE override beats manifest
+# Case (g) — manifest is the SSOT; install.conf SNAPMULTI_RELEASE is NO
+# LONGER a shadow override. Manifest always wins.
 mkdir -p "$TMP/g"
 cat > "$TMP/g/install.conf" <<'EOF'
 INSTALL_TYPE=server
@@ -129,8 +132,27 @@ cat > "$TMP/g/release-manifest.json" <<'EOF'
 }
 EOF
 derive_for_test "$TMP/g"
-assert "[[ '$SNAPMULTI_RELEASE' == 'v0.8.0-pre' ]]" "(g) install.conf SNAPMULTI_RELEASE overrides manifest (chain B)"
-assert "[[ '$SNAPMULTI_IMAGE_SET' == '0.7.7' ]]" "(g) but SNAPMULTI_IMAGE_SET still from manifest (chain C separate)"
+assert "[[ '$SNAPMULTI_RELEASE' == 'v0.7.7' ]]" "(g) manifest wins — install.conf SNAPMULTI_RELEASE ignored (SSOT)"
+assert "[[ '$SNAPMULTI_IMAGE_SET' == '0.7.7' ]]" "(g) manifest wins for SNAPMULTI_IMAGE_SET too"
+
+# Case (h): IMAGE_TAG override on top of manifest — operator pins to :dev
+# while server keeps the manifest release identity. Common workflow.
+mkdir -p "$TMP/h"
+cat > "$TMP/h/install.conf" <<'EOF'
+INSTALL_TYPE=server
+IMAGE_TAG=dev
+EOF
+cat > "$TMP/h/release-manifest.json" <<'EOF'
+{
+  "snapmulti_release": "v0.7.9",
+  "image_set": "0.7.9",
+  "requires_image_rebuild": false
+}
+EOF
+derive_for_test "$TMP/h"
+assert "[[ '$IMAGE_TAG' == 'dev' ]]" "(h) IMAGE_TAG=dev override preserved with manifest present"
+assert "[[ '$SNAPMULTI_RELEASE' == 'v0.7.9' ]]" "(h) SNAPMULTI_RELEASE still from manifest"
+assert "[[ '$SNAPMULTI_IMAGE_SET' == '0.7.9' ]]" "(h) SNAPMULTI_IMAGE_SET still from manifest"
 
 echo
 echo "## Summary"

--- a/tests/test_prepare_sd_manifest.sh
+++ b/tests/test_prepare_sd_manifest.sh
@@ -3,14 +3,15 @@
 #
 # We deliberately do NOT run prepare-sd.sh end-to-end (it needs root,
 # a real boot partition, cloud-init patching, etc.). Instead we grep
-# the script for the wiring contracts the iter-2 plan locks in:
+# the script for the wiring contracts:
 #   - manifest helper sourced BEFORE ADV_IMAGE_TAG init
 #   - parse_release_manifest invoked with the canonical path
 #   - ADV_IMAGE_TAG default = $MANIFEST_IMAGE_SET (with 'latest' fallback)
-#   - install.conf heredoc emits SNAPMULTI_RELEASE + SNAPMULTI_IMAGE_SET
+#   - install.conf heredoc does NOT emit SNAPMULTI_RELEASE / SNAPMULTI_IMAGE_SET
+#     (SSOT is release-manifest.json on the SD — see fix/release-identity-ssot)
 #   - release-manifest.json staged onto SD (guarded copy)
 #   - verify-list includes release-manifest.json + common/release-manifest.sh
-#   - summary print includes the 2 new keys
+#   - summary print sources release identity from manifest, not install.conf
 
 set -euo pipefail
 
@@ -51,16 +52,22 @@ assert "(( ${src_line:-0} < ${init_line:-0} ))" \
 assert "grep -qE 'ADV_IMAGE_TAG=\"\\\$\\{MANIFEST_IMAGE_SET:-latest\\}\"' '$PREPARE'" \
     "ADV_IMAGE_TAG default = manifest image_set (fallback 'latest')"
 
-assert "grep -q 'SNAPMULTI_RELEASE=\$MANIFEST_RELEASE' '$PREPARE'" \
-    "install.conf heredoc emits SNAPMULTI_RELEASE=\$MANIFEST_RELEASE"
+# SSOT contract — install.conf heredoc MUST NOT carry the manifest values.
+# Duplicating them would let a stale install.conf shadow a fresh manifest
+# the next time prepare-sd.sh runs against the same SD (the bug fix/release-
+# identity-ssot closes). The heredoc lives between the install.conf opener
+# and its `EOF` terminator; we scope the search to that block.
+heredoc_block=$(awk '/cat > "\$DEST\/install\.conf" <<EOF/,/^EOF$/' "$PREPARE")
+assert "! grep -q '^SNAPMULTI_RELEASE=' <<<\"\$heredoc_block\"" \
+    "install.conf heredoc does NOT emit SNAPMULTI_RELEASE (SSOT is release-manifest.json)"
 
-assert "grep -q 'SNAPMULTI_IMAGE_SET=\$MANIFEST_IMAGE_SET' '$PREPARE'" \
-    "install.conf heredoc emits SNAPMULTI_IMAGE_SET=\$MANIFEST_IMAGE_SET"
+assert "! grep -q '^SNAPMULTI_IMAGE_SET=' <<<\"\$heredoc_block\"" \
+    "install.conf heredoc does NOT emit SNAPMULTI_IMAGE_SET (SSOT is release-manifest.json)"
 
 assert "grep -qE 'cp .*release-manifest\.json.*DEST' '$PREPARE'" \
     "release-manifest.json staged onto SD"
 
-# Guarded copy — the iter-2 codex major: set -e tolerance when manifest absent
+# Guarded copy — set -e tolerance when manifest absent
 assert "grep -B1 'cp .*release-manifest\.json.*DEST' '$PREPARE' | grep -qE '\\[\\[ -f .*release-manifest\.json' " \
     "release-manifest.json copy guarded by [[ -f ... ]]"
 
@@ -70,15 +77,11 @@ assert "grep -q 'release-manifest.json' '$PREPARE'" \
 assert "grep -q 'common/release-manifest.sh' '$PREPARE'" \
     "verify-list mentions common/release-manifest.sh"
 
-assert "grep -q '^SNAPMULTI_RELEASE=' '$PREPARE'" \
-    "summary print covers SNAPMULTI_RELEASE (grep on install.conf inside echo)" \
-    || true   # weak — the regex above already validates the heredoc
+assert "grep -qE 'release-manifest -> SNAPMULTI_RELEASE=' '$PREPARE'" \
+    "summary print sources SNAPMULTI_RELEASE from manifest (not install.conf)"
 
-assert "grep -qE 'install.conf -> SNAPMULTI_RELEASE=' '$PREPARE'" \
-    "summary print includes SNAPMULTI_RELEASE line"
-
-assert "grep -qE 'install.conf -> SNAPMULTI_IMAGE_SET=' '$PREPARE'" \
-    "summary print includes SNAPMULTI_IMAGE_SET line"
+assert "grep -qE 'release-manifest -> SNAPMULTI_IMAGE_SET=' '$PREPARE'" \
+    "summary print sources SNAPMULTI_IMAGE_SET from manifest (not install.conf)"
 
 echo
 echo "## Summary"

--- a/tests/test_prepare_sd_ps1_static.sh
+++ b/tests/test_prepare_sd_ps1_static.sh
@@ -59,10 +59,16 @@ assert_contains "$content" "Get-Content -Raw -Path \$ManifestPath" \
     "release-manifest.json read with Get-Content -Raw"
 assert_contains "$content" "ConvertFrom-Json" \
     "release-manifest.json parsed via ConvertFrom-Json"
-assert_contains "$content" "SNAPMULTI_RELEASE=\$ManifestRelease" \
-    "install.conf emits SNAPMULTI_RELEASE from manifest"
-assert_contains "$content" "SNAPMULTI_IMAGE_SET=\$ManifestImageSet" \
-    "install.conf emits SNAPMULTI_IMAGE_SET from manifest"
+if grep -qE '^\s*SNAPMULTI_RELEASE=\$ManifestRelease' <<<"$content"; then
+    fail=$((fail+1)); echo "FAIL: install.conf must NOT emit SNAPMULTI_RELEASE (SSOT is release-manifest.json)"
+else
+    echo "PASS: install.conf does NOT emit SNAPMULTI_RELEASE (SSOT is release-manifest.json)"
+fi
+if grep -qE '^\s*SNAPMULTI_IMAGE_SET=\$ManifestImageSet' <<<"$content"; then
+    fail=$((fail+1)); echo "FAIL: install.conf must NOT emit SNAPMULTI_IMAGE_SET (SSOT is release-manifest.json)"
+else
+    echo "PASS: install.conf does NOT emit SNAPMULTI_IMAGE_SET (SSOT is release-manifest.json)"
+fi
 assert_contains "$content" "Copy-Item \$ManifestPath -Destination \$Dest" \
     "release-manifest.json staged to SD destination"
 assert_contains "$content" "'release-manifest.json'" \

--- a/tests/test_prepare_sd_ps1_static.sh
+++ b/tests/test_prepare_sd_ps1_static.sh
@@ -62,12 +62,12 @@ assert_contains "$content" "ConvertFrom-Json" \
 if grep -qE '^\s*SNAPMULTI_RELEASE=\$ManifestRelease' <<<"$content"; then
     fail=$((fail+1)); echo "FAIL: install.conf must NOT emit SNAPMULTI_RELEASE (SSOT is release-manifest.json)"
 else
-    echo "PASS: install.conf does NOT emit SNAPMULTI_RELEASE (SSOT is release-manifest.json)"
+    pass=$((pass+1)); echo "PASS: install.conf does NOT emit SNAPMULTI_RELEASE (SSOT is release-manifest.json)"
 fi
 if grep -qE '^\s*SNAPMULTI_IMAGE_SET=\$ManifestImageSet' <<<"$content"; then
     fail=$((fail+1)); echo "FAIL: install.conf must NOT emit SNAPMULTI_IMAGE_SET (SSOT is release-manifest.json)"
 else
-    echo "PASS: install.conf does NOT emit SNAPMULTI_IMAGE_SET (SSOT is release-manifest.json)"
+    pass=$((pass+1)); echo "PASS: install.conf does NOT emit SNAPMULTI_IMAGE_SET (SSOT is release-manifest.json)"
 fi
 assert_contains "$content" "Copy-Item \$ManifestPath -Destination \$Dest" \
     "release-manifest.json staged to SD destination"


### PR DESCRIPTION
**Bug osservato su snapvideo**: install.conf SNAPMULTI_RELEASE=v0.7.8.8 vs release-manifest.json sulla SD = v0.7.8.9. La duplicazione lascia install.conf shadow il manifest quando prepare-sd.sh gira due volte cross tag-bump.

**Fix**: `release-manifest.json` sulla SD = unica SSOT per release identity. `install.conf` perde `SNAPMULTI_RELEASE` + `SNAPMULTI_IMAGE_SET`. `IMAGE_TAG` resta come operator-override genuino.

| File | Cambio |
|------|--------|
| `scripts/prepare-sd.sh` | heredoc install.conf: rimossi i 2 keys, summary cita "release-manifest" come source |
| `scripts/prepare-sd.ps1` | sync |
| `scripts/firstboot.sh` | precedence chain: legge solo manifest per RELEASE/IMAGE_SET, install.conf solo per IMAGE_TAG |
| `tests/test_prepare_sd_manifest.sh` | inverte assert: heredoc must NOT emit keys |
| `tests/test_prepare_sd_ps1_static.sh` | idem ps1 |
| `tests/test_firstboot_image_tag_derivation.sh` | cases c/d/g aggiornati, h aggiunto (IMAGE_TAG override + manifest) |

### Validation
- 13/13 PASS test_prepare_sd_manifest
- 23/23 PASS test_prepare_sd_ps1_static
- 18/18 PASS test_firstboot_image_tag_derivation
- Deferred a release-gate: reflash device + verify install.conf su SD non contiene i 2 keys