### PR TITLE
fix(status): delay first snapshot until MPD healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`snapmulti-status`: delay first snapshot until MPD healthy (#533)** — `OnBootSec` bumped 2 min → 4 min (covers observed 3m14s MPD startup time on Pi 4 + NFS library); adaptive `ExecStartPre` polls `docker inspect mpd` for healthy state up to 5 min so slow configs (Pi Zero, large libraries, cold NFS scans) no longer surface a misleading red `/status` on first boot. Steady-state cost ~0.1 s (loop exits on first iteration). If MPD stays unhealthy past the wait the snapshot still publishes — page shows the real FAIL rather than silently skipping.
+
 ## [0.7.9.1] — 2026-05-28
 
 > Script-only patch (image_set stays 0.7.7). Resolves the v0.7.9 persistence regression. Field-validated on snapvideo: overlay active + `server.json` + `server.json.prev` + 4 groups all survived reboot under `overlayroot="tmpfs"`.

--- a/scripts/common/snapmulti-status.service
+++ b/scripts/common/snapmulti-status.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Refresh snapMULTI system-status snapshot for /status web page
-# Run after Docker so smoke checks see the containers
-After=docker.service network-online.target
+# Run after Docker AND after the snapmulti server unit so smoke checks
+# observe the stack in steady state, not mid-boot.
+After=docker.service network-online.target snapmulti-server.service
 # Hard-fail-tolerant — the snapshot is best-effort; if smoke can't run
 # (Docker briefly down, etc.) the next timer firing tries again.
 StartLimitIntervalSec=300
@@ -9,9 +10,27 @@ StartLimitBurst=5
 
 [Service]
 Type=oneshot
-# TimeoutStartSec kills runaway runs that would block the next timer (RuntimeMaxSec has no effect on Type=oneshot).
-TimeoutStartSec=120
+# TimeoutStartSec needs to cover ExecStartPre (up to 5 min waiting for
+# MPD healthy) + ExecStart (~10-15 s steady state). 360 s total is the
+# upper bound; runs that hit it have a real problem worth surfacing.
+TimeoutStartSec=360
 KillMode=mixed
+# Adaptive wait for MPD healthy on the first post-boot firing. The
+# OnBootSec=4min in snapmulti-status.timer gives most installs enough
+# headroom, but Pi Zero / large libraries / cold NFS scans can push
+# MPD healthy out past that. Without this wait, the first snapshot
+# captures a misleading "mpd: starting" / "mpd: unhealthy" state and
+# /status shows red for 5 min until the next timer firing.
+# On subsequent firings MPD is already healthy → loop exits in 1
+# iteration (~0.1 s). Always exits 0 so a stuck MPD still publishes a
+# snapshot — the snapshot will FAIL the mpd check, which is the
+# correct outcome to surface.
+ExecStartPre=/bin/bash -c 'for _i in $(seq 1 60); do \
+    [[ "$(docker inspect mpd --format "{{if .State.Health}}{{.State.Health.Status}}{{end}}" 2>/dev/null)" == "healthy" ]] && exit 0; \
+    sleep 5; \
+done; \
+logger -t snapmulti-status "ExecStartPre: mpd still not healthy after 300s wait — publishing snapshot anyway"; \
+exit 0'
 # `flock --nonblock` exits 1 when the lock is busy (concurrent run). That's
 # the intended "skip this firing" behaviour, not a failure — tell systemd so
 # the journal doesn't log a misleading FAILED status.

--- a/scripts/common/snapmulti-status.timer
+++ b/scripts/common/snapmulti-status.timer
@@ -3,8 +3,12 @@ Description=Periodic snapMULTI system-status snapshot for /status web page
 
 [Timer]
 # Wait for containers to come up before the FIRST snapshot — otherwise
-# the page shows red on every fresh boot, alarming beginners.
-OnBootSec=2min
+# the page shows red on every fresh boot, alarming beginners. 4 min
+# covers MPD startup on Pi 4 8GB + NFS library (observed 3m14s post-
+# boot for the container healthcheck to flip; small margin on top).
+# Slower configs are handled by the adaptive ExecStartPre wait in
+# snapmulti-status.service that polls `docker inspect mpd` for healthy.
+OnBootSec=4min
 # 5-min interval: the page is for beginner self-diagnosis, not real-time
 # incident response. 5min × 4 hours = 48 SD writes (atomic .tmp + mv) —
 # negligible churn vs the boot of the smoke check itself (~2-3 s of


### PR DESCRIPTION
Fix for the misleading red /status page during the first ~5 min after a fresh boot.

| Observation (snapvideo, Pi 4 8GB, NFS library) | Value |
|------|-------|
| boot | 00:58:07 |
| first status snapshot fired | 01:00:07 (OnBootSec=2min) |
| MPD healthy | 01:01:21 (+3m14s) |
| Gap | snapshot ran 41-74s BEFORE MPD healthy |

## Fix
- `OnBootSec=2min` → `4min` (covers observed MPD start)
- ExecStartPre adaptive wait: polls `docker inspect mpd` for healthy, up to 5 min. Steady-state cost ~0.1 s.
- `TimeoutStartSec=120s` → `360s` (worst-case wait + smoke run)
- `After=` adds `snapmulti-server.service` so smoke runs against settled stack
- If MPD stays unhealthy past the wait, snapshot publishes anyway → page surfaces the FAIL (correct outcome)

## Validation
- Unit syntax + ExecStartPre exit code verified live on snapvideo (steady state, MPD already healthy → loop exits 1st iteration `status=0/SUCCESS`)
- Full reboot validation pending reflash