### PR TITLE
chore(release): roll [Unreleased] into v0.7.8.13 (auto-boot smoke false-positive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8.13] — 2026-05-27
+
+> Script-only patch (image_set stays 0.7.7). Auto-boot smoke false-positive on systemd `starting` state (#507).
+
 ### Fixed
 - **auto-boot smoke false-positive on `starting` systemd state (#507)** — `snapmulti-auto-boot-smoke.service` is itself the last pending boot unit, so `systemctl is-system-running` can never return `running` while the smoke is executing. The check always saw `starting`, marked it FAIL, and the post-boot acoustic cue played a warning tone even when every container was healthy. `check_boot_health.sh` now treats `starting` as informational (not a failure) when invoked from the auto-boot wrapper (`SNAPMULTI_AUTO_BOOT=1`). Manual smoke runs still fail on `starting` as expected (real anomaly).
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.12",
+  "snapmulti_release": "v0.7.8.13",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Script-only release with PR #507. `image_set` stays `0.7.7`.