### PR TITLE
fix(udev): drop DEVTYPE from USB autosuspend rule (cosmetic journal warning)

### DIFF
--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -98,7 +98,13 @@ tune_usb_autosuspend() {
 
     if echo -1 > /sys/module/usbcore/parameters/autosuspend 2>/dev/null; then
         if mkdir -p /etc/udev/rules.d 2>/dev/null; then
-            if ! echo 'ACTION=="add", SUBSYSTEM=="usb", DEVTYPE=="usb_device", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"' \
+            # DEVTYPE intentionally omitted: it's evaluated against USB
+            # interface events too, where it's not "usb_device", and
+            # systemd-udevd then logs "Invalid key 'DEVTYPE'" on every
+            # rule reload (cosmetic but noisy in journals). The combo
+            # SUBSYSTEM=="usb" + TEST=="power/autosuspend" already
+            # filters to whole-device events that carry the attribute.
+            if ! echo 'ACTION=="add", SUBSYSTEM=="usb", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"' \
                 > /etc/udev/rules.d/50-usb-no-autosuspend.rules 2>/dev/null; then
                 is_overlayroot && warn "USB autosuspend: udev rule skipped (overlayroot)"
             fi


### PR DESCRIPTION
Log review snapvideo trovava 2 noise entries per ogni udev reload:
\`\`\`
/etc/udev/rules.d/50-usb-no-autosuspend.rules:1 Invalid key 'DEVTYPE'
\`\`\`

Cause: \`DEVTYPE==\"usb_device\"\` veniva valutato anche contro USB *interface* events (dove DEVTYPE != usb_device). systemd-udevd logga \"Invalid key\" come warning cosmetico ma rumoroso in journal.

### Fix
Rimosso \`DEVTYPE==\"usb_device\"\`. Il match restante (\`SUBSYSTEM==\"usb\"\` + \`TEST==\"power/autosuspend\"\`) basta: il TEST filtra solo whole-device events che hanno l'attribute. Behaviour autosuspend identico, journal pulito.

No release roll — accumula con altri fix futuri.