### PR TITLE
fix(backup-from-sd): support widened myMPD workdir + server.json layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Seed on install** runs `snapmulti-state-backup.service` once when arming the watcher — protects upgrade scenarios where state pre-exists the watcher and would otherwise leave the boot-partition backup stale until the next user change.
   - **Boot partition mount state preserved** — `backup-snapmulti-state.sh` + `backup-mpd.sh` detect whether `/boot/firmware` was previously ro and restore THAT state on exit. The original v0.7.9 fix unconditionally remounted ro at exit, which during firstboot (both-mode) cascaded to break `raspi-config do_overlayfs` and prevented overlay activation entirely — discovered by user pattern-recognition ("readonly in server mode has always worked").
   - Removed `snapmulti-data-persistence.service`, `snapmulti-data-setup.sh`, and the misleading `check_persistence.sh` smoke module; replaced with `check_state_backup.sh` (verifies backup freshness on the actual persistent path) + `check_timers.sh` now also asserts the path + timer units are enabled and active.
+  - **`backup-from-sd.sh` catches up to widened backup scope (#530)** — host-side reflash extractor now handles the current `mympd/workdir/` layout (atomic stage+swap to avoid merging stale files from the previous SD with the restored backup) and restores `data/server.json`. Legacy `mympd/state/`-only backups still work with a warning that user customisations aren't in the backup.
 
 ## [0.7.9] — 2026-05-28
 

--- a/scripts/backup-from-sd.sh
+++ b/scripts/backup-from-sd.sh
@@ -96,11 +96,43 @@ main() {
         restored=$((restored + 1))
     fi
 
-    # myMPD state
-    if [[ -d "$backup_dir/mympd/state" ]]; then
+    # myMPD workdir — current layout is the whole workdir/ (state +
+    # config + smartpls + scripts + pics). Older backups may carry
+    # just state/; support both layouts.
+    if [[ -d "$backup_dir/mympd/workdir" ]]; then
+        mkdir -p "$PROJECT_DIR/mympd"
+        # Replace any existing workdir at the destination to avoid
+        # merging stale files from the previous SD with the restored
+        # backup. Same atomic stage+swap idiom as the boot-time
+        # restore script.
+        local _stage="$PROJECT_DIR/mympd/workdir.restore.$$"
+        local _old="$PROJECT_DIR/mympd/workdir.old.$$"
+        rm -rf "$_stage" "$_old"
+        cp -a "$backup_dir/mympd/workdir" "$_stage"
+        if [[ -d "$PROJECT_DIR/mympd/workdir" ]]; then
+            mv "$PROJECT_DIR/mympd/workdir" "$_old"
+        fi
+        mv "$_stage" "$PROJECT_DIR/mympd/workdir"
+        rm -rf "$_old"
+        ok "myMPD workdir restored → mympd/workdir/ (state + config + smartpls + scripts + pics)"
+        restored=$((restored + 1))
+    elif [[ -d "$backup_dir/mympd/state" ]]; then
+        # Legacy layout — pre-v0.7.9.x SD card. Only state/ subdir
+        # was backed up; user-customised smart playlists / scripts /
+        # theme are not present in this backup.
         mkdir -p "$PROJECT_DIR/mympd/workdir"
         cp -r "$backup_dir/mympd/state" "$PROJECT_DIR/mympd/workdir/"
-        ok "myMPD playlists restored → mympd/workdir/state/"
+        ok "myMPD state restored (legacy backup layout, state/ only) → mympd/workdir/state/"
+        warn "Backup is from a pre-v0.7.9.x install — smart playlists / scripts / theme not present in this backup. Future backups will cover the full workdir."
+        restored=$((restored + 1))
+    fi
+
+    # snapserver group state (server.json) — added in the
+    # post-v0.7.9 persistence pattern. Older backups predate this.
+    if [[ -f "$backup_dir/data/server.json" ]]; then
+        mkdir -p "$PROJECT_DIR/data"
+        cp "$backup_dir/data/server.json" "$PROJECT_DIR/data/server.json"
+        ok "snapserver group state restored → data/server.json"
         restored=$((restored + 1))
     fi
 


### PR DESCRIPTION
Follow-up #529 review finding (P2). The boot-partition backup layout changed; the host-side extractor lagged behind.

## Bug

`backup-from-sd.sh` only checked legacy `mympd/state` subdir. After the persistence work widened backups to the whole `mympd/workdir` + new `data/server.json`, running the extractor on a post-fix SD silently skips all myMPD user customisations + snapcast group state → next reflash loses everything.

## Fix

| Source layout on SD | Extractor behaviour |
|---------------------|---------------------|
| `mympd/workdir/` (current) | atomic stage+swap restore of whole workdir |
| `mympd/state/` only (legacy SDs) | restore state/ + warn that customisations aren't in the backup |
| `data/server.json` (current) | restore snapserver groups |

Atomic stage+swap matches the `restore-snapmulti-state` idiom — avoids merging stale files from the previous SD with the backup.

## Validation

bash -n + shellcheck clean (only pre-existing SC1091 info on sourced lib).

Live test on next reflash cycle:
1. Reflash a device that has fresh-layout backup
2. Run `backup-from-sd.sh` on the SD (host-side)
3. Confirm `mympd/workdir/{state,config,smartpls,scripts,pics}` + `data/server.json` extracted to project dir
4. Fresh SD prep + reflash → device sees restored state