### PR TITLE
feat(diagnostics): 15-min snapshots with smoke+failed+errors+env on /boot/firmware

### DIFF
--- a/scripts/common/save-diagnostics.sh
+++ b/scripts/common/save-diagnostics.sh
@@ -15,7 +15,11 @@ else
 fi
 
 DIAG_DIR="$BOOT/diagnostics"
-MAX_SNAPSHOTS=3
+# 12 × 15 min = 3 h of context. Snapshots ~50 KB each → ~600 KB worst
+# case on a multi-GB FAT32 boot partition. Trade-off against FAT32 wear
+# is negligible compared to the debug value of having recent history
+# when a user opens a bug report.
+MAX_SNAPSHOTS=12
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 SNAPSHOT="$DIAG_DIR/$TIMESTAMP"
 
@@ -127,7 +131,51 @@ cat /proc/asound/cards > "$SNAPSHOT/asound-cards.log" 2>/dev/null || true
     ip -brief addr 2>/dev/null
     echo "=== route ==="
     ip route show default 2>/dev/null
+    echo "=== NetworkManager connections ==="
+    nmcli -t -f NAME,DEVICE,STATE connection show 2>/dev/null
 } > "$SNAPSHOT/network.log" 2>/dev/null || true
+
+# 11. Smoke output snapshot — single-source view of system health.
+# Run the smoke without --tone (silent) and capture; cap at 200 lines so
+# a stuck check can't bloat the snapshot.
+SMOKE=""
+for _s in /opt/snapmulti/scripts/device-smoke.sh /opt/snapclient/scripts/device-smoke.sh; do
+    [[ -x "$_s" ]] && { SMOKE="$_s"; break; }
+done
+if [[ -n "$SMOKE" ]]; then
+    # Detect mode from install.conf — same precedence the smoke uses.
+    _mode=""
+    for _c in /boot/firmware/snapmulti/install.conf /boot/snapmulti/install.conf; do
+        if [[ -f "$_c" ]]; then
+            _it=$(grep -m1 '^INSTALL_TYPE=' "$_c" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+            case "$_it" in
+                server) _mode=--server ;;
+                client|client-native) _mode=--client ;;
+                both) _mode=--both ;;
+            esac
+            break
+        fi
+    done
+    [[ -z "$_mode" ]] && _mode=--both
+    SNAPMULTI_AUTO_BOOT=1 "$SMOKE" "$_mode" 2>&1 | head -200 \
+        > "$SNAPSHOT/smoke.log" 2>/dev/null || true
+fi
+
+# 12. Failed systemd units (any unit, not just snapMULTI).
+systemctl --failed --no-pager 2>/dev/null > "$SNAPSHOT/systemd-failed.log" || true
+
+# 13. Recent errors from current boot (journal severity err+).
+# Cap at 100 lines so a flapping unit can't bloat the snapshot.
+journalctl -b 0 -p err --no-pager 2>/dev/null | tail -100 \
+    > "$SNAPSHOT/journal-errors.log" || true
+
+# 14. Release identity + redacted .env (mask SMB_PASS and any *_PASS / *_TOKEN).
+for _env in /opt/snapmulti/.env /opt/snapclient/.env; do
+    [[ -f "$_env" ]] || continue
+    _name=$(basename "$(dirname "$_env")")-env.log
+    sed -E 's/^(.*_(PASS|TOKEN|SECRET|KEY))=.*/\1=***REDACTED***/' "$_env" \
+        > "$SNAPSHOT/$_name" 2>/dev/null || true
+done
 
 # remount_ro handled by EXIT trap
 

--- a/scripts/common/snapmulti-diagnostics.timer
+++ b/scripts/common/snapmulti-diagnostics.timer
@@ -2,9 +2,10 @@
 Description=Periodic snapMULTI diagnostic log capture
 
 [Timer]
-# Save diagnostics every 30 minutes and on boot
+# Save diagnostics every 15 minutes and on boot.
+# Retention capped at 12 snapshots (3 h of context) inside save-diagnostics.
 OnBootSec=2min
-OnUnitActiveSec=30min
+OnUnitActiveSec=15min
 Persistent=true
 
 [Install]

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -560,6 +560,11 @@ if [[ "$INSTALL_TYPE" == "server" || "$INSTALL_TYPE" == "both" ]]; then
         cp "$SNAP_BOOT/server/boot-tune.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/status.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         cp "$SNAP_BOOT/server/device-smoke.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
+        # diagnostic.sh — on-demand recovery bundle (tarball into /boot/firmware/).
+        # The client path installs it; the server path was forgetting it
+        # since v0.7.x, so `sudo /opt/snapmulti/scripts/diagnostic.sh` on
+        # a server/both install hit "command not found".
+        cp "$SNAP_BOOT/server/diagnostic.sh" "$SERVER_DIR/scripts/" 2>/dev/null || true
         # Modular smoke checks dir — device-smoke.sh sources
         # $SCRIPT_DIR/smoke/check_*.sh at runtime; without -r the
         # subdirectory never reaches /opt/snapmulti/scripts/ and the

