### PR TITLE
fix(mympd): bump default MEM_LIMIT 64M → 128M (OOM on large libraries)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,8 +75,9 @@ PGID=1000
 # Also used by myMPD (must wait for MPD to be ready before starting)
 #MPD_START_PERIOD=60s
 
-# myMPD (Web UI) — measured idle: 8M
-#MYMPD_MEM_LIMIT=64M
+# myMPD (Web UI) — idle 8M, but peaks past 64M with large libraries (76k+ songs);
+# OOM-killed on snapvideo 2026-05-27 with the old 64M default. 128M is safe.
+#MYMPD_MEM_LIMIT=128M
 #MYMPD_MEM_RESERVE=32M
 #MYMPD_CPU_LIMIT=0.5
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,7 +196,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${MYMPD_MEM_LIMIT:-64M}
+          memory: ${MYMPD_MEM_LIMIT:-128M}
           cpus: '${MYMPD_CPU_LIMIT:-0.5}'
         reservations:
           memory: ${MYMPD_MEM_RESERVE:-32M}


### PR DESCRIPTION
**Log review snapvideo 2026-05-27 19:02:25**: mympd OOM-killed by cgroup memcg constraint.

\`\`\`
kernel: webserver invoked oom-killer ... task=mympd, pid=1910
kernel: Memory cgroup out of memory: Killed process 1910 (mympd) total-vm:47912kB, anon-rss:29776kB
\`\`\`

64M limit insufficient quando il webserver interno fa cover-art + playlist queries concurrent su una libreria 76k+ songs. Container restartato OK, ma con \"unhealthy\" tone falso-positivo visto subito dopo.

### Fix
- \`docker-compose.yml\`: default \`MYMPD_MEM_LIMIT\` 64M → 128M
- \`.env.example\`: comment updated con incident reference

### Evidence che 128M è safe
snapvideo già su 128M (qualcuno l'ha alzato post-OOM) → utilizzo attuale \`27 MB / 128 MB\` (21%). Plenty di headroom.

### Impact
- Devices con \`.env\` esplicito \`MYMPD_MEM_LIMIT=...\` non sono toccati (override mantained)
- Nuovi reflash (post-merge) prendono 128M default automaticamente
- Script-only release (image_set 0.7.7 unchanged)