### PR TITLE
chore(release): roll [Unreleased] into v0.7.8.12 (fb-display lazy LAN_IP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.12] — 2026-05-26
+
+> Script-only patch (image_set stays 0.7.7). fb-display lazy LAN_IP — same bug pattern of v0.7.8.11 EXTERNAL_HOST fix, found while investigating the apparent "transient network outage" after a reflash (#501).
+
 ### Fixed
-- **fb-display IP cached as `?.?.?.?` after early-boot start** — `LAN_IP = _get_lan_ip()` ran at module-import time, so when the fb-display container started before DHCP completed (observed: 16 s window post-reflash on snapvideo) the placeholder `"?.?.?.?"` was cached for the lifetime of the process. The screen kept showing `?.?.?.?` until a healthcheck-driven container restart picked up the real IP — 27 min on snapvideo, easily mistaken for a network outage. Now `get_lan_ip()` is lazy with a 30 s TTL plus aggressive retry while the placeholder is cached: the first frame after DHCP completion already shows the real IP. Same bug pattern as `metadata-service.py:EXTERNAL_HOST` fixed in v0.7.8.11.
+- **fb-display IP cached as `?.?.?.?` after early-boot start (#501)** — `LAN_IP = _get_lan_ip()` ran at module-import time, so when the fb-display container started before DHCP completed (observed: 16 s window post-reflash on snapvideo) the placeholder `"?.?.?.?"` was cached for the lifetime of the process. Screen kept showing `?.?.?.?` for 27 min (until healthcheck restart) — easily mistaken for a network outage. Now `get_lan_ip()` is lazy with 30 s TTL + aggressive retry while the placeholder is cached: first frame after DHCP completion shows the real IP.
 
 ## [0.7.8.11] — 2026-05-26
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.11",
+  "snapmulti_release": "v0.7.8.12",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Script-only release containing PR #501 (fb-display LAN_IP lazy fix). image_set stays 0.7.7.