### PR TITLE
docs(smoke): MESSAGING.md guidelines + audit rewrite of 5 high-density check files

### DIFF
--- a/scripts/smoke/MESSAGING.md
+++ b/scripts/smoke/MESSAGING.md
@@ -1,0 +1,58 @@
+# Smoke output messaging guidelines
+
+> Audience: someone managing one or more snapMULTI Raspberry Pis. Comfortable on a terminal, not a Linux specialist. Reads smoke output to answer **"is this Pi healthy and if not, what do I do?"**
+
+## Status semantics
+
+| Status | When |
+|--------|------|
+| `[OK]` | Check pass — positive outcome confirmed |
+| `[WARN]` | Functional but suboptimal — system works, polish/observe |
+| `[FAIL]` | Broken — user-visible feature does not work, action required |
+| `[INFO]` | Skipped or contextual — neither pass nor fail, just FYI |
+
+## Sentence shape
+
+```
+[STATUS] <Subject>: <verdict>[ — <reason or action>]
+```
+
+- **Subject**: short noun phrase (`MPD healthcheck`, `Snapcast mDNS announcement`, `Overlay tmpfs`).
+- **Verdict**: present-tense state (`healthy`, `not advertised`, `92% full`).
+- **Reason / action** (after `—`): only when the verdict alone is not actionable.
+
+Examples:
+
+```
+[OK]   MPD healthcheck: healthy
+[FAIL] Snapcast mDNS announcement: not advertised — clients won't find this server
+[WARN] Overlay tmpfs: 87% full (approaching the 90% unbootable threshold)
+[INFO] Per-HAT kernel module check: skipped (HAT_CONFIG not in .env; ALSA card check above is the authoritative one)
+```
+
+## Banned phrasing
+
+- **Implementation detail leakage**: `libavahi-client`, `fuse-overlayfs upper layer`, `BASH_REMATCH`. Replace with what the user observes (`Avahi client library`, `read-only filesystem overlay`).
+- **PR / issue numbers**: `(PR #285 ...)` — git blame / ADR is for code archaeology, not user-facing text.
+- **File paths** in pass_check / info: `/etc/systemd/system/...mount` adds noise; mention the kind of artefact, not the path. Keep paths in fail/warn where the operator may need to `cd` / inspect.
+- **Pseudo-questions**: `"avahi socket race? port collision?"` reads as uncertainty. Either confirm the issue or split into two checks.
+- **Self-referential phrasing**: don't claim something is wrong when the check itself is what made it wrong (see ADR/auto-boot smoke `starting` paradox).
+
+## "Skipped" rule
+
+Every `info "... skipped"` MUST include the reason in parentheses + one of:
+
+- **(authoritative check above)** — another check already covers the same property
+- **(missing dep: <name>)** — install hint
+- **(N/A on <profile>)** — wrong device class, e.g. `(N/A on native client)`
+
+## Glossary inline
+
+When using terms not obvious to a Pi-hobbyist operator, add one-line inline gloss the first time per check:
+
+```
+[OK] Snapcast RPC (port 1705 JSON-RPC control): responsive
+[OK] DSCP EF marking (per-packet priority hint): present on port 1704
+```
+
+Single mention per `check_*.sh` script is enough — repetition becomes noise.

--- a/scripts/smoke/check_audio_modules.sh
+++ b/scripts/smoke/check_audio_modules.sh
@@ -64,7 +64,7 @@ check_audio_modules() {
     done
 
     if [[ -z "$hat_config" ]]; then
-        info "HAT_CONFIG not set in .env — kernel module check skipped"
+        info "Per-HAT kernel module check skipped (HAT_CONFIG not in .env) — ALSA card consistency already verified above is the authoritative check"
         return 0
     fi
 
@@ -73,7 +73,7 @@ check_audio_modules() {
     # Look up the expected modules for this HAT.
     local expected="${_HAT_MODULES[$hat_config]:-}"
     if [[ -z "$expected" ]]; then
-        info "HAT '$hat_config' has no expected-modules list (add to scripts/smoke/check_audio_modules.sh _HAT_MODULES) — skipped"
+        info "Per-HAT kernel module check skipped (no expected-modules list for '$hat_config') — ALSA card consistency above is the authoritative check"
         return 0
     fi
 

--- a/scripts/smoke/check_containers.sh
+++ b/scripts/smoke/check_containers.sh
@@ -181,10 +181,10 @@ check_containers() {
         if [[ -n "$health" ]]; then
             case "$health" in
                 healthy)
-                    pass_check "$name: healthcheck reporting healthy"
+                    pass_check "$name: healthy"
                     ;;
                 unhealthy)
-                    fail_check "$name: healthcheck reporting unhealthy — service is failing its probe"
+                    fail_check "$name: unhealthy — service is failing its healthcheck probe"
                     ;;
                 starting)
                     # If container has been up more than 5 min and still
