### PR TITLE
fix(fb-display): lazy LAN_IP — stop showing ?.?.?.? after early-boot DHCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **fb-display IP cached as `?.?.?.?` after early-boot start** — `LAN_IP = _get_lan_ip()` ran at module-import time, so when the fb-display container started before DHCP completed (observed: 16 s window post-reflash on snapvideo) the placeholder `"?.?.?.?"` was cached for the lifetime of the process. The screen kept showing `?.?.?.?` until a healthcheck-driven container restart picked up the real IP — 27 min on snapvideo, easily mistaken for a network outage. Now `get_lan_ip()` is lazy with a 30 s TTL plus aggressive retry while the placeholder is cached: the first frame after DHCP completion already shows the real IP. Same bug pattern as `metadata-service.py:EXTERNAL_HOST` fixed in v0.7.8.11.
+
 ## [0.7.8.11] — 2026-05-26
 
 > Script-only patch (image_set stays 0.7.7). CAKE QoS NM dispatcher fix + pcp purge + metadata lazy-init (#493).

--- a/client/common/docker/fb-display/fb_display.py
+++ b/client/common/docker/fb-display/fb_display.py
@@ -66,7 +66,23 @@ def _get_lan_ip() -> str:
     return "?.?.?.?"
 
 
-LAN_IP = _get_lan_ip()
+# Lazy + auto-refresh: container can start before DHCP completes (observed:
+# fb-display showed "?.?.?.?" for 27 min after a reflash boot because the
+# old module-level eager evaluation cached the empty-network state forever).
+# TTL also picks up IP changes on DHCP renewal or network swap.
+_LAN_IP_CACHE: tuple[str, float] = ("?.?.?.?", 0.0)
+_LAN_IP_TTL = 30.0
+
+
+def get_lan_ip() -> str:
+    global _LAN_IP_CACHE
+    now = time.time()
+    cached_ip, cached_at = _LAN_IP_CACHE
+    # Refresh if TTL expired, OR if we still have the placeholder (keep retrying
+    # cheaply until DHCP gives us something real).
+    if cached_ip == "?.?.?.?" or now - cached_at > _LAN_IP_TTL:
+        _LAN_IP_CACHE = (_get_lan_ip(), now)
+    return _LAN_IP_CACHE[0]
 server_info: dict = {}
 
 SNAPCAST_MDNS_TYPE = "_snapcast._tcp.local."
@@ -991,7 +1007,7 @@ def render_base_frame() -> Image.Image:
     if srv_ver and srv_ver != "unknown":
         ver_parts.append(f"srv {srv_ver}")
     ver_suffix = "  •  " + "  /  ".join(ver_parts) if ver_parts else ""
-    status_text = f"{LAN_IP}  →  {snapserver_display}{ver_suffix}"
+    status_text = f"{get_lan_ip()}  →  {snapserver_display}{ver_suffix}"
     status_font_size = max(10, L["clock_h"] // 3)
     status_font = _get_font(status_font_size)
     bbox = draw.textbbox((0, 0), status_text, font=status_font)

--- a/client/common/docker/fb-display/fb_display.py
+++ b/client/common/docker/fb-display/fb_display.py
@@ -83,6 +83,8 @@ def get_lan_ip() -> str:
     if cached_ip == "?.?.?.?" or now - cached_at > _LAN_IP_TTL:
         _LAN_IP_CACHE = (_get_lan_ip(), now)
     return _LAN_IP_CACHE[0]
+
+
 server_info: dict = {}
 
 SNAPCAST_MDNS_TYPE = "_snapcast._tcp.local."


### PR DESCRIPTION
**Root cause del "transient network rotto" osservato dopo reflash v0.7.8.11.**

NM journal su snapvideo conferma: WiFi UP in 2 s, DHCP lease in 4 s, network activated @20:06:04 (16 s dopo boot). MA fb-display container è partito 1-2 s prima del DHCP completion → \`LAN_IP = _get_lan_ip()\` ha valutato \`?.?.?.?\` e l'ha **cached per la lifetime del processo**. Display ha mostrato \`?.?.?.?\` per 27 min (fino a che un healthcheck restart ha re-importato il modulo).

Falso positivo "we broke the network" — la rete era UP. Solo fb-display non si refreshava.

### Bug pattern identico a v0.7.8.11
\`metadata-service.py:EXTERNAL_HOST\` aveva lo stesso bug (module-level eager evaluation, cached forever). Stesso fix: lazy + cache.

### Fix
\`\`\`python
_LAN_IP_CACHE = ("?.?.?.?", 0.0)
_LAN_IP_TTL = 30.0

def get_lan_ip() -> str:
    cached_ip, cached_at = _LAN_IP_CACHE
    if cached_ip == "?.?.?.?" or now - cached_at > _LAN_IP_TTL:
        _LAN_IP_CACHE = (_get_lan_ip(), now)
    return _LAN_IP_CACHE[0]
\`\`\`

Aggressive retry quando placeholder cached → primo render post-DHCP mostra IP reale. Stable IP → 0 cost (cached 30 s).

### Validation
- Syntax OK (\`python3 -c "import ast; ast.parse(...)"\`)
- Existing \`_get_lan_ip()\` test ancora valido (testa la helper)
- E2E deferred a reflash next time