### PR TITLE
docs(advanced): purge stale install.conf release-identity refs

### DIFF
--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -165,34 +165,34 @@ Dopo ogni reflash o aggiornamento in-place, esegui il test di salute sul device 
 
 ## Strategia release & pinning image-set
 
+> Razionale architetturale: [ADR-006](adr/ADR-006.release-identity-script-only-patches.md).
+
 snapMULTI separa due concetti di versione, così una release di soli script (CHANGELOG, docs, fix nell'installer) non costringe a ricostruire e ripubblicare le immagini Docker:
 
-- **`SNAPMULTI_RELEASE`** — il tag git della release (es. `v0.7.7`). Quello che `gh release view` mostra.
+- **`SNAPMULTI_RELEASE`** — il tag git della release (es. `v0.7.8.12`). Quello che `gh release view` mostra.
 - **`SNAPMULTI_IMAGE_SET`** — il tag Docker delle immagini a cui la release si aggancia (es. `0.7.7`). Quello che `docker compose pull` scarica.
 
-La maggior parte delle release incrementa entrambi. Una release di soli script incrementa `SNAPMULTI_RELEASE` e mantiene `SNAPMULTI_IMAGE_SET` all'ultimo valore pubblicato. La fonte di verità è `release-manifest.json` alla radice del repo.
+La maggior parte delle release incrementa entrambi. Una release di soli script incrementa `SNAPMULTI_RELEASE` e mantiene `SNAPMULTI_IMAGE_SET` all'ultimo valore pubblicato. La fonte di verità è `release-manifest.json` alla radice del repo, copiato sulla SD da `prepare-sd.sh`.
 
-### Catena di precedenza — `IMAGE_TAG`
+### Catena di precedenza
 
-Il tag Docker effettivamente usato si calcola in questo ordine (vince il primo non vuoto):
+Da v0.7.8.10 (consolidamento SSOT), `install.conf` non porta più la release identity — `release-manifest.json` sulla SD è l'unica fonte. `IMAGE_TAG` resta in `install.conf` come unico legittimo operator override.
 
-1. `install.conf` `IMAGE_TAG=` (override operatore — `dev`, `0.7.6`, ecc.)
-2. `install.conf` `SNAPMULTI_IMAGE_SET=` (scritto da prepare-sd a partire dal manifest)
-3. `release-manifest.json` `image_set` (fallback dal manifest)
-4. `latest` (fallback finale)
+- **`SNAPMULTI_RELEASE`** = `manifest snapmulti_release` > `""`
+- **`SNAPMULTI_IMAGE_SET`** = `manifest image_set` > `""`
+- **`IMAGE_TAG`** (tag Docker effettivamente caricato) = `install.conf IMAGE_TAG` (override operatore — `dev`, un tag specifico) > `manifest image_set` > `latest`
 
-Implementata una sola volta in `scripts/common/release-manifest.sh::derive_image_tag()` e consumata da `firstboot.sh`, `deploy.sh`, e dal `setup.sh` del client. Ogni consumer usa la stessa catena — zero drift.
+Implementata una sola volta in `scripts/common/release-manifest.sh::derive_image_tag()` e consumata da `firstboot.sh`, `deploy.sh`, e dal `setup.sh` del client.
 
-### Tabella di backward-compat
+### Tabella di compatibilità
 
 | install.conf | manifest | `IMAGE_TAG` risultante |
 |--------------|----------|------------------------|
 | solo `IMAGE_TAG=0.7.4` | — | `0.7.4` (SD legacy da v0.7.4) |
 | solo `IMAGE_TAG=latest` | — | `latest` (default legacy) |
-| `SNAPMULTI_IMAGE_SET=0.7.5`, no IMAGE_TAG | — | `0.7.5` |
-| `SNAPMULTI_IMAGE_SET=0.7.5`, `IMAGE_TAG=dev` | — | `dev` (override vince) |
 | vuoto | assente | `latest` |
 | vuoto | `image_set=0.7.7` | `0.7.7` |
+| `IMAGE_TAG=dev` | `image_set=0.7.7` | `dev` (override operatore vince) |
 
 Riprodotta in `tests/test_firstboot_image_tag_derivation.sh`.
 
@@ -230,7 +230,7 @@ Il gate bypassa sia `requires_image_rebuild=false` sia il check di esistenza su 
 
 Dopo deploy / reflash:
 
-- Riga info del test di salute: `device-smoke.sh` → sezione `System` → `Release v0.7.7 (images 0.7.7)`
+- Riga info del test di salute: `device-smoke.sh` → sezione `System` → `Release v0.7.8.12 (images 0.7.7)`
 - Pacchetto diagnostico: `scripts/diagnostic.sh` produce `meta.txt` con `snapmulti_release=...` e `snapmulti_image_set=...`; il pacchetto include anche il `release-manifest.json` (scrubbato) dalla partizione di boot.
 - `.env` del server: `grep ^SNAPMULTI_ /opt/snapmulti/.env`
 - `.env` del client: `grep ^SNAPMULTI_ /opt/snapclient/.env`

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -165,34 +165,34 @@ After every reflash or in-place update, run the smoke test on the device to conf
 
 ## Release strategy & image-set pinning
 
+> Architectural rationale: [ADR-006](adr/ADR-006.release-identity-script-only-patches.md).
+
 snapMULTI separates two version concepts so a script-only release (CHANGELOG, docs, installer fixes) does not force a Docker image rebuild + repush:
 
-- **`SNAPMULTI_RELEASE`** — the git tag of the release (e.g. `v0.7.7`). What `gh release view` shows.
+- **`SNAPMULTI_RELEASE`** — the git tag of the release (e.g. `v0.7.8.12`). What `gh release view` shows.
 - **`SNAPMULTI_IMAGE_SET`** — the Docker image tag the release pins to (e.g. `0.7.7`). What `docker compose pull` fetches.
 
-Most releases bump both. A script-only release bumps `SNAPMULTI_RELEASE` and keeps `SNAPMULTI_IMAGE_SET` at the last published value. The source of truth is `release-manifest.json` at the repo root.
+Most releases bump both. A script-only release bumps `SNAPMULTI_RELEASE` and keeps `SNAPMULTI_IMAGE_SET` at the last published value. The source of truth is `release-manifest.json` at the repo root, staged onto the SD by `prepare-sd.sh`.
 
-### Precedence chain — `IMAGE_TAG`
+### Precedence chain
 
-The Docker tag actually used is computed in this order (first non-empty wins):
+Since v0.7.8.10 (SSOT consolidation), `install.conf` no longer carries release identity — release-manifest.json on the SD is the only source. `IMAGE_TAG` stays in `install.conf` as the one legitimate operator override.
 
-1. `install.conf` `IMAGE_TAG=` (operator override — `dev`, `0.7.6`, etc.)
-2. `install.conf` `SNAPMULTI_IMAGE_SET=` (set by prepare-sd from the manifest)
-3. `release-manifest.json` `image_set` (manifest fallback)
-4. `latest` (final fallback)
+- **`SNAPMULTI_RELEASE`** = `manifest snapmulti_release` > `""`
+- **`SNAPMULTI_IMAGE_SET`** = `manifest image_set` > `""`
+- **`IMAGE_TAG`** (Docker tag actually pulled) = `install.conf IMAGE_TAG` (operator override — `dev`, a specific tag) > `manifest image_set` > `latest`
 
-This is implemented once in `scripts/common/release-manifest.sh::derive_image_tag()` and consumed by `firstboot.sh`, `deploy.sh`, and the client's `setup.sh`. Every consumer uses the same chain — no drift.
+Implemented once in `scripts/common/release-manifest.sh::derive_image_tag()` and consumed by `firstboot.sh`, `deploy.sh`, and the client's `setup.sh`.
 
-### Backward-compat matrix
+### Compatibility matrix
 
 | install.conf | manifest | Resulting `IMAGE_TAG` |
 |--------------|----------|-----------------------|
 | `IMAGE_TAG=0.7.4` only | — | `0.7.4` (legacy SD card from v0.7.4) |
 | `IMAGE_TAG=latest` only | — | `latest` (legacy default) |
-| `SNAPMULTI_IMAGE_SET=0.7.5`, no IMAGE_TAG | — | `0.7.5` |
-| `SNAPMULTI_IMAGE_SET=0.7.5`, `IMAGE_TAG=dev` | — | `dev` (override wins) |
 | empty | absent | `latest` |
 | empty | `image_set=0.7.7` | `0.7.7` |
+| `IMAGE_TAG=dev` | `image_set=0.7.7` | `dev` (operator override wins) |
 
 Reproduced in `tests/test_firstboot_image_tag_derivation.sh`.
 
@@ -230,7 +230,7 @@ The gate bypasses both `requires_image_rebuild=false` and the Docker Hub existen
 
 After a deploy / reflash:
 
-- Smoke test info line: `device-smoke.sh` → `System` section → `Release v0.7.7 (images 0.7.7)`
+- Smoke test info line: `device-smoke.sh` → `System` section → `Release v0.7.8.12 (images 0.7.7)`
 - Diagnostic bundle: `scripts/diagnostic.sh` produces `meta.txt` with `snapmulti_release=...` and `snapmulti_image_set=...`; the bundle also includes the scrubbed `release-manifest.json` from the boot partition.
 - Server `.env`: `grep ^SNAPMULTI_ /opt/snapmulti/.env`
 - Client `.env`: `grep ^SNAPMULTI_ /opt/snapclient/.env`


### PR DESCRIPTION
Audit docs ha trovato 3 punti stale in \`docs/ADVANCED.md\` (+ \`.it.md\`) post-v0.7.8.10 SSOT consolidation:

1. **Precedence chain riga 180**: \`install.conf SNAPMULTI_IMAGE_SET=\` come step #2 — **non più valido** (v0.7.8.10 ha rimosso il key da install.conf)
2. **Backward-compat matrix righe 192-193**: scenari \`SNAPMULTI_IMAGE_SET=0.7.5 in install.conf\` — **non più rappresentano realtà**
3. **Version examples**: \`v0.7.7\` ovunque → bumped a \`v0.7.8.12\`

### Fix
- Precedence chain: solo \`manifest\` per SNAPMULTI_RELEASE/IMAGE_SET, \`install.conf IMAGE_TAG\` solo operator override
- Compatibility matrix: rimosse 2 legacy rows, aggiunta 1 nuova
- Pointer ad ADR-006 (architectural rationale)
- IT mirror in sync

Docs only, no code.