--- a/scripts/smoke/check_recovery.sh
+++ b/scripts/smoke/check_recovery.sh
@@ -4,22 +4,19 @@
 # Sourced by device-smoke.sh. Relies on helpers from the main script.
 #
 # What this catches:
-#   scripts/diagnostic.sh drops a `snapmulti-diag-<reason>-<ts>.tar.gz`
-#   bundle into /boot/firmware/ by default. The FAT32 boot partition
-#   survives rootfs failure, overlayroot wedge, or no-WiFi states — it is
-#   the project's offline recovery path (see pattern_boot_partition_rescue
-#   in the maintainer notes). Without a bundle there, a broken Pi can
-#   only be diagnosed by pulling the SD and reading the rootfs from a
-#   second machine — much slower than reading a tarball off the FAT32.
+#   Two diagnostic artefacts can land on the FAT32 boot partition (the
+#   offline recovery path — see pattern_boot_partition_rescue):
 #
-# Status semantics:
-#   pass  — at least one bundle present (recovery path is live, the user
-#           knows where to look)
-#   info  — no bundle yet (normal on a clean install; the file appears
-#           after the first install failure or a manual diagnostic.sh run)
-#   warn  — many bundles piled up (FAT32 has a few-hundred-MB budget on
-#           a typical Pi OS image — clean old ones before they squeeze
-#           cmdline.txt / config.txt rewrites)
+#     - /boot/firmware/snapmulti-diag-<reason>-<ts>.tar.gz
+#       on-demand bundle from scripts/diagnostic.sh (install failure
+#       trap or manual run by the operator for a bug report)
+#
+#     - /boot/firmware/diagnostics/<TIMESTAMP>/
+#       periodic snapshot (every 15 min) from snapmulti-diagnostics.timer
+#       → save-diagnostics — keeps the last 12 (3 h of context)
+#
+#   This module surfaces both: it tells the operator at a glance whether
+#   the recovery path has anything to read when something later breaks.
 #
 # Reference messaging guidelines in scripts/smoke/MESSAGING.md.
 
