### PR TITLE
docs(adr): ADR-006 release identity + cross-ref ADR-001/002 in USAGE

### DIFF
--- a/docs/USAGE.it.md
+++ b/docs/USAGE.it.md
@@ -6,6 +6,8 @@ Il riferimento "come è fatto" — servizi, porte, sorgenti audio, modello di si
 
 ## Architettura
 
+> I razionali architetturali sono registrati in [`docs/adr/`](adr/ADR-INDEX.md). Più rilevanti per questa sezione: [ADR-001](adr/ADR-001.host-networking.md) (host networking — perché ogni container usa `network_mode: host`) e [ADR-002](adr/ADR-002.fifo-audio-routing.md) (named pipe in `/audio/` per il routing source → snapserver).
+
 Stack server (7 container, host networking):
 
 | Container | Ruolo | Porta |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,6 +6,8 @@ The "how it's put together" reference — services, ports, audio sources, securi
 
 ## Architecture
 
+> Architectural rationales are recorded in [`docs/adr/`](adr/ADR-INDEX.md). The most relevant for this section: [ADR-001](adr/ADR-001.host-networking.md) (host networking — why every container uses `network_mode: host`) and [ADR-002](adr/ADR-002.fifo-audio-routing.md) (named pipes in `/audio/` for source → snapserver routing).
+
 Server stack (7 containers, host networking):
 
 | Container | Role | Port |

