### PR TITLE
fix(deps): mympd tag is 25.0.2 not v25.0.2 (manifest unknown on reflash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **go-librespot `v0.7.1` → `v0.7.3`** — upstream release hardens the dealer + accesspoint connection lifecycles ("do not leak previous dealer connection", "harden accesspoint/dealer connection lifecycle", "unify client shutdown around access point and dealer lifecycles", "unblock chunked reader close during chunk prefetch"). Strong candidate fix for the iPhone-zeroconf `loadContext` nil-deref crash observed in v0.7.0/v0.7.1 (`compose rm + up` was the workaround). v0.7.3 also adds zeroconf name update API. Closes #471.
-- **myMPD `:latest` → `:v25.0.2`** — explicit pin replaces drift-tracking `:latest` so a reflash with the same release tag always pulls the same myMPD image. Currently `:latest` and `:v25.0.2` resolve to the same digest, so no behaviour change. Closes #470.
+- **myMPD `:latest` → `:25.0.2`** — explicit pin replaces drift-tracking `:latest` so a reflash with the same release tag always pulls the same myMPD image. The upstream Docker registry uses unprefixed numeric tags (no `v`), unlike the GitHub release tag name. Closes #470.
 
 ### Fixed
 - **`snapmulti-status`: delay first snapshot until MPD healthy (#533)** — `OnBootSec` bumped 2 min → 4 min (covers observed 3m14s MPD startup time on Pi 4 + NFS library); adaptive `ExecStartPre` polls `docker inspect mpd` for healthy state up to 5 min so slow configs (Pi Zero, large libraries, cold NFS scans) no longer surface a misleading red `/status` on first boot. Steady-state cost ~0.1 s (loop exits on first iteration). If MPD stays unhealthy past the wait the snapshot still publishes — page shows the real FAIL rather than silently skipping.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
           memory: ${SPOTIFY_MEM_RESERVE:-128M}
 
   mympd:
-    image: ghcr.io/jcorporation/mympd/mympd:v25.0.2
+    image: ghcr.io/jcorporation/mympd/mympd:25.0.2
     container_name: mympd
     restart: unless-stopped
     network_mode: host

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -255,7 +255,7 @@ Configurazione del firewall (regole `ufw`) e setup QoS / `cake` qdisc sono docum
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:v25.0.2` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:25.0.2` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:latest` | ~200–300 MB |
 
 **Immagini client** (dalla directory [client](../client/)):

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -255,7 +255,7 @@ Firewall configuration (`ufw` rules) and QoS / `cake` qdisc setup are documented
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:v25.0.2` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:25.0.2` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:latest` | ~200–300 MB |
 
 **Client images** (from [client](../client/) directory):


### PR DESCRIPTION
v0.7.9.2 ships a broken pin — reflash fails at deploy step with `manifest unknown` because `ghcr.io/jcorporation/mympd/mympd:v25.0.2` does not exist on the upstream registry. The tag is `25.0.2` (no `v` prefix).

| Tag | Exists on ghcr.io |
|-----|-------------------|
| `mympd:25.0.2` | ✅ |
| `mympd:v25.0.2` | ❌ |
| `mympd:latest` | ✅ |

## Diff
- `docker-compose.yml` line 162: `v25.0.2` → `25.0.2`
- `docs/HARDWARE.md` + `docs/HARDWARE.it.md` line 258: image-size table sync
- `CHANGELOG.md`: corrected entry + note that upstream uses unprefixed tags

## Validation
- `docker manifest inspect ghcr.io/jcorporation/mympd/mympd:25.0.2` → exists ✓
- Full grep sweep: no remaining `mympd:v25` references in repo

## Release plan
Cut v0.7.9.3 immediately after merge — current v0.7.9.2 cannot reflash.