### PR TITLE
fix(pizero): IPv4 pin for snapserver discovery on native install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Pi Zero 2W native — IPv4 pin for snapserver discovery** — snapclient's built-in libavahi-client browse occasionally latched onto an IPv6 link-local SRV target that did not route on the local LAN, leaving audio silent with a healthy server visible to every other client. New `discover-server-native.sh` runs as `ExecStartPre` on `snapclient.service`: scans `_snapcast._tcp` via `avahi-browse`, picks the first IPv4 advertiser, pins `--host <ip>` into `/etc/default/snapclient`. Best-effort: missing tool or no IPv4 result leaves snapclient's own mDNS as fallback (current behaviour).
+
 ## [0.7.8.16] — 2026-05-28
 
 > Script-only patch (image_set stays 0.7.7). mympd OOM fix + udev rule cleanup found during snapvideo log review.

--- a/client/common/scripts/discover-server-native.sh
+++ b/client/common/scripts/discover-server-native.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Discover an IPv4 _snapcast._tcp advertiser via avahi-browse and pin
+# `--host <ip>` into /etc/default/snapclient. Wired as ExecStartPre on
+# snapclient.service via the snapMULTI drop-in installed by
+# setup-zero2w.sh.
+#
+# Native client only (Pi Zero 2W). The Docker client path uses
+# scripts/discover-server.sh which feeds the result to docker compose
+# via .env — that file is pruned on the native install (see comment at
+# top of discover-server.sh) because it depends on docker compose, but
+# the underlying problem it solves applies here too: snapclient's
+# built-in libavahi-client browse can latch onto an IPv6 link-local SRV
+# target that does not route, leaving audio silent even with a healthy
+# server on the same LAN. Pinning an explicit IPv4 host removes the
+# guesswork.
+#
+# Idempotent: only rewrites /etc/default/snapclient when the resolved
+# host differs from what the file already carries. Safe to run on every
+# snapclient.service start.
+#
+# Best-effort: when avahi-browse is missing or returns no IPv4 target,
+# leave SNAPCLIENT_OPTS untouched. snapclient's own mDNS retry is the
+# graceful fallback — better silent than wedged on a stale --host.
+set -euo pipefail
+
+DEFAULTS="${SNAPCLIENT_DEFAULTS:-/etc/default/snapclient}"
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-8}"
+SERVICE_TYPE="${SNAPCAST_SERVICE_TYPE:-_snapcast._tcp}"
+TAG="[discover-native]"
+
+_log() { echo "$TAG $*" >&2; }
+
+[[ -f "$DEFAULTS" ]] || { _log "$DEFAULTS missing — nothing to do"; exit 0; }
+
+if ! command -v avahi-browse >/dev/null 2>&1; then
+    _log "avahi-browse missing — leaving SNAPCLIENT_OPTS unchanged"
+    exit 0
+fi
+
+# avahi-browse -rpt format (semicolon-separated):
+#   =;iface;proto;name;type;domain;hostname;address;port;txt   ← fully resolved
+# Require resolved record (`=`), IPv4 protocol, numeric port (rejects PTR-only).
+ip=$(timeout "$SCAN_TIMEOUT" avahi-browse -rpt "$SERVICE_TYPE" 2>/dev/null \
+    | awk -F';' '/^=/ && $3=="IPv4" && $9 ~ /^[0-9]+$/ {print $8; exit}' || true)
+
+if [[ -z "$ip" || ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    _log "no IPv4 ${SERVICE_TYPE} advertiser — falling back to snapclient built-in mDNS"
+    exit 0
+fi
+
+current=$(grep -oE -- '--host[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' "$DEFAULTS" 2>/dev/null \
+    | awk '{print $NF}' | head -1 || true)
+if [[ "$current" == "$ip" ]]; then
+    _log "snapserver $ip already pinned, no change"
+    exit 0
+fi
+
+# Strip any prior --host arg (idempotent on multiple runs / IP changes),
+# then prepend the freshly resolved one. SNAPCLIENT_OPTS must be a single
+# line for this rewrite to work — setup-zero2w.sh writes it that way.
+tmp=$(mktemp "${DEFAULTS}.XXXXXX")
+sed -E \
+    -e 's|--host[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*||g' \
+    -e "s|^(SNAPCLIENT_OPTS=\")|\\1--host ${ip} |" \
+    "$DEFAULTS" > "$tmp"
+mv "$tmp" "$DEFAULTS"
+chmod 644 "$DEFAULTS"
+_log "pinned snapserver ${ip}${current:+ (was: $current)}"

--- a/client/common/scripts/setup-zero2w.sh
+++ b/client/common/scripts/setup-zero2w.sh
@@ -419,15 +419,49 @@ SNAPCLIENT_OPTS="--hostID ${CLIENT_ID} --soundcard ${SOUNDCARD} --mixer ${MIXER}
 EOF
 ok "/etc/default/snapclient configured"
 
+# ── IPv4-pin discover hook ───────────────────────────────────────
+# snapclient's built-in libavahi-client browse can latch onto an IPv6
+# link-local SRV target that doesn't route on Pi Zero 2W LANs, leaving
+# audio silent with a healthy server. Ship a small ExecStartPre that
+# pins --host <IPv4> in /etc/default/snapclient before each start.
+# Mirrors discover-server.sh's IPv4 filter, scaled down (no anti-flap
+# state machine — single-shot per service start is enough for native).
+step "Installing IPv4-pin discover helper"
+DISCOVER_SCRIPT="/usr/local/sbin/snapmulti-discover-snapserver"
+_discover_src=""
+for _cand in \
+    "$SCRIPT_DIR/discover-server-native.sh" \
+    "$SCRIPT_DIR/../scripts/discover-server-native.sh" \
+    "/opt/snapclient/scripts/discover-server-native.sh"; do
+    if [[ -f "$_cand" ]]; then
+        _discover_src="$_cand"
+        break
+    fi
+done
+if [[ -n "$_discover_src" ]]; then
+    install -m 0755 "$_discover_src" "$DISCOVER_SCRIPT"
+    ok "Installed $DISCOVER_SCRIPT"
+else
+    warn "discover-server-native.sh not staged — IPv4 pinning disabled (snapclient will fall back to built-in mDNS)"
+    DISCOVER_SCRIPT=""
+fi
+unset _cand _discover_src
+
 # ── systemd drop-in override ─────────────────────────────────────
 # The .deb ships /lib/systemd/system/snapclient.service with
 # User=snapclient Group=snapclient and Restart=on-failure. We layer
 # a drop-in to add restart limits, real-time audio scheduling, and
 # explicit network ordering. Drop-ins survive .deb upgrades cleanly.
+#
+# ExecStartPre runs as root (drop-in inherits User= from .deb unit
+# but ExecStartPre+ entries override that). Without root, the rewrite
+# of /etc/default/snapclient would fail silently and discovery would
+# stay broken — the `+` prefix is the supported way.
 step "Installing systemd drop-in override"
 DROPIN_DIR=/etc/systemd/system/snapclient.service.d
 mkdir -p "$DROPIN_DIR"
-cat > "$DROPIN_DIR/snapmulti-override.conf" <<'EOF'
+{
+    cat <<'EOF'
 # Drop-in override installed by snapMULTI setup-zero2w.sh.
 # Layered on top of the upstream snapclient.service shipped by the
 # badaix snapcast .deb. Survives .deb upgrades.
@@ -444,6 +478,12 @@ RestartSec=5
 LimitRTPRIO=10
 LimitMEMLOCK=infinity
 EOF
+    if [[ -n "$DISCOVER_SCRIPT" ]]; then
+        cat <<EOF
+ExecStartPre=+${DISCOVER_SCRIPT}
+EOF
+    fi
+} > "$DROPIN_DIR/snapmulti-override.conf"
 ok "systemd drop-in installed at $DROPIN_DIR/snapmulti-override.conf"
 
 # ── Enable + start ───────────────────────────────────────────────

--- a/client/common/scripts/setup-zero2w.sh
+++ b/client/common/scripts/setup-zero2w.sh
@@ -460,8 +460,13 @@ unset _cand _discover_src
 step "Installing systemd drop-in override"
 DROPIN_DIR=/etc/systemd/system/snapclient.service.d
 mkdir -p "$DROPIN_DIR"
-{
-    cat <<'EOF'
+# Two-phase write: the awk extractor in .github/workflows/validate.yml
+# lifts the static heredoc (between the marker line and the next EOF)
+# and feeds it to systemd-analyze verify. Embedding an unexpanded
+# ${DISCOVER_SCRIPT:+...} placeholder in the heredoc would survive the
+# extraction verbatim and choke verify, so the optional ExecStartPre
+# line is appended in a separate statement.
+cat > "$DROPIN_DIR/snapmulti-override.conf" <<'EOF'
 # Drop-in override installed by snapMULTI setup-zero2w.sh.
 # Layered on top of the upstream snapclient.service shipped by the
 # badaix snapcast .deb. Survives .deb upgrades.
@@ -478,12 +483,9 @@ RestartSec=5
 LimitRTPRIO=10
 LimitMEMLOCK=infinity
 EOF
-    if [[ -n "$DISCOVER_SCRIPT" ]]; then
-        cat <<EOF
-ExecStartPre=+${DISCOVER_SCRIPT}
-EOF
-    fi
-} > "$DROPIN_DIR/snapmulti-override.conf"
+if [[ -n "$DISCOVER_SCRIPT" ]]; then
+    printf 'ExecStartPre=+%s\n' "$DISCOVER_SCRIPT" >> "$DROPIN_DIR/snapmulti-override.conf"
+fi
 ok "systemd drop-in installed at $DROPIN_DIR/snapmulti-override.conf"
 
 # ── Enable + start ───────────────────────────────────────────────

--- a/scripts/prepare-sd.ps1
+++ b/scripts/prepare-sd.ps1
@@ -180,6 +180,7 @@ function Assert-PreparedSdCard {
             'client/scripts/diagnostic.sh',
             'client/scripts/audio-hat-detect.sh',
             'client/scripts/discover-server.sh',
+            'client/scripts/discover-server-native.sh',
             'client/scripts/display.sh',
             'client/scripts/display-detect.sh',
             'client/scripts/common/install-deps.sh',

--- a/scripts/prepare-sd.sh
+++ b/scripts/prepare-sd.sh
@@ -598,6 +598,7 @@ copy_client_files() {
     [[ -f "$CLIENT_DIR/common/scripts/audio-hat-detect.sh" ]] && cp "$CLIENT_DIR/common/scripts/audio-hat-detect.sh" "$dest/scripts/"
     [[ -f "$CLIENT_DIR/common/scripts/ro-mode.sh" ]] && cp "$CLIENT_DIR/common/scripts/ro-mode.sh" "$dest/scripts/"
     [[ -f "$CLIENT_DIR/common/scripts/discover-server.sh" ]] && cp "$CLIENT_DIR/common/scripts/discover-server.sh" "$dest/scripts/"
+    [[ -f "$CLIENT_DIR/common/scripts/discover-server-native.sh" ]] && cp "$CLIENT_DIR/common/scripts/discover-server-native.sh" "$dest/scripts/"
     [[ -f "$CLIENT_DIR/common/scripts/display.sh" ]] && cp "$CLIENT_DIR/common/scripts/display.sh" "$dest/scripts/"
     [[ -f "$CLIENT_DIR/common/scripts/display-detect.sh" ]] && cp "$CLIENT_DIR/common/scripts/display-detect.sh" "$dest/scripts/"
 


### PR DESCRIPTION
Pi Zero 2W native snapclient occasionalmente sceglie un target IPv6 link-local da `_snapcast._tcp` mDNS — non instradabile → audio silent con server sano visibile a tutti gli altri client.

## Cosa

| File | Change |
|------|--------|
| `client/common/scripts/discover-server-native.sh` | **nuovo** — avahi-browse → primo IPv4 → riscrive `--host <ip>` in `/etc/default/snapclient`, idempotente |
| `client/common/scripts/setup-zero2w.sh` | installa script in `/usr/local/sbin/snapmulti-discover-snapserver` + aggiunge `ExecStartPre=+...` nel drop-in |
| `scripts/prepare-sd.sh` + `.ps1` | stage del nuovo script sulla boot partition |
| `CHANGELOG.md` | entry [Unreleased] |

## Perché in più sul path nativo

Il path Docker già ha `discover-server.sh` (state machine completa con anti-flap). Sul nativo è stato volutamente prunato (vedi top di `discover-server.sh:5-13`). Ma il problema IPv6 link-local resta: ora abbiamo una versione mini, single-shot per service start — sufficiente per single-room/single-server.

## Safe by design

- Tool `avahi-browse` mancante o nessun IPv4 → `SNAPCLIENT_OPTS` non viene toccato. snapclient cade sul proprio mDNS (comportamento attuale).
- Il rewrite è idempotente: stesso IP → no-op. IP diverso → rimpiazza il vecchio `--host`.
- `ExecStartPre=+...` con il `+` per privilegi root (altrimenti il rewrite di `/etc/default/snapclient` fallisce silenziosamente perché la unit è `User=snapclient`).

## Validation

Done locally: `bash -n` + `shellcheck` clean per discover-server-native.sh e setup-zero2w.sh.

Deferred: reflash pizero + osservare journal `[discover-native] pinned snapserver <ip>` prima di snapclient start; verificare `cat /etc/default/snapclient` contiene `--host <IPv4>`.