### PR TITLE
docs(landing-page): point README + INSTALL to :8083/ as start URL

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -100,7 +100,7 @@ Lo script ti guida con poche domande: il ruolo (**Audio Player** / **Music Serve
 
 Espelli l'SD, inseriscila nel Pi, accendi. Aspetta circa 10-15 minuti — l'installer al primo boot gira da solo (niente SSH), mostra l'avanzamento su HDMI se hai uno schermo collegato, poi si riavvia una volta.
 
-**Ha funzionato quando**: con uno schermo collegato, il display HDMI mostra la schermata "in riproduzione" di snapMULTI (copertina / spettro). In ogni caso, da un altro dispositivo apri `http://<hostname>.local:8083/status` — tutti i controlli devono essere verdi. Poi fai cast di qualcosa (vedi **Dopo l'installazione** più sotto).
+**Ha funzionato quando**: con uno schermo collegato, il display HDMI mostra la schermata "in riproduzione" di snapMULTI (copertina / spettro). In ogni caso, da un altro dispositivo apri `http://<hostname>.local:8083/`, poi apri **Status** — tutti i controlli devono essere verdi. Poi fai cast di qualcosa (vedi **Dopo l'installazione** più sotto).
 
 > **Procedura dettagliata** con troubleshooting e percorso di recupero diagnostico: [docs/INSTALL.it.md](docs/INSTALL.it.md).
 > **Policy hardware** (combinazioni Pi/audio validate vs sperimentali): [docs/HARDWARE.it.md](docs/HARDWARE.it.md).
@@ -111,6 +111,7 @@ Sostituisci `hostname` con quello che hai impostato allo Step 1.
 
 | URL | Cosa fa |
 |-----|---------|
+| `http://hostname.local:8083/` | **Punto di partenza** — link a tutte le pagine web e API snapMULTI |
 | `http://hostname.local:1780` | **Snapweb** — volume per stanza, raggruppa altoparlanti, cambia sorgente |
 | `http://hostname.local:8180` | **myMPD** — sfoglia e riproduce la libreria musicale |
 | `http://hostname.local:8083/status` | **Pagina di stato** — stato container + audio + NFS |
@@ -138,7 +139,7 @@ Prima di riflashare, esegui `./scripts/backup-from-sd.sh` per conservare l'indic
 
 ## Se qualcosa fallisce
 
-**Installato ma non lo raggiungi?** Se il Pi ha finito ma `http://<hostname>.local:1780` non si apre: cerca l'indirizzo IP del Pi nella lista dispositivi del router e usa quello. La risoluzione `.local` (mDNS) non funziona su alcune configurazioni Windows e su WiFi ospiti / mesh / VLAN che isolano i client — tieni il Pi e il telefono/laptop sulla stessa rete normale. Altro aiuto mDNS: [docs/TROUBLESHOOTING.it.md](docs/TROUBLESHOOTING.it.md).
+**Installato ma non lo raggiungi?** Se il Pi ha finito ma `http://<hostname>.local:8083/` non si apre: cerca l'indirizzo IP del Pi nella lista dispositivi del router e usa quello. La risoluzione `.local` (mDNS) non funziona su alcune configurazioni Windows e su WiFi ospiti / mesh / VLAN che isolano i client — tieni il Pi e il telefono/laptop sulla stessa rete normale. Altro aiuto mDNS: [docs/TROUBLESHOOTING.it.md](docs/TROUBLESHOOTING.it.md).
 
 Se è il primo boot a interrompersi: snapMULTI esegue l'installazione come servizio systemd e cattura tutto strada facendo. La trap di cleanup scrive un pacchetto diagnostico anonimizzato sulla **partizione boot** dell'SD (FAT32, leggibile da qualsiasi computer — niente SSH necessario):
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The script walks you through a few questions: the role (**Audio Player** / **Mus
 
 Eject the SD, insert it in the Pi, power on. Wait about 10-15 minutes — the first-boot installer runs on its own (no SSH), shows progress on HDMI if a screen is attached, then reboots once.
 
-**It worked when**: with a screen attached, the HDMI display shows the snapMULTI now-playing screen (cover art / spectrum). Either way, from another device open `http://<hostname>.local:8083/status` — every check should be green. Then cast something (see **After install** below).
+**It worked when**: with a screen attached, the HDMI display shows the snapMULTI now-playing screen (cover art / spectrum). Either way, from another device open `http://<hostname>.local:8083/`, then open **Status** — every check should be green. Then cast something (see **After install** below).
 
 > **Detailed walk-through** with troubleshooting and the diagnostic-bundle recovery path: [docs/INSTALL.md](docs/INSTALL.md).
 > **Hardware policy** (validated vs experimental Pi/audio combinations): [docs/HARDWARE.md](docs/HARDWARE.md).
@@ -111,6 +111,7 @@ Replace `hostname` with what you set in Step 1.
 
 | URL | What it does |
 |-----|--------------|
+| `http://hostname.local:8083/` | **Start here** — links to every snapMULTI web page and API |
 | `http://hostname.local:1780` | **Snapweb** — per-room volume, group speakers, switch source |
 | `http://hostname.local:8180` | **myMPD** — browse and play music library |
 | `http://hostname.local:8083/status` | **Status page** — container + audio + NFS status |
@@ -138,7 +139,7 @@ Before re-flashing, run `./scripts/backup-from-sd.sh` to preserve your MPD music
 
 ## If something fails
 
-**Installed but you can't reach it?** If the Pi finished but `http://<hostname>.local:1780` won't load: find the Pi's IP address in your router's device list and use that instead. `.local` (mDNS) name resolution fails on some Windows setups and on guest / mesh / VLAN Wi-Fi that isolates clients — keep the Pi and your phone/laptop on the same ordinary network. More mDNS help: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
+**Installed but you can't reach it?** If the Pi finished but `http://<hostname>.local:8083/` won't load: find the Pi's IP address in your router's device list and use that instead. `.local` (mDNS) name resolution fails on some Windows setups and on guest / mesh / VLAN Wi-Fi that isolates clients — keep the Pi and your phone/laptop on the same ordinary network. More mDNS help: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
 
 If the first boot itself aborted: snapMULTI runs the install as a systemd service and captures everything as it goes. The cleanup trap writes a redacted diagnostic bundle to the SD card's **boot partition** (FAT32, readable from any computer — no SSH needed):
 

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -17,7 +17,7 @@ Hai già dimestichezza con Raspberry Pi Imager e terminale? Questa è tutta l'in
 5. Dalla cartella snapMULTI, esegui `./scripts/prepare-sd.sh` su macOS/Linux oppure `.\scripts\prepare-sd.ps1` su Windows.
 6. Scegli cosa deve fare questo Pi: **Audio Player**, **Music Server** o **Server + Player**.
 7. Espelli la SD, avvia il Pi e attendi circa 10-15 minuti. Installa, verifica e poi riavvia una volta.
-8. Apri `http://<hostname>.local:1780` per Snapweb oppure `http://<hostname>.local:8180` per myMPD.
+8. Apri `http://<hostname>.local:8083/` — la pagina iniziale contiene i link a Snapweb, myMPD, status e API.
 
 Se un passaggio non è chiaro, continua con la procedura dettagliata qui sotto. Se il primo boot fallisce, recupera il pacchetto diagnostico dalla SD come descritto in [TROUBLESHOOTING.it.md — In caso di dubbio](TROUBLESHOOTING.it.md#in-caso-di-dubbio--prendi-il-pacchetto-diagnostico).
 
@@ -371,15 +371,15 @@ Se non lo senti, l'installazione prosegue comunque — ma controlla alimentazion
 
 > **Placeholder hostname.** Da qui in avanti, `<hostname>.local` significa l'hostname che hai impostato in Imager al Passo 1c. Se hai impostato `myradio`, usa `myradio.local` ovunque appaia `<hostname>.local` qui sotto.
 
-### Controllo per principianti — aprire la pagina di stato
+### Controllo per principianti — aprire la pagina iniziale
 
 Da un altro computer o telefono sulla stessa rete, apri:
 
 ```
-http://<hostname>.local:8083/status
+http://<hostname>.local:8083/
 ```
 
-Se la pagina si apre e tutti i controlli sono verdi, la piattaforma è sana. Se non si apre, prova lo stesso URL usando l'indirizzo IP del Pi al posto di `<hostname>.local`.
+Da quella pagina apri **Status**. Se tutti i controlli sono verdi, la piattaforma è sana. Se la pagina iniziale non si apre, prova lo stesso URL usando l'indirizzo IP del Pi al posto di `<hostname>.local`.
 
 ### Trovare il Pi sulla tua rete
 
@@ -426,9 +426,17 @@ fb-display         Up X minutes (healthy)
 ```
 `audio-visualizer` e `fb-display` appaiono solo se un display HDMI era collegato al primo avvio.
 
-### Aprire l'interfaccia web (solo server)
+### Aprire le interfacce web (solo server)
 
-Apri il tuo browser e vai a:
+Il punto di ingresso principale è:
+
+```
+http://<hostname>.local:8083/
+```
+
+Contiene i link a tutte le pagine snapMULTI apribili da browser.
+
+Per la libreria musicale, apri:
 
 ```
 http://<hostname>.local:8180
@@ -441,6 +449,8 @@ L'**interfaccia web Snapcast** (controlla quale speaker riproduce cosa) è a:
 ```
 http://<hostname>.local:1780
 ```
+
+Se **Status** è verde e le interfacce web si aprono, il server è pronto. Prova a riprodurre un brano da Snapweb (`http://<hostname>.local:1780`) oppure fai cast da Spotify/AirPlay per confermare che l'audio funzioni.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,7 +17,7 @@ Already comfortable with Raspberry Pi Imager and terminals? This is the whole in
 5. From the snapMULTI folder, run `./scripts/prepare-sd.sh` on macOS/Linux or `.\scripts\prepare-sd.ps1` on Windows.
 6. Choose what this Pi should do: **Audio Player**, **Music Server**, or **Server + Player**.
 7. Eject the SD, boot the Pi, and wait about 10-15 minutes. It installs, verifies, then reboots once.
-8. Open `http://<hostname>.local:1780` for Snapweb or `http://<hostname>.local:8180` for myMPD.
+8. Open `http://<hostname>.local:8083/` — the start page links to Snapweb, myMPD, status, and API endpoints.
 
 If any step is unclear, continue with the detailed walkthrough below. If first boot fails, recover the diagnostic bundle from the SD card as described in [TROUBLESHOOTING.md — When in doubt](TROUBLESHOOTING.md#when-in-doubt--grab-the-diagnostic-bundle).
 
@@ -369,15 +369,15 @@ If you don't hear it, the install still continues — but check power, volume, a
 
 > **Hostname placeholder.** From here on, `<hostname>.local` means the hostname you set in Imager at Step 1c. If you set `myradio`, use `myradio.local` everywhere `<hostname>.local` appears below.
 
-### Beginner check — open the status page
+### Beginner check — open the start page
 
 From another computer or phone on the same network, open:
 
 ```
-http://<hostname>.local:8083/status
+http://<hostname>.local:8083/
 ```
 
-If the page opens and every check is green, the platform is healthy. If it does not open, try the same URL with the Pi's IP address instead of `<hostname>.local`.
+Open **Status** from that page. If every check is green, the platform is healthy. If the start page does not open, try the same URL with the Pi's IP address instead of `<hostname>.local`.
 
 ### Find the Pi on your network
 
@@ -424,9 +424,17 @@ fb-display         Up X minutes (healthy)
 ```
 `audio-visualizer` and `fb-display` only appear if an HDMI display was connected at first boot.
 
-### Open the web interface (server only)
+### Open the web interfaces (server only)
 
-Open your browser and go to:
+The main entry point is:
+
+```
+http://<hostname>.local:8083/
+```
+
+It links to all browser-facing snapMULTI pages.
+
+For the music library, open:
 
 ```
 http://<hostname>.local:8180
@@ -440,7 +448,7 @@ The **Snapcast web UI** (control which speaker plays what) is at:
 http://<hostname>.local:1780
 ```
 
-If everything shows "healthy" and the web interfaces load — your server is ready. Try playing a track from Snapweb (`http://<hostname>.local:1780`) or cast from Spotify/AirPlay to confirm audio works.
+If **Status** is green and the web interfaces load — your server is ready. Try playing a track from Snapweb (`http://<hostname>.local:1780`) or cast from Spotify/AirPlay to confirm audio works.
 
 ---
 


### PR DESCRIPTION
PR #488 ha introdotto la **landing page** a \`http://<host>:8083/\` (lista clickable di Snapweb / myMPD / status / version / metadata / health / APIs). Ma onboarding docs (README, INSTALL) puntavano ancora primo accesso a \`:8083/status\`, \`:1780\` (Snapweb), \`:8180\` (myMPD) — la landing page rimaneva invisibile al primo accesso.

### Cambio
- Primo URL raccomandato: \`http://<hostname>.local:8083/\`
- Da lì l'utente clicca su Snapweb / myMPD / Status

### Files
- README.md + README.it.md
- docs/INSTALL.md + docs/INSTALL.it.md

EN + IT sync. Docs-only, no code.