### PR TITLE
chore(deps): bump go-librespot v0.7.3 + pin myMPD v25.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **go-librespot `v0.7.1` → `v0.7.3`** — upstream release hardens the dealer + accesspoint connection lifecycles ("do not leak previous dealer connection", "harden accesspoint/dealer connection lifecycle", "unify client shutdown around access point and dealer lifecycles", "unblock chunked reader close during chunk prefetch"). Strong candidate fix for the iPhone-zeroconf `loadContext` nil-deref crash observed in v0.7.0/v0.7.1 (`compose rm + up` was the workaround). v0.7.3 also adds zeroconf name update API. Closes #471.
+- **myMPD `:latest` → `:v25.0.2`** — explicit pin replaces drift-tracking `:latest` so a reflash with the same release tag always pulls the same myMPD image. Currently `:latest` and `:v25.0.2` resolve to the same digest, so no behaviour change. Closes #470.
+
 ### Fixed
 - **`snapmulti-status`: delay first snapshot until MPD healthy (#533)** — `OnBootSec` bumped 2 min → 4 min (covers observed 3m14s MPD startup time on Pi 4 + NFS library); adaptive `ExecStartPre` polls `docker inspect mpd` for healthy state up to 5 min so slow configs (Pi Zero, large libraries, cold NFS scans) no longer surface a misleading red `/status` on first boot. Steady-state cost ~0.1 s (loop exits on first iteration). If MPD stays unhealthy past the wait the snapshot still publishes — page shows the real FAIL rather than silently skipping.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ ARM-only audio source using `edgecrush3r/tidal-connect` as base image (Raspbian 
 
 ## Conventions
 
-- **Docker images**: `lollonet/snapmulti-{server,airplay,mpd,metadata}:latest` (Docker Hub, built in CI) + `ghcr.io/devgianlu/go-librespot:v0.7.1` (upstream) + `lollonet/snapmulti-tidal:latest` (ARM only)
+- **Docker images**: `lollonet/snapmulti-{server,airplay,mpd,metadata}:latest` (Docker Hub, built in CI) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `lollonet/snapmulti-tidal:latest` (ARM only)
 - **Multi-arch**: linux/amd64 (studio) + linux/arm64 (ci-runner-x86), native builds on self-hosted runners
 - **Config paths**: all config in `config/`, all scripts in `scripts/`, shared libs in `scripts/common/`
 - **Deployment**: tag push (`v*`) triggers build → manifest → deploy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
   # Open Spotify app → Connect to a device → Select "<hostname> Spotify"
   # Metadata + playback control via meta_go-librespot.py (Snapcast plugin)
   librespot:
-    image: ghcr.io/devgianlu/go-librespot:v0.7.1
+    image: ghcr.io/devgianlu/go-librespot:v0.7.3
     container_name: librespot
     restart: unless-stopped
     network_mode: host
@@ -159,7 +159,7 @@ services:
           memory: ${SPOTIFY_MEM_RESERVE:-128M}
 
   mympd:
-    image: ghcr.io/jcorporation/mympd/mympd:latest
+    image: ghcr.io/jcorporation/mympd/mympd:v25.0.2
     container_name: mympd
     restart: unless-stopped
     network_mode: host

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -252,10 +252,10 @@ Configurazione del firewall (regole `ufw`) e setup QoS / `cake` qdisc sono docum
 |----------|------------|
 | `lollonet/snapmulti-server:latest` | ~80–120 MB |
 | `lollonet/snapmulti-airplay:latest` | ~30–50 MB |
-| `ghcr.io/devgianlu/go-librespot:v0.7.1` | ~30–50 MB |
+| `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:latest` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:v25.0.2` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:latest` | ~200–300 MB |
 
 **Immagini client** (dalla directory [client](../client/)):

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -252,10 +252,10 @@ Firewall configuration (`ufw` rules) and QoS / `cake` qdisc setup are documented
 |-------|------|
 | `lollonet/snapmulti-server:latest` | ~80–120 MB |
 | `lollonet/snapmulti-airplay:latest` | ~30–50 MB |
-| `ghcr.io/devgianlu/go-librespot:v0.7.1` | ~30–50 MB |
+| `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:latest` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:v25.0.2` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:latest` | ~200–300 MB |
 
 **Client images** (from [client](../client/) directory):


### PR DESCRIPTION
Bundled dep bumps. Both upstreams already released; we were behind.

| Dep | Before | After | Why |
|-----|--------|-------|-----|
| go-librespot | `v0.7.1` (Feb 2026) | `v0.7.3` (25 May 2026) | Dealer/accesspoint lifecycle hardening — likely fix for iPhone-zeroconf `loadContext` crash. Closes #471 |
| myMPD | `:latest` (drift) | `:v25.0.2` | Reproducibility — same digest today, but no upstream rolling under our feet. Closes #470 |

## Validation
- ✅ CHANGELOG.md entry under `[Unreleased]` (Changed)
- ⏳ Real iPhone-zeroconf crash repro deferred to reflash (can't repro from this workstation)
- ⏳ Tidal/AirPlay smoke unaffected (orthogonal to these deps)