### PR TITLE
chore(release): roll [Unreleased] into v0.7.8.11 (CAKE NM + pcp + metadata lazy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.11] — 2026-05-26
+
+> Script-only patch (image_set stays 0.7.7). CAKE QoS NM dispatcher fix + pcp purge + metadata lazy-init (#493).
+
 ### Fixed
-- **Metadata service `EXTERNAL_HOST` lazy-evaluated** — `metadata-service.py` ran `_resolve_external_host()` at module-import time, doing `socket.getfqdn()` + `socket.gethostbyname()` synchronously. On macOS dev hosts with slow reverse-DNS (observed: 30 s hang on `jupiter.fritz.box`) every `pytest tests/test_metadata_service.py` import blocked for 30 s, making the pre-push hook unusable. Now `get_external_host()` caches lazily on first call; runtime Pi hosts still resolve sub-millisecond.
-- **CAKE QoS hook moved to NetworkManager dispatcher (latent since PR #144)** — Pi OS runs NetworkManager, not systemd-networkd, so `/etc/networkd-dispatcher/routable.d/50-cake-qos` never fired. Default qdisc stayed `fq_codel` on every boot — Snapcast worked but lost DSCP-aware prioritization (Voice tin). Hook moved to `/etc/NetworkManager/dispatcher.d/50-cake-qos` with NM signature (`$1=iface, $2=action`); deploy.sh removes the legacy file. `check_qos.sh` updated to verify the new path and warn if the old one lingers. DSCP iptables marking was always effective (separate path).
+- **CAKE QoS hook moved to NetworkManager dispatcher (latent since PR #144)** — Pi OS runs NetworkManager, not systemd-networkd, so `/etc/networkd-dispatcher/routable.d/50-cake-qos` never fired. Default qdisc stayed `fq_codel` on every boot — Snapcast worked but lost DSCP-aware prioritization (Voice tin). Hook moved to `/etc/NetworkManager/dispatcher.d/50-cake-qos` with NM signature; `deploy.sh` removes the legacy file. DSCP iptables marking was always effective (separate path).
+- **Legacy `pcp` purged on install** — `--no-install-recommends` on sysstat already avoids pcp on new installs, but devices reflashed from Pi OS images that ship pcp keep it around. Its SysV init wrapper floods journald with "lacks a native systemd unit file" on every daemon-reload. `install-deps.sh` now best-effort purges `pcp pcp-conf pcp-pmda-*`.
+- **`metadata-service.py` `EXTERNAL_HOST` lazy-evaluated** — was resolved at module-import time via `socket.getfqdn()` + `gethostbyname()`. On dev hosts with slow reverse-DNS (observed: 30 s hang) every pytest import blocked, making the pre-push hook unusable. Now `get_external_host()` caches lazily on first call.
 
 ## [0.7.8.10] — 2026-05-26
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.10",
+  "snapmulti_release": "v0.7.8.11",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Script-only release containing PR #493 (3 fixes). `image_set` stays `0.7.7`.