### PR TITLE
chore(release): roll [Unreleased] into v0.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Pi Zero 2W — snapclient IPv6 link-local latch (#521 → #522)** — snapclient's built-in libavahi-client browse occasionally latched onto an IPv6 link-local SRV target that did not route on the local LAN, leaving audio silent with a healthy server visible to every other client. #521 shipped a surgical workaround (`ExecStartPre` pin `--host <IPv4>` into `/etc/default/snapclient`). #522 supersedes it by killing IPv6 at the kernel level — the workaround is removed, snapclient's built-in mDNS auto-rediscovery is restored for free, and the same class of bug stops affecting other consumers (fb-display, future zeroconf code).
+- **mympd crash-loop after ADR-007** — `ghcr.io/jcorporation/mympd` upstream default is `MYMPD_HTTP_HOST=[::]:8180` (dual-stack listen). With IPv6 disabled at kernel level the bind returns `EAFNOSUPPORT` (errno 97) and the container exits, re-spawning every few seconds. Pin `MYMPD_HTTP_HOST=0.0.0.0` in `docker-compose.yml`. Caught immediately after rolling ADR-007 to snapvideo. snapserver / MPD / metadata-service already bind IPv4 explicitly — mympd was the only consumer of the upstream IPv6 default.
 
 ### Removed
 - **PR #521 workaround retired (#522)** — `discover-server-native.sh` + the `ExecStartPre=+/usr/local/sbin/snapmulti-discover-snapserver` line on the Pi Zero 2W drop-in. Native auto-rediscovery restored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.9] — 2026-05-28
+
+> Script-only patch (image_set stays 0.7.7). Network-stack simplification: IPv6 disabled at kernel cmdline by default, with documented opt-out. Resolves a recurring class of dual-stack mDNS / Snapcast discovery failures on consumer LANs.
+
 ### Changed
-- **IPv6 disabled by default on every install (ADR-007)** — `prepare-sd.sh` / `prepare-sd.ps1` now write `ipv6.disable=1` to `/boot/firmware/cmdline.txt` by default. snapMULTI is a LAN-only audio appliance and dual-stack mDNS / Snapcast discovery causes intermittent silent failures on consumer LANs (see PR #521 + the broader Avahi dual-publish race in issue #425). Kernel-level disable pre-empts every userland subsystem, lives outside the overlayroot upper layer, and is reversible by removing the token from `cmdline.txt`. Opt out with `DISABLE_IPV6=false ./scripts/prepare-sd.sh ...` for the rare operator with a hard IPv6 requirement. Documented in [ADVANCED](docs/ADVANCED.md#ipv6-disabled-by-default) + [TROUBLESHOOTING](docs/TROUBLESHOOTING.md#ipv6-disabled--is-this-a-problem). `install-deps.sh` installs `Acquire::ForceIPv4 "true"` apt config so first-boot package fetches don't stall on AAAA timeouts.
+- **IPv6 disabled by default on every install (ADR-007, #522)** — `prepare-sd.sh` / `prepare-sd.ps1` now write `ipv6.disable=1` to `/boot/firmware/cmdline.txt` by default. snapMULTI is a LAN-only audio appliance and dual-stack mDNS / Snapcast discovery causes intermittent silent failures on consumer LANs (see #521 + the broader Avahi dual-publish race in #425). Kernel-level disable pre-empts every userland subsystem, lives outside the overlayroot upper layer, and is reversible by removing the token from `cmdline.txt`. Opt out with `DISABLE_IPV6=false ./scripts/prepare-sd.sh ...` for the rare operator with a hard IPv6 requirement. Documented in [ADVANCED](docs/ADVANCED.md#ipv6-disabled-by-default) + [TROUBLESHOOTING](docs/TROUBLESHOOTING.md#ipv6-disabled--is-this-a-problem). `install-deps.sh` installs `Acquire::ForceIPv4 "true"` apt config so first-boot package fetches don't stall on AAAA timeouts.
+
+### Fixed
+- **Pi Zero 2W — snapclient IPv6 link-local latch (#521 → #522)** — snapclient's built-in libavahi-client browse occasionally latched onto an IPv6 link-local SRV target that did not route on the local LAN, leaving audio silent with a healthy server visible to every other client. #521 shipped a surgical workaround (`ExecStartPre` pin `--host <IPv4>` into `/etc/default/snapclient`). #522 supersedes it by killing IPv6 at the kernel level — the workaround is removed, snapclient's built-in mDNS auto-rediscovery is restored for free, and the same class of bug stops affecting other consumers (fb-display, future zeroconf code).
 
 ### Removed
-- **PR #521 workaround retired** — `discover-server-native.sh` + the `ExecStartPre=+/usr/local/sbin/snapmulti-discover-snapserver` line on the Pi Zero 2W drop-in. With IPv6 killed at kernel level snapclient's built-in mDNS browse only sees IPv4 records, so the `--host` pinning is redundant. Its removal also restores snapclient's auto-rediscovery on server-IP change — a benefit the surgical workaround had cost.
+- **PR #521 workaround retired (#522)** — `discover-server-native.sh` + the `ExecStartPre=+/usr/local/sbin/snapmulti-discover-snapserver` line on the Pi Zero 2W drop-in. Native auto-rediscovery restored.
 
 ## [0.7.8.16] — 2026-05-28
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,10 @@ services:
       - ./mpd/playlists:/playlists:ro
     environment:
       - TZ=${TZ:-Europe/Berlin}
+      # Force IPv4-only bind. myMPD default is [::]:8180 (dual-stack v6+v4
+      # mapped) which fails with EAFNOSUPPORT when the host kernel has
+      # IPv6 disabled — see ADR-007.
+      - MYMPD_HTTP_HOST=0.0.0.0
       - MYMPD_HTTP_PORT=8180
       - MYMPD_SSL=false
     # service_started (not service_healthy): myMPD retries MPD connection

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.7.8.16",
+  "snapmulti_release": "v0.7.9",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Script-only patch — `image_set` stays `0.7.7`, no Docker rebuild.

| Cut from | Headline |
|----------|----------|
| #522 | IPv6 disabled at kernel cmdline by default (ADR-007) |
| #521 → #522 | Pi Zero 2W IPv6 link-local latch — surgical workaround retired |

Validation done locally on pizero (cmdline edit + reboot); snapdigi + snapvideo cmdline patched, awaiting operator reboot before tag.