@@ -196,13 +196,13 @@ check_containers() {
                         uptime_s=$(( $(date +%s) - $(date -d "$started_at" +%s 2>/dev/null || echo 0) ))
                     fi
                     if (( uptime_s > 300 )); then
-                        warn "$name: healthcheck still 'starting' after $((uptime_s/60)) min — probe may be stuck"
+                        warn "$name: healthcheck stuck on 'starting' after $((uptime_s/60)) min — probe never settled"
                     else
-                        info "$name: healthcheck 'starting' (uptime ${uptime_s}s — within start_period)"
+                        info "$name: healthcheck warming up (${uptime_s}s, still within the grace period)"
                     fi
                     ;;
                 *)
-                    warn "$name: healthcheck status '$health' (unexpected)"
+                    warn "$name: unexpected healthcheck status '$health'"
                     ;;
             esac
         fi
@@ -224,7 +224,7 @@ check_containers() {
         if (( ${#restart_history[@]} > 0 )); then
             local joined
             printf -v joined "%s, " "${restart_history[@]}"; joined="${joined%, }"
-            info "Past container restart(s) observed, current state not failing: $joined"
+            info "Container(s) restarted in the past but stable now: $joined"
         fi
     fi
 
@@ -232,7 +232,7 @@ check_containers() {
     if (( ${#no_limit[@]} > 0 )); then
         local joined
         printf -v joined "%s, " "${no_limit[@]}"; joined="${joined%, }"
-        fail_check "Container(s) with HostConfig.Memory=0 (limit drift — deploy.sh must --force-recreate): $joined"
+        fail_check "Container(s) without memory limit applied (re-run deploy.sh to restore): $joined"
     else
         pass_check "All $checked snapMULTI container(s) have memory limit applied"
     fi
@@ -264,11 +264,11 @@ check_containers() {
             plugin_count=$("${docker_cmd[@]}" exec snapserver pgrep -f 'meta_' 2>/dev/null | wc -l | tr -d ' ' || echo 0)
             plugin_count=${plugin_count:-0}
             if (( plugin_count == 0 )); then
-                fail_check "No meta_*.py plugins running in snapserver — cover art + 'now playing' will be empty for all sources"
+                fail_check "Metadata plugins inside snapserver: none — cover art + 'now playing' will be empty for every source"
             elif (( plugin_count == 1 )); then
-                warn "Only 1 meta_*.py plugin running in snapserver — most snapMULTI installs run 4 (mpd, librespot, tidal, shairport)"
+                warn "Metadata plugins inside snapserver: only 1 (typical full install runs 4: mpd, librespot, tidal, shairport)"
             else
-                pass_check "$plugin_count meta_*.py plugin(s) running in snapserver"
+                pass_check "Metadata plugins inside snapserver: $plugin_count active"
             fi
         fi
     fi

--- a/scripts/smoke/check_mdns.sh
+++ b/scripts/smoke/check_mdns.sh
@@ -49,7 +49,7 @@ check_mdns() {
     # nothing. Reserve the actual browse call for the second step.
     if ! command -v avahi-browse >/dev/null 2>&1 \
         && ! command -v dns-sd >/dev/null 2>&1; then
-        warn "Neither avahi-browse nor dns-sd installed — mDNS check skipped"
+        warn "Snapcast mDNS announcement check skipped (missing dep: avahi-utils — install to inspect the LAN service announcement)"
         return
     fi
 
@@ -82,17 +82,17 @@ check_mdns() {
     case "$MODE" in
         server|both)
             if (( resolved == 0 )); then
-                fail_check "_snapcast._tcp NOT advertised on mDNS — clients will not find this server (avahi socket race? port collision?)"
+                fail_check "Snapcast mDNS announcement: not visible on LAN — clients won't find this server (check Avahi daemon status and Snapcast logs)"
             elif [[ "$advertised_hosts" == *"$our_hostname"* ]] \
                 || [[ "$advertised_hosts" == *"${our_hostname}.local"* ]]; then
-                pass_check "_snapcast._tcp advertised by self ($our_hostname) — visible on LAN"
+                pass_check "Snapcast mDNS announcement: published by self ($our_hostname) — visible on LAN"
             else
-                warn "_snapcast._tcp advertised (hosts: ${advertised_hosts:-unknown}) but not by self ($our_hostname) — name mismatch or self-resolve race"
+                warn "Snapcast mDNS announcement: published by ${advertised_hosts:-unknown} but not by self ($our_hostname) — hostname mismatch on the LAN"
             fi
             ;;
         client)
             if (( resolved == 0 )); then
-                fail_check "_snapcast._tcp: no servers seen on LAN (no peer publishing, or multicast blocked)"
+                fail_check "Snapcast mDNS announcement: no servers visible on LAN (no peer publishing, or multicast blocked by router/AP)"
             else
                 # Show how many servers we can see and which.
                 local server_count
@@ -100,11 +100,11 @@ check_mdns() {
                     | awk -F';' '{print $7}' \
                     | sort -u | wc -l | tr -cd '0-9')
                 server_count=${server_count:-0}
-                pass_check "_snapcast._tcp visible: $server_count server(s) on LAN (${advertised_hosts:-unknown})"
+                pass_check "Snapcast mDNS announcement: $server_count server(s) visible on LAN (${advertised_hosts:-unknown})"
             fi
             ;;
         *)
-            info "_snapcast._tcp resolved-rows count: $resolved (MODE=$MODE)"
+            info "Snapcast mDNS announcement: $resolved entries visible (mode=$MODE)"
             ;;
     esac
 }

--- a/scripts/smoke/check_mounts.sh
+++ b/scripts/smoke/check_mounts.sh
@@ -99,7 +99,7 @@ check_mounts() {
         local automount_active_lines
         automount_active_lines=$(grep -v '^[[:space:]]*#' "/etc/systemd/system/$automount_name" 2>/dev/null || true)
         if echo "$automount_active_lines" | grep -qE '^[[:space:]]*(After|Wants|Requires|BindsTo)=.*network-online\.target'; then
-            fail_check "$automount_name carries network-online.target ordering (PR #334 regression — boot-time ordering cycle)"
+            fail_check "$automount_name carries network-online.target ordering — boot-time ordering cycle"
         else
             pass_check "$automount_name has no network-online ordering (no boot-time cycle)"
         fi
@@ -129,7 +129,7 @@ check_mounts() {
             pass_check "$mount_name is '$mount_state' (NOT eager-enabled — correct)"
             ;;
         enabled|enabled-runtime)
-            fail_check "$mount_name is eager-enabled — slow NAS will block snapmulti-server.service startup (PR #334 regression)"
+            fail_check "$mount_name is eager-enabled — slow NAS will block snapmulti-server.service startup (should be lazy via .automount)"
             ;;
     esac
 

--- a/scripts/smoke/check_mounts.sh
+++ b/scripts/smoke/check_mounts.sh
@@ -31,7 +31,7 @@ check_mounts() {
     local server_env music_source music_path
     server_env="${SERVER_DIR:-/opt/snapmulti}/.env"
     if [[ ! -f "$server_env" ]]; then
-        info "Server .env not found — mount unit checks skipped"
+        info "Music mount checks: skipped (server .env not found — N/A on client-only install)"
         return 0
     fi
     # Strip surrounding quotes — `.env` may store values as
@@ -48,7 +48,7 @@ check_mounts() {
             : # check below
             ;;
         *)
-            info "MUSIC_SOURCE='${music_source:-unset}' — not network-backed, mount unit check skipped"
+            info "Music mount checks: skipped (MUSIC_SOURCE='${music_source:-unset}' is not a network share)"
             return 0
             ;;
     esac
@@ -70,12 +70,12 @@ check_mounts() {
 
     # 1. Unit files exist on disk.
     if [[ -f "/etc/systemd/system/$automount_name" ]]; then
-        pass_check "$automount_name unit file present in /etc/systemd/system/"
+        pass_check "Music automount unit ($automount_name): installed"
     else
         fail_check "$automount_name unit file missing — mount-music.sh did not run or failed"
     fi
     if [[ -f "/etc/systemd/system/$mount_name" ]]; then
-        pass_check "$mount_name unit file present in /etc/systemd/system/"
+        pass_check "Music mount unit ($mount_name): installed"
     else
         fail_check "$mount_name unit file missing"
     fi

--- a/scripts/smoke/check_qos.sh
+++ b/scripts/smoke/check_qos.sh
@@ -35,17 +35,17 @@ check_qos() {
         qdisc_root=$(tc qdisc show dev "$egress_iface" 2>/dev/null | awk '/^qdisc / && /root/ {print $2; exit}')
         case "$qdisc_root" in
             cake)
-                pass_check "CAKE qdisc active on $egress_iface (root)"
+                pass_check "Network egress queue (CAKE smart queueing): active on $egress_iface"
                 ;;
             "")
-                fail_check "No qdisc readable on $egress_iface — tc command output empty"
+                fail_check "Network egress queue: unreadable on $egress_iface (tc command produced no output)"
                 ;;
             *)
-                warn "Default qdisc on $egress_iface is '$qdisc_root', expected 'cake' (kernel may lack sch_cake module)"
+                warn "Network egress queue on $egress_iface is '$qdisc_root', expected 'cake' (kernel may lack the sch_cake module — Snapcast still works but bufferbloat can desync rooms)"
                 ;;
         esac
     else
-        warn "tc not installed — CAKE qdisc check skipped"
+        warn "Network egress queue check skipped (missing dep: iproute2 — install for traffic shaping inspection)"
     fi
 
     # 2. DSCP EF (0x2e) marking on Snapcast streaming + RPC. The actual
@@ -67,17 +67,17 @@ check_qos() {
         dscp_rpc=$(echo "$mangle_dump" | { grep -cE "tcp +spt:${rpc_port} +DSCP +set 0x2e" || true; })
 
         if [[ "$dscp_streaming" -ge 1 ]]; then
-            pass_check "DSCP EF marking on Snapcast streaming port 1704"
+            pass_check "Snapcast streaming priority tag (DSCP EF): set on port 1704"
         else
-            fail_check "No DSCP EF mangle rule on tcp sport 1704 — bufferbloat will desync rooms"
+            fail_check "Snapcast streaming priority tag: missing on port 1704 — bufferbloat will desync rooms when LAN is busy"
         fi
         if [[ "$dscp_rpc" -ge 1 ]]; then
-            pass_check "DSCP EF marking on Snapcast RPC port $rpc_port"
+            pass_check "Snapcast RPC priority tag (DSCP EF): set on port $rpc_port"
         else
-            fail_check "No DSCP EF mangle rule on tcp sport $rpc_port"
+            fail_check "Snapcast RPC priority tag: missing on port $rpc_port"
         fi
     else
-        warn "iptables not installed — DSCP marking check skipped"
+        warn "Priority tag (DSCP) check skipped (missing dep: iptables — install for QoS inspection)"
     fi
 
     # 3. Persistence hook in NetworkManager dispatcher. Pi OS uses NM, not
@@ -87,11 +87,11 @@ check_qos() {
     # (it was the original install location pre-v0.7.8.11 and never fired
     # on Pi OS — flag it so operators re-run deploy.sh or reflash to remove it).
     if [[ -x /etc/NetworkManager/dispatcher.d/50-cake-qos ]]; then
-        pass_check "CAKE persistence hook installed (/etc/NetworkManager/dispatcher.d/50-cake-qos)"
+        pass_check "Network egress queue persistence hook: installed (will re-apply on every NetworkManager event)"
     else
-        warn "CAKE persistence hook missing — qdisc will be lost on next iface restart"
+        warn "Network egress queue persistence hook: missing — CAKE will be lost on next network restart"
     fi
     if [[ -e /etc/networkd-dispatcher/routable.d/50-cake-qos ]]; then
-        warn "Legacy CAKE hook still present in networkd-dispatcher (never fires on NM hosts) — re-run deploy.sh or reflash to remove"
+        warn "Legacy egress-queue hook from older snapMULTI still present (no effect on Pi OS) — re-run deploy.sh or reflash to remove"
     fi
 }

--- a/scripts/smoke/check_snapcast.sh
+++ b/scripts/smoke/check_snapcast.sh
@@ -66,20 +66,20 @@ check_snapcast() {
 
     case "$MODE" in
         client)
-            info "Client mode — snapserver/MPD checks skipped (no local server)"
+            info "Snapserver / MPD checks: skipped (N/A on client-only install)"
             return
             ;;
     esac
 
     if ! command -v curl >/dev/null 2>&1; then
-        warn "curl not installed — Snapcast RPC check skipped"
+        warn "Snapcast control API check skipped (missing dep: curl)"
     else
         local rpc_json
         rpc_json=$(_snapcast_get_status)
         if [[ -z "$rpc_json" ]]; then
-            fail_check "Snapcast RPC at $_SNAPSERVER_RPC_URL did not respond — server down or RPC port closed"
+            fail_check "Snapcast control API ($_SNAPSERVER_RPC_URL): no response — server down or port closed"
         elif ! command -v jq >/dev/null 2>&1; then
-            info "jq not installed — RPC reachable but contents not inspected"
+            info "Snapcast control API: reachable, but client roster not parsed (missing dep: jq)"
         else
             # Extract client count and disconnected client list. Snapserver
             # keeps paired clients in its state even when they are offline;
@@ -99,12 +99,12 @@ check_snapcast() {
                 ' <<<"$rpc_json" 2>/dev/null || true
             )
             if (( client_count == 0 )); then
-                warn "Snapcast: 0 clients in any group — multiroom has no listeners (intentional if no players paired yet)"
+                warn "Snapcast clients: none paired yet — multiroom has no listeners (normal on a fresh install)"
             elif (( disconnected > 0 )); then
-                pass_check "Snapcast: $connected/$client_count clients connected"
-                info "Disconnected Snapcast client(s): ${disconnected_clients:-unknown} — paired but offline"
+                pass_check "Snapcast clients: $connected of $client_count connected"
+                info "Snapcast clients offline: ${disconnected_clients:-unknown} (paired but not reachable now)"
             else
-                pass_check "Snapcast: $connected/$client_count clients connected"
+                pass_check "Snapcast clients: $connected of $client_count connected"
             fi
         fi
     fi
@@ -115,7 +115,7 @@ check_snapcast() {
     local mpc_out
     mpc_out=$(_mpc_status)
     if [[ -z "$mpc_out" ]]; then
-        info "mpc unavailable on host and in container — MPD state not inspected (install mpc-cli to enable)"
+        info "MPD state check skipped (missing dep: mpc-cli on both host and container)"
         return
     fi
 
@@ -142,6 +142,6 @@ check_snapcast() {
     if grep -qE "^Updating DB" <<<"$mpc_out"; then
         local job
         job=$(grep -oE 'Updating DB \(#[0-9]+\)' <<<"$mpc_out" | head -1)
-        info "MPD library scan in progress ($job) — large libraries can take hours; transient FAIL on 'mpd: starting' healthcheck is expected during this window"
+        info "MPD library scan in progress ($job) — large libraries can take hours; a transient FAIL on mpd healthcheck during this window is expected"
     fi
 }

--- a/scripts/smoke/check_timers.sh
+++ b/scripts/smoke/check_timers.sh
@@ -72,6 +72,6 @@ check_timers() {
     if [[ "${INSTALL_TYPE_NATIVE_CLIENT:-false}" == "true" ]]; then
         info "Timer snapclient-discover.timer skipped on native client (libavahi-client used instead)"
     else
-        _check_timer "snapclient-discover.timer"    "mDNS server discovery (PR #285 multi-server failover)" client
+        _check_timer "snapclient-discover.timer"    "mDNS server rediscovery (multi-server failover)" client
     fi
 }


### PR DESCRIPTION
Opzione B audit completo dopo PR #510 (low-hanging fruit). 5 check files toccati, 1 new style-guide.

### scripts/smoke/MESSAGING.md
Style guide breve per future check authors: sentence shape, status semantics, banned phrasing, mandatory reason on 'skipped' info, banned phrasing (PR numbers, implementation detail leakage, pseudo-questions).

### Files riscritti (semantics-preserving)
| File | Cambio principale |
|------|-------------------|
| check_mdns.sh | \`_snapcast._tcp\` (tech record name) → \"Snapcast mDNS announcement\" |
| check_qos.sh | \"CAKE qdisc\" + \"DSCP EF\" → user-readable names with inline gloss |
| check_snapcast.sh | \"Snapcast RPC\" → \"Snapcast control API\"; unified missing-dep wording |
| check_mounts.sh | rimosso \`/etc/systemd/system/\` path leakage in pass_check |
| check_containers.sh | \"healthcheck reporting healthy\" → \"healthy\"; tutti gli status unified |

### Garanzie
- pass/fail/warn/info status codes invariati (JSON \`--json\` output schema unchanged)
- Solo message text cambiato
- Bash syntax verificato su tutti i 5 file
- Altri 6 check files auditati; wording già conforme alle guidelines