### PR TITLE
chore(release): roll [Unreleased] into v0.7.9 (final)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.9] — 2026-05-28
+
+> Script-only patch (image_set stays 0.7.7). Network-stack simplification (IPv6 off at kernel level) + state persistence under overlayroot + expanded status-page coverage. Resolves a class of dual-stack mDNS / Snapcast discovery failures and the long-standing "snapcast groups vanish at reboot" gap.
+
 ### Added
-- **snapserver + myMPD state persistence (`snapmulti-data-persistence.service`)** — overlayroot's tmpfs upper layer used to wipe `/opt/snapmulti/data/server.json` (snapcast group names, client positions, group memberships) and `/opt/snapmulti/mympd/workdir/` (myMPD smart playlists, custom scripts, theme prefs) on every reboot. New systemd oneshot service binds those paths to `/media/root-rw/snapmulti-persist/` (a directory outside the overlay tree, on the writable backing fs) so all container-written state survives reboot. Adding a new staged path is a small fan-out edit (`STAGED_PATHS_DEFAULT` in the setup script, `ExecStop` umount line in the embedded unit, `_STAGED_PATHS` in `check_persistence.sh`). First-run migration copies any existing content from the staged path (live upper layer OR lower-layer post-firstboot) into the persistent location before activating the bind, so no state is lost on upgrade. No-op on non-overlayroot installs.
-- **Status page coverage expanded** — 6 new checks surface previously-invisible state:
+- **snapserver + myMPD state persistence (`snapmulti-data-persistence.service`, #525)** — overlayroot's tmpfs upper layer used to wipe `/opt/snapmulti/data/server.json` (snapcast group names, client positions, group memberships) and `/opt/snapmulti/mympd/workdir/` (myMPD smart playlists, custom scripts, theme prefs) on every reboot. New systemd oneshot service binds those paths to `/media/root-rw/snapmulti-persist/` (a directory outside the overlay tree, on the writable backing fs) so all container-written state survives reboot. `EnvironmentFile=-${PROJECT_ROOT}/.env` propagates PUID/PGID so non-default user installs work too. First-run migration copies any existing content from the staged path into the persistent location before activating the bind, so no state is lost on upgrade. No-op on non-overlayroot installs. Documented in [ADVANCED](docs/ADVANCED.md#read-only-filesystem) + [USAGE](docs/USAGE.md#systemd-units).
+- **Status page coverage expanded (#525)** — 6 new checks surface previously-invisible state:
   - `/boot/firmware` FAT32 free space (fixed 512 MB partition — full = no diagnostic bundles, no MPD backup, no kernel upgrade)
   - `/media/root-rw` backing fs free space (full = overlay cannot grow, OOM imminent)
   - Memory headroom + `MemAvailable` (would have caught the mympd OOM in v0.7.8.16 hours earlier — surfaces 80 %+ pressure)
@@ -17,10 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pending update (queries `/version` endpoint — operator sees at a glance if a reflash brings a newer release)
   - Now-playing stream + track (which stream the connected clients actually hear, plus track metadata)
   - Previous boot end state (info-level — flags kernel panic / power loss vs clean reboot)
-
-## [0.7.9] — 2026-05-28
-
-> Script-only patch (image_set stays 0.7.7). Network-stack simplification: IPv6 disabled at kernel cmdline by default, with documented opt-out. Resolves a recurring class of dual-stack mDNS / Snapcast discovery failures on consumer LANs.
 
 ### Changed
 - **IPv6 disabled by default on every install (ADR-007, #522)** — `prepare-sd.sh` / `prepare-sd.ps1` now write `ipv6.disable=1` to `/boot/firmware/cmdline.txt` by default. snapMULTI is a LAN-only audio appliance and dual-stack mDNS / Snapcast discovery causes intermittent silent failures on consumer LANs (see #521 + the broader Avahi dual-publish race in #425). Kernel-level disable pre-empts every userland subsystem, lives outside the overlayroot upper layer, and is reversible by removing the token from `cmdline.txt`. Opt out with `DISABLE_IPV6=false ./scripts/prepare-sd.sh ...` for the rare operator with a hard IPv6 requirement. Documented in [ADVANCED](docs/ADVANCED.md#ipv6-disabled-by-default) + [TROUBLESHOOTING](docs/TROUBLESHOOTING.md#ipv6-disabled--is-this-a-problem). `install-deps.sh` installs `Acquire::ForceIPv4 "true"` apt config so first-boot package fetches don't stall on AAAA timeouts.


### PR DESCRIPTION
Fold persistence + status-page additions from #525 into the [0.7.9] section. release-manifest.json already v0.7.9 / image_set 0.7.7 from earlier prep.