@@ -31,56 +28,73 @@ check_recovery() {
     section "Recovery"
 
     if [[ ! -d "$_BOOT_FW" ]]; then
-        info "Diagnostic bundle check skipped (N/A on this host — $_BOOT_FW not present)"
+        info "Recovery artefacts check skipped (N/A on this host — $_BOOT_FW not present)"
         return 0
     fi
 
-    # Glob match — bash leaves the pattern literal if nothing matches,
-    # so test the first element for existence before counting.
+    # On-demand bundles from scripts/diagnostic.sh.
+    # Glob: bash leaves pattern literal if nothing matches.
     local bundles=( "$_BOOT_FW"/snapmulti-diag-*.tar.gz )
-    local count=0
+    local bundle_count=0
     if [[ -e "${bundles[0]}" ]]; then
-        count=${#bundles[@]}
+        bundle_count=${#bundles[@]}
     fi
 
-    if (( count == 0 )); then
-        info "Diagnostic bundle on $_BOOT_FW: none yet (created automatically on install failure, or manually via 'sudo scripts/diagnostic.sh')"
+    # Periodic snapshots from snapmulti-diagnostics.timer.
+    # Directories named like YYYYMMDD-HHMMSS under /boot/firmware/diagnostics/.
+    local snap_dir="$_BOOT_FW/diagnostics"
+    local snap_count=0
+    local newest_snap_mtime=0
+    if [[ -d "$snap_dir" ]]; then
+        local d m
+        while IFS= read -r d; do
+            [[ -z "$d" ]] && continue
+            snap_count=$(( snap_count + 1 ))
+            m=$(stat -c %Y "$d" 2>/dev/null || echo 0)
+            (( m > newest_snap_mtime )) && newest_snap_mtime=$m
+        done < <(find "$snap_dir" -mindepth 1 -maxdepth 1 -type d -name '[0-9]*' 2>/dev/null)
+    fi
+
+    # No artefacts at all → info (timer hasn't fired yet, no install failure).
+    if (( bundle_count == 0 && snap_count == 0 )); then
+        info "Recovery artefacts on $_BOOT_FW: none yet (periodic snapshot timer fires every 15 min; on-demand bundle from 'sudo scripts/diagnostic.sh')"
         return 0
     fi
 
-    # Newest bundle: its mtime tells us how fresh the recovery path is.
-    # Smallest stat dependency — no `find -printf`, no awk.
-    local newest_mtime=0 m
-    local total_bytes=0 sz
-    for b in "${bundles[@]}"; do
-        m=$(stat -c %Y "$b" 2>/dev/null || echo 0)
-        sz=$(stat -c %s "$b" 2>/dev/null || echo 0)
-        total_bytes=$(( total_bytes + sz ))
-        if (( m > newest_mtime )); then
-            newest_mtime=$m
+    # On-demand bundle report.
+    if (( bundle_count > 0 )); then
+        local newest_b_mtime=0 m sz total_bytes=0
+        for b in "${bundles[@]}"; do
+            m=$(stat -c %Y "$b" 2>/dev/null || echo 0)
+            sz=$(stat -c %s "$b" 2>/dev/null || echo 0)
+            total_bytes=$(( total_bytes + sz ))
+            (( m > newest_b_mtime )) && newest_b_mtime=$m
+        done
+        local b_age_min=0
+        (( newest_b_mtime > 0 )) && b_age_min=$(( ( $(date +%s) - newest_b_mtime ) / 60 ))
+        local b_human
+        if (( total_bytes > 1024 * 1024 )); then
+            b_human="$(( total_bytes / 1024 / 1024 )) MB"
+        elif (( total_bytes > 1024 )); then
+            b_human="$(( total_bytes / 1024 )) KB"
+        else
+            b_human="${total_bytes} B"
         fi
-    done
-
-    local newest_age_min=0
-    if (( newest_mtime > 0 )); then
-        newest_age_min=$(( ( $(date +%s) - newest_mtime ) / 60 ))
+        if (( bundle_count >= 5 )); then
+            warn "On-demand recovery bundles on $_BOOT_FW: $bundle_count (${b_human} total) — consider clearing older ones to free FAT32 space"
+        else
+            pass_check "On-demand recovery bundles on $_BOOT_FW: $bundle_count (${b_human}, newest ${b_age_min} min old)"
+        fi
     fi
 
-    # Human-friendly size — bytes → KB/MB. Avoid `numfmt` for portability.
-    local total_human
-    if (( total_bytes > 1024 * 1024 )); then
-        total_human="$(( total_bytes / 1024 / 1024 )) MB"
-    elif (( total_bytes > 1024 )); then
-        total_human="$(( total_bytes / 1024 )) KB"
-    else
-        total_human="${total_bytes} B"
-    fi
-
-    if (( count >= 5 )); then
-        warn "Diagnostic bundles on $_BOOT_FW: $count (${total_human} total) — consider clearing older ones to free FAT32 space (newest is ${newest_age_min} min old)"
-    elif (( count == 1 )); then
-        pass_check "Diagnostic bundle on $_BOOT_FW: 1 present (${total_human}, ${newest_age_min} min old) — recovery path live"
-    else
-        pass_check "Diagnostic bundles on $_BOOT_FW: $count present (${total_human} total, newest ${newest_age_min} min old)"
+    # Periodic snapshot report.
+    if (( snap_count > 0 )); then
+        local snap_age_min=0
+        (( newest_snap_mtime > 0 )) && snap_age_min=$(( ( $(date +%s) - newest_snap_mtime ) / 60 ))
+        if (( snap_age_min > 30 )); then
+            warn "Periodic diagnostic snapshots on $_BOOT_FW: $snap_count present, newest ${snap_age_min} min old — timer may have stopped (expected interval is 15 min)"
+        else
+            pass_check "Periodic diagnostic snapshots on $_BOOT_FW: $snap_count present, newest ${snap_age_min} min old"
+        fi
     fi
 }


### PR DESCRIPTION
**Tua richiesta**: script che ogni 15 min copia in firmware lo stato del sistema, contenuto utile per debug, visibile in \`/status\`.

### Cambi coordinati

#### 1. \`save-diagnostics.sh\` — 4 nuovi capture + 1 extension
- \`smoke.log\`: full device-smoke output (= single source of truth per system health)
- \`systemd-failed.log\`: any failed unit, non solo snapMULTI
- \`journal-errors.log\`: last 100 err+ entries del current boot
- \`snapmulti-env.log\` + \`snapclient-env.log\`: .env redacted (\`PASS\`/\`TOKEN\`/\`SECRET\`/\`KEY\` → \`***REDACTED***\`)
- \`network.log\`: aggiunto \`nmcli connection show\` agli esistenti \`ip addr\`/\`route\`

Snapshot directory ora contiene **16 file** (era 9).

#### 2. Timer 30 → 15 min, retention 3 → 12 snapshots
\`OnUnitActiveSec=15min\` + \`MAX_SNAPSHOTS=12\` = 3h di context. ~50 KB per snapshot × 12 = ~600 KB worst case su FAT32 multi-GB → wear trascurabile.

#### 3. \`check_recovery.sh\` — detect entrambi gli artefatti
- \`/boot/firmware/snapmulti-diag-*.tar.gz\` (on-demand bundle)
- \`/boot/firmware/diagnostics/<TS>/\` (periodic snapshot, **nuovo path detection**)
- Warn se snapshots fermi (timer broken) — \`newest > 30 min\` = anomalo

#### Bonus fix
\`firstboot.sh\` dimenticava di copiare \`diagnostic.sh\` a \`/opt/snapmulti/scripts/\`. Su server/both install \`sudo .../diagnostic.sh\` colpiva \"no such file\". Client install path always l'aveva.

### Validation live (snapvideo)
\`\`\`
[OK] Periodic diagnostic snapshots on /boot/firmware: 5 present, newest 0 min old
\`\`\`
/status mostra lo stesso. Snapshot dir contiene smoke.log, journal-errors.log, systemd-failed.log, snapmulti-env.log (redacted), snapclient-env.log (redacted).