### PR TITLE
docs(advanced): bump version examples v0.7.8.12 → v0.7.8.16

### DIFF
--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -169,7 +169,7 @@ Dopo ogni reflash o aggiornamento in-place, esegui il test di salute sul device 
 
 snapMULTI separa due concetti di versione, così una release di soli script (CHANGELOG, docs, fix nell'installer) non costringe a ricostruire e ripubblicare le immagini Docker:
 
-- **`SNAPMULTI_RELEASE`** — il tag git della release (es. `v0.7.8.12`). Quello che `gh release view` mostra.
+- **`SNAPMULTI_RELEASE`** — il tag git della release (es. `v0.7.8.16`). Quello che `gh release view` mostra.
 - **`SNAPMULTI_IMAGE_SET`** — il tag Docker delle immagini a cui la release si aggancia (es. `0.7.7`). Quello che `docker compose pull` scarica.
 
 La maggior parte delle release incrementa entrambi. Una release di soli script incrementa `SNAPMULTI_RELEASE` e mantiene `SNAPMULTI_IMAGE_SET` all'ultimo valore pubblicato. La fonte di verità è `release-manifest.json` alla radice del repo, copiato sulla SD da `prepare-sd.sh`.
@@ -230,7 +230,7 @@ Il gate bypassa sia `requires_image_rebuild=false` sia il check di esistenza su 
 
 Dopo deploy / reflash:
 
-- Riga info del test di salute: `device-smoke.sh` → sezione `System` → `Release v0.7.8.12 (images 0.7.7)`
+- Riga info del test di salute: `device-smoke.sh` → sezione `System` → `Release v0.7.8.16 (images 0.7.7)`
 - Pacchetto diagnostico: `scripts/diagnostic.sh` produce `meta.txt` con `snapmulti_release=...` e `snapmulti_image_set=...`; il pacchetto include anche il `release-manifest.json` (scrubbato) dalla partizione di boot.
 - `.env` del server: `grep ^SNAPMULTI_ /opt/snapmulti/.env`
 - `.env` del client: `grep ^SNAPMULTI_ /opt/snapclient/.env`

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -169,7 +169,7 @@ After every reflash or in-place update, run the smoke test on the device to conf
 
 snapMULTI separates two version concepts so a script-only release (CHANGELOG, docs, installer fixes) does not force a Docker image rebuild + repush:
 
-- **`SNAPMULTI_RELEASE`** — the git tag of the release (e.g. `v0.7.8.12`). What `gh release view` shows.
+- **`SNAPMULTI_RELEASE`** — the git tag of the release (e.g. `v0.7.8.16`). What `gh release view` shows.
 - **`SNAPMULTI_IMAGE_SET`** — the Docker image tag the release pins to (e.g. `0.7.7`). What `docker compose pull` fetches.
 
 Most releases bump both. A script-only release bumps `SNAPMULTI_RELEASE` and keeps `SNAPMULTI_IMAGE_SET` at the last published value. The source of truth is `release-manifest.json` at the repo root, staged onto the SD by `prepare-sd.sh`.
@@ -230,7 +230,7 @@ The gate bypasses both `requires_image_rebuild=false` and the Docker Hub existen
 
 After a deploy / reflash:
 
-- Smoke test info line: `device-smoke.sh` → `System` section → `Release v0.7.8.12 (images 0.7.7)`
+- Smoke test info line: `device-smoke.sh` → `System` section → `Release v0.7.8.16 (images 0.7.7)`
 - Diagnostic bundle: `scripts/diagnostic.sh` produces `meta.txt` with `snapmulti_release=...` and `snapmulti_image_set=...`; the bundle also includes the scrubbed `release-manifest.json` from the boot partition.
 - Server `.env`: `grep ^SNAPMULTI_ /opt/snapmulti/.env`
 - Client `.env`: `grep ^SNAPMULTI_ /opt/snapclient/.env`


### PR DESCRIPTION
Cosmetic update — gli example strings in docs/ADVANCED.md (+ .it.md) puntavano ancora a v0.7.8.12. Bump al current latest (v0.7.8.16).