### PR TITLE
docs(adr): ADR-001 — narrow scope from "all containers" to "audio-path"

### DIFF
--- a/docs/adr/ADR-001.host-networking.md
+++ b/docs/adr/ADR-001.host-networking.md
@@ -4,7 +4,7 @@ status: accepted
 date: 2026-01-15
 ---
 
-# ADR-001: Host Networking for All Containers
+# ADR-001: Host Networking for Audio-Path Containers
 
 ## Context
 
@@ -12,7 +12,11 @@ Snapcast clients discover the server via mDNS (multicast DNS). Audio source serv
 
 ## Decision
 
-All containers use `network_mode: host`. No bridge networking, no port mapping.
+All containers in the audio path use `network_mode: host`:
+- **Server stack (7/7)**: snapserver, mpd, mympd, shairport-sync, librespot, tidal-connect, metadata
+- **Client stack (2/3)**: snapclient, fb-display
+
+`audio-visualizer` is the documented exception — it serves a WebSocket spectrum feed on port 8081 to fb-display on the same host, has no multicast/mDNS need, and stays on Docker's default bridge networking. Keeping it isolated reduces host-port surface area for no functional cost.
 
 ## Consequences
 


### PR DESCRIPTION
ADR audit ha trovato drift in **ADR-001**: dichiara \"All containers use \`network_mode: host\`\" ma \`audio-visualizer\` è su bridge (default).

### Realtà runtime
| Stack | Host networking | Bridge |
|-------|-----------------|--------|
| Server (7) | snapserver, mpd, mympd, shairport-sync, librespot, tidal-connect, metadata | — |
| Client (3) | snapclient, fb-display | audio-visualizer (port 8081 WS, no mDNS need) |

### Fix
- Titolo: \"for All Containers\" → \"for Audio-Path Containers\"
- Decision section: enumera i 9 host-networked + documenta \`audio-visualizer\` come intentional exception

Le altre 4 ADR (002 FIFO, 003 read_only, 004 metadata, 005 reflash) auditate, **zero drift**.