### PR TITLE
fix(smoke): auto-boot tolerates 'starting' systemd state (self-referential paradox)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **auto-boot smoke false-positive on `starting` systemd state (#507)** — `snapmulti-auto-boot-smoke.service` is itself the last pending boot unit, so `systemctl is-system-running` can never return `running` while the smoke is executing. The check always saw `starting`, marked it FAIL, and the post-boot acoustic cue played a warning tone even when every container was healthy. `check_boot_health.sh` now treats `starting` as informational (not a failure) when invoked from the auto-boot wrapper (`SNAPMULTI_AUTO_BOOT=1`). Manual smoke runs still fail on `starting` as expected (real anomaly).
+
 ## [0.7.8.12] — 2026-05-26
 
 > Script-only patch (image_set stays 0.7.7). fb-display lazy LAN_IP — same bug pattern of v0.7.8.11 EXTERNAL_HOST fix, found while investigating the apparent "transient network outage" after a reflash (#501).

--- a/scripts/common/auto-boot-smoke.sh
+++ b/scripts/common/auto-boot-smoke.sh
@@ -55,5 +55,8 @@ sleep 10  # let snapmulti-status.timer fire its first snapshot
 
 # Always exit 0 — the tone IS the signal. Failing the unit on a smoke WARN would degrade systemd state (sys is-system-running=degraded) and trigger a self-referential FAIL cascade on the next smoke run.
 # SNAPMULTI_FORCE_TONE=1: auto-boot must always play (user explicitly chose option B over "don't interrupt music") so post-reboot status is audible even when MPD autoplay resumed during boot.
-SNAPMULTI_FORCE_TONE=1 "$SMOKE" "$MODE" --tone >/dev/null || true
+# SNAPMULTI_AUTO_BOOT=1: signals check_boot_health.sh to tolerate
+# 'starting' as info instead of FAIL (self-referential paradox — system
+# state is starting *because* this very service is pending).
+SNAPMULTI_AUTO_BOOT=1 SNAPMULTI_FORCE_TONE=1 "$SMOKE" "$MODE" --tone >/dev/null || true
 exit 0

--- a/scripts/smoke/check_boot_health.sh
+++ b/scripts/smoke/check_boot_health.sh
@@ -99,6 +99,14 @@ check_boot_health() {
 
     local sys_state
     sys_state=$(systemctl is-system-running 2>/dev/null || true)
+    # Self-referential paradox: when smoke runs from snapmulti-auto-boot-smoke.service,
+    # system state cannot be 'running' yet — it's pending on the auto-boot-smoke
+    # service itself. Treat 'starting' as info in that context. SNAPMULTI_AUTO_BOOT
+    # is set by the auto-boot wrapper (scripts/common/auto-boot-smoke.sh).
+    if [[ "$sys_state" == "starting" && "${SNAPMULTI_AUTO_BOOT:-}" == "1" ]]; then
+        info "systemd still 'starting' (expected — smoke is itself a pending boot unit)"
+        return 0
+    fi
     case "$sys_state" in
         running)
             pass_check "systemd is-system-running: running"


### PR DESCRIPTION
**Confermato live su snapvideo post-reflash v0.7.8.12**: hai sentito tono di failure/warning mentre tutti i container erano healthy. Smoke manuale 30s dopo = pass (tritono ascendente).

### Root cause (paradosso)
\`snapmulti-auto-boot-smoke.service\` runs come unit systemd. Mentre gira, \`systemctl is-system-running\` ritorna \`'starting'\` perché QUESTA stessa service è l'ultima unit pending. \`check_boot_health.sh\` vede 'starting' e fa \`fail_check\` → tono failure.

### Evidenza
\`\`\`
$ systemd-analyze blame | head -3
2min 198ms snapmulti-auto-boot-smoke.service  ← se stesso!
   26.299s snapmulti-server.service
   16.613s snapclient.service

$ journalctl -u snapmulti-auto-boot-smoke.service -b | grep -E 'starting|healthy'
[ERROR] systemd state unexpected: 'starting'  ← FAIL → warning tone
[OK] mpd: healthcheck reporting healthy        ← container fine
... 9 altri [OK]
\`\`\`

\`is-system-running\` non potrà MAI essere 'running' all'interno di auto-boot-smoke — è self-referential.

### Fix
- \`auto-boot-smoke.sh\` exporta \`SNAPMULTI_AUTO_BOOT=1\` quando invoca lo smoke
- \`check_boot_health.sh\` tratta 'starting' come \`info\` (non fail) se quella env è settata
- Manual smoke runs (no env) continuano a marcare 'starting' come fail — è anomalia reale mid-day

### Impatto
Boot post-reflash: tritone PASS invece di tono WARN, anche se sistema è pienamente healthy. Fine dei false-positive che fanno preoccupare l'utente.