--- a/docs/adr/ADR-006.release-identity-script-only-patches.md
+++ b/docs/adr/ADR-006.release-identity-script-only-patches.md
@@ -1,0 +1,70 @@
+---
+id: ADR-006
+status: accepted
+date: 2026-05-26
+---
+
+# ADR-006: Release Identity & Script-Only Patches
+
+## Context
+
+Two release cadences had collapsed onto a single tag/version system, with two real-world consequences:
+
+1. **Every tag triggered a multi-arch Docker image rebuild** (~30 min on self-hosted CI), even when the change was a shell-script edit, a docs typo, or a smoke test fix. The 12-release cascade `v0.7.8.0 → v0.7.8.12` in 10 days made this overhead operationally painful.
+2. **Release identity was duplicated** in `install.conf` (operator-facing) and `release-manifest.json` (build-facing). After PR re-runs of `prepare-sd.sh` across a tag bump, the two diverged on the same SD card. Observed on snapvideo (2026-05-26): `install.conf` carried `SNAPMULTI_RELEASE=v0.7.8.8` while `release-manifest.json` had `v0.7.8.9`. `firstboot.sh` precedence gave install.conf priority → `/version` endpoint showed the wrong tag.
+
+## Decisions
+
+### 1. Two independent identifiers
+
+| Variable | Owns | Bumps when |
+|----------|------|------------|
+| `SNAPMULTI_RELEASE` | The git tag (e.g. `v0.7.8.12`). Surfaced on `/version`, smoke output, diagnostics, fb-display badge. Tracks "what code is on this device". | Every release, including script-only patches. |
+| `SNAPMULTI_IMAGE_SET` | The Docker image tag (e.g. `0.7.7`). Determines which images the device pulls / runs. | Only when container images actually change. |
+
+A release where only scripts / docs / configs change keeps `SNAPMULTI_IMAGE_SET` pointing at the previously published image set. Devices reflash and pick up the new scripts; containers re-pull the same image they had before, so no multi-arch build is needed.
+
+### 2. Manifest gate in `build-push.yml`
+
+`release-manifest.json` carries `requires_image_rebuild: true | false`. The `gate` job reads it on every tag push:
+
+- `requires_image_rebuild: true` — proceeds with multi-arch build + manifest publish.
+- `requires_image_rebuild: false` — skips builds; only verifies the named `SNAPMULTI_IMAGE_SET` already exists on Docker Hub. Manifest gate becomes a no-op ~10 s job.
+
+Operator emergency override: `gh workflow run build-push.yml -f force_rebuild=true` bypasses the gate (used for accidentally-deleted Docker Hub tags or base-image CVE rebuilds).
+
+### 3. `release-manifest.json` on the SD is the single SSOT
+
+`install.conf` no longer carries `SNAPMULTI_RELEASE` / `SNAPMULTI_IMAGE_SET`. They are operator-irrelevant: the operator picks `INSTALL_TYPE`, `AUDIO_HAT`, `MUSIC_SOURCE`, etc., but release identity follows the staged manifest. `firstboot.sh` and `deploy.sh` read manifest only.
+
+`IMAGE_TAG` remains in `install.conf` as the one legitimate operator override (pin to `:dev` for development builds while the manifest stays on a release tag). When unset, it falls back to `SNAPMULTI_IMAGE_SET` from the manifest.
+
+## Consequences
+
+### Positive
+
+- Script-only patches ship in ~10 s of CI time instead of ~30 min — the v0.7.8.x cascade became feasible.
+- `/version`, smoke, fb-display all agree with the git tag, not with whatever was set in install.conf on an earlier reflash.
+- Container images are not rebuilt without reason — fewer registry pulls, less Docker Hub bandwidth, less risk of CVE-driven base-image breakage between unchanged releases.
+- Operator override path for `IMAGE_TAG` survives (pin to `:dev` while bumping the release tag for changelog/docs).
+
+### Negative
+
+- One more value (`requires_image_rebuild`) to set correctly when cutting a release. Forgetting to set it to `true` when images DID change ships a tag whose `:0.x.y` image doesn't exist on Docker Hub.
+- The manifest gate's "verify image exists" step is a Docker Hub HTTP call — Docker Hub outages would block tag pushes. Acceptable tradeoff vs the 30-min build cost on every patch.
+- Two identifiers visible to advanced users can confuse first-time reviewers ("why two versions?"). Mitigated by the precedence chain docs in `scripts/common/release-manifest.sh` header.
+
+## Implementation
+
+- `scripts/common/release-manifest.sh` — parser + precedence chain library, sourced by `prepare-sd.sh`, `firstboot.sh`, `deploy.sh`, `setup.sh`.
+- `release-manifest.json` — the SSOT, lives at repo root and is staged onto the SD by `prepare-sd.sh`.
+- `.github/workflows/build-push.yml:gate` — the manifest gate, runs on every tag push, branches build vs no-op.
+- Precedence chain (formal):
+  - **(A)** `IMAGE_TAG` = `install.conf IMAGE_TAG` > `manifest image_set` > `"latest"`
+  - **(B)** `SNAPMULTI_RELEASE` = `manifest snapmulti_release` > `""`
+  - **(C)** `SNAPMULTI_IMAGE_SET` = `manifest image_set` > `""`
+
+## Notes
+
+- DEC-003 (reflash-only updates, recorded in ADR-005) is the prerequisite that makes this work: there is no in-place upgrade path that could touch one of the two identifiers and leave the other stale on a long-lived device.
+- The SSOT consolidation (decision 3) shipped in v0.7.8.10 (PR #491) after the divergence was caught live on snapvideo; the manifest gate (decisions 1 + 2) shipped in v0.7.8.0 and was validated through the 12-release v0.7.8.x cascade.

--- a/docs/adr/ADR-INDEX.md
+++ b/docs/adr/ADR-INDEX.md
@@ -14,3 +14,4 @@ source_of_truth: true
 | ADR-003 | [Read-Only Containers](ADR-003.read-only-containers.md) | Accepted | 2026-03-01 |
 | ADR-004 | [Centralized Metadata Service](ADR-004.metadata-architecture.md) | Accepted | 2026-02-19 |
 | ADR-005 | [Reflash-Only, systemd Lifecycle, Robustness-First](ADR-005.reflash-systemd-robustness.md) | Accepted | 2026-04-22 |
+| ADR-006 | [Release Identity & Script-Only Patches](ADR-006.release-identity-script-only-patches.md) | Accepted | 2026-05-26 |


### PR DESCRIPTION
**A**: ADR-006 \"Release Identity & Script-Only Patches\" consolida 2 decisioni che vivevano solo nel CHANGELOG:

- Due identificatori indipendenti (\`SNAPMULTI_RELEASE\` vs \`SNAPMULTI_IMAGE_SET\`) + manifest gate per script-only releases (v0.7.8.0)
- \`release-manifest.json\` su SD come SSOT, \`install.conf\` non porta più release-identity keys (v0.7.8.10)

**C**: \`USAGE.md\` (EN + IT) Architecture section linka ADR-001 (host networking) + ADR-002 (FIFO routing) — erano foundational ma orfani nei docs prose.

### Files
- \`docs/adr/ADR-006.release-identity-script-only-patches.md\` (new)
- \`docs/adr/ADR-INDEX.md\` (+1 row)
- \`docs/USAGE.md\` + \`docs/USAGE.it.md\` (1 line each)

Docs-only, no code change.