### PR TITLE
test: refresh stale assertions after #511 + #517

### DIFF
--- a/tests/test_log_hygiene.sh
+++ b/tests/test_log_hygiene.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Static checks for log-hygiene fixes:
 #   - Compose security_opt uses `=` (not deprecated `:`) for no-new-privileges + apparmor
-#   - udev USB autosuspend rule scoped to DEVTYPE==usb_device (interfaces don't expose power/autosuspend)
+#   - udev USB autosuspend rule omits DEVTYPE (PR #517 — interface events emit "Invalid key" warnings)
 
 set -euo pipefail
 
@@ -31,13 +31,13 @@ for f in "$ROOT/docker-compose.yml" "$ROOT/client/common/docker-compose.yml"; do
 done
 
 echo
-echo "## udev USB autosuspend — scoped to usb_device"
+echo "## udev USB autosuspend — DEVTYPE omitted (PR #517)"
 
 TUNE="$ROOT/scripts/common/system-tune.sh"
-assert "grep -q 'DEVTYPE==\"usb_device\"' '$TUNE'" \
-    "system-tune.sh: rule filters DEVTYPE==usb_device"
+assert "! grep -qE \"^[[:space:]]*if !.*DEVTYPE==\\\"usb_device\\\"\" '$TUNE'" \
+    "system-tune.sh: rule no longer carries DEVTYPE filter (would re-introduce udev warnings)"
 assert "grep -q 'TEST==\"power/autosuspend\"' '$TUNE'" \
-    "system-tune.sh: rule keeps TEST==power/autosuspend (belt+suspenders)"
+    "system-tune.sh: rule keeps TEST==power/autosuspend (selector)"
 
 echo
 echo "## Summary"

--- a/tests/test_smoke_runtime_classification.sh
+++ b/tests/test_smoke_runtime_classification.sh
@@ -116,9 +116,9 @@ snapcast_output="$(
     MODE=both \
     bash -c "section() { printf 'SECTION %s\\n' \"\$*\"; }; pass_check() { printf '[OK] %s\\n' \"\$*\"; }; fail_check() { printf '[ERROR] %s\\n' \"\$*\"; }; warn() { printf '[WARN] %s\\n' \"\$*\"; }; info() { printf '[INFO] %s\\n' \"\$*\"; }; source '$CHECK_SNAPCAST'; check_snapcast"
 )"
-assert_contains "$snapcast_output" "[OK] Snapcast: 2/3 clients connected" "offline Snapcast clients do not prevent pass"
-assert_contains "$snapcast_output" "[INFO] Disconnected Snapcast client(s): pi3-1gb(192.0.2.89)" "offline Snapcast clients are listed"
-assert_not_contains "$snapcast_output" "[WARN] Snapcast: 2/3 clients connected" "offline Snapcast clients are not warnings"
+assert_contains "$snapcast_output" "[OK] Snapcast clients: 2 of 3 connected" "offline Snapcast clients do not prevent pass"
+assert_contains "$snapcast_output" "[INFO] Snapcast clients offline: pi3-1gb(192.0.2.89)" "offline Snapcast clients are listed"
+assert_not_contains "$snapcast_output" "[WARN] Snapcast clients: 2 of 3 connected" "offline Snapcast clients are not warnings"
 
 set +e
 container_output="$(
@@ -130,7 +130,7 @@ rc=$?
 set -e
 assert_rc "$rc" "0" "historical restart on healthy container does not fail"
 assert_contains "$container_output" "[OK] No active container restart failures among 1 snapMULTI container(s)" "healthy restart history is classified as OK"
-assert_contains "$container_output" "[INFO] Past container restart(s) observed, current state not failing: mympd(RC=1)" "historical restart is still reported"
+assert_contains "$container_output" "[INFO] Container(s) restarted in the past but stable now: mympd(RC=1)" "historical restart is still reported"
 assert_not_contains "$container_output" "crash-loop" "historical restart is not called crash-loop"
 
 unhealthy_output="$(


### PR DESCRIPTION
Sblocco CI per ogni PR successivo. Due test sono diventati obsoleti senza essere aggiornati:

| Test | PR che ha rotto | Modifica |
|------|-----------------|----------|
| `test_log_hygiene.sh` | #517 | rimosso `DEVTYPE==\"usb_device\"` dal rule udev |
| `test_smoke_runtime_classification.sh` | #511 | rewrite messaggi snapcast/container (smoke audit) |

Nessun codice di produzione toccato — solo allineamento alle stringhe nuove.