### PR TITLE
fix(smoke): purge developer jargon from user-facing messages

### DIFF
--- a/scripts/smoke/check_audio_modules.sh
+++ b/scripts/smoke/check_audio_modules.sh
@@ -64,7 +64,7 @@ check_audio_modules() {
     done
 
     if [[ -z "$hat_config" ]]; then
-        info "HAT_CONFIG not set in .env — kernel module check skipped"
+        info "Per-HAT kernel module check skipped (HAT_CONFIG not in .env) — ALSA card consistency already verified above is the authoritative check"
         return 0
     fi
 
@@ -73,7 +73,7 @@ check_audio_modules() {
     # Look up the expected modules for this HAT.
     local expected="${_HAT_MODULES[$hat_config]:-}"
     if [[ -z "$expected" ]]; then
-        info "HAT '$hat_config' has no expected-modules list (add to scripts/smoke/check_audio_modules.sh _HAT_MODULES) — skipped"
+        info "Per-HAT kernel module check skipped (no expected-modules list for '$hat_config') — ALSA card consistency above is the authoritative check"
         return 0
     fi
 

--- a/scripts/smoke/check_mounts.sh
+++ b/scripts/smoke/check_mounts.sh
@@ -99,7 +99,7 @@ check_mounts() {
         local automount_active_lines
         automount_active_lines=$(grep -v '^[[:space:]]*#' "/etc/systemd/system/$automount_name" 2>/dev/null || true)
         if echo "$automount_active_lines" | grep -qE '^[[:space:]]*(After|Wants|Requires|BindsTo)=.*network-online\.target'; then
-            fail_check "$automount_name carries network-online.target ordering (PR #334 regression — boot-time ordering cycle)"
+            fail_check "$automount_name carries network-online.target ordering — boot-time ordering cycle"
         else
             pass_check "$automount_name has no network-online ordering (no boot-time cycle)"
         fi
@@ -129,7 +129,7 @@ check_mounts() {
             pass_check "$mount_name is '$mount_state' (NOT eager-enabled — correct)"
             ;;
         enabled|enabled-runtime)
-            fail_check "$mount_name is eager-enabled — slow NAS will block snapmulti-server.service startup (PR #334 regression)"
+            fail_check "$mount_name is eager-enabled — slow NAS will block snapmulti-server.service startup (should be lazy via .automount)"
             ;;
     esac
 

--- a/scripts/smoke/check_timers.sh
+++ b/scripts/smoke/check_timers.sh
@@ -72,6 +72,6 @@ check_timers() {
     if [[ "${INSTALL_TYPE_NATIVE_CLIENT:-false}" == "true" ]]; then
         info "Timer snapclient-discover.timer skipped on native client (libavahi-client used instead)"
     else
-        _check_timer "snapclient-discover.timer"    "mDNS server discovery (PR #285 multi-server failover)" client
+        _check_timer "snapclient-discover.timer"    "mDNS server rediscovery (multi-server failover)" client
     fi
 }


### PR DESCRIPTION
User-feedback feedback observed durante smoke output review:

1. \`HAT_CONFIG not set in .env — kernel module check skipped\` — confusing. ALSA card consistency check appena sopra dice già che il HAT è OK (\`sndrpihifiberry present in ALSA\`). L'utente legge "skipped" e pensa "manca qualcosa?".
2. \`(PR #285 multi-server failover)\` in Timer description — internal jargon. User non sa cosa è PR #285.

### Fix
| Where | Before | After |
|-------|--------|-------|
| check_timers.sh | \"...discovery (PR #285 multi-server failover)\" | \"...rediscovery (multi-server failover)\" |
| check_mounts.sh ×2 | \"...(PR #334 regression — ...)\", \"...(PR #334 regression)\" | rephrased without PR refs |
| check_audio_modules.sh ×2 | \"HAT_CONFIG not set ... skipped\" | \"Per-HAT kernel module check skipped ... ALSA card consistency above is the authoritative check\" |

User-facing strings only. Internal comments (// rationale, source-of-truth refs) left unchanged.