### PR TITLE
fix(smoke): disambiguate /status 503 — timer vs bind-mount vs stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`/status` snapshot smoke check disambiguated** — the HTTP 503 branch used to lump three distinct root causes into one message ("check snapmulti-status.timer AND /audio bind-mount on metadata container"), forcing the operator to chase both. The check now probes directly: (a) snapshot file missing on host — INFO on fresh boot (< 5 min uptime + timer not yet armed), FAIL after; (b) file present on host but metadata container cannot read it — FAIL pointing at the bind-mount + PUID/PGID; (c) file present and readable in container but service still returns 503 — FAIL with the actual response body so the cause is visible. No false-positive on the first-boot window before `OnBootSec=4min`.
+
 ## [0.7.9.3] — 2026-05-29
 
 > Hotfix for v0.7.9.2. The myMPD pin in that release was `:v25.0.2`, but the upstream Docker registry tags myMPD as `25.0.2` (no `v` prefix). Reflash failed at the deploy step with `manifest unknown`. v0.7.9.3 fixes the tag — no other changes. v0.7.9.2 should be considered stillborn.

--- a/scripts/device-smoke.sh
+++ b/scripts/device-smoke.sh
@@ -992,7 +992,36 @@ if [[ "$MODE" == "server" || "$MODE" == "both" ]]; then
         _status_code=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' 'http://127.0.0.1:8083/status?format=json' 2>/dev/null || true)
         case "$_status_code" in
             200) pass_check "/status snapshot present and readable (issue #177 path)" ;;
-            503) fail_check "/status reports no snapshot — check snapmulti-status.timer AND /audio bind-mount on metadata container" ;;
+            503)
+                # Disambiguate the 503 — three distinct root causes used
+                # to be lumped under "check snapmulti-status.timer AND
+                # /audio bind-mount" which forced the operator to chase
+                # both. Probe directly.
+                #
+                #   (a) Snapshot file missing on host. On fresh boot the
+                #       timer fires at OnBootSec=4min — INFO until then,
+                #       FAIL after.
+                #   (b) File present on host but metadata container can't
+                #       see it. Bind-mount missing or wrong perms.
+                #   (c) File present + readable in container but service
+                #       still returns 503. Stale / parse error in
+                #       metadata-service itself — surface the body.
+                _snap_file="/opt/snapmulti/audio/system-status.json"
+                _uptime_s=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 999999)
+                if [[ ! -e "$_snap_file" ]]; then
+                    _last_trig=$(systemctl show snapmulti-status.timer -p LastTriggerUSec --value 2>/dev/null || true)
+                    if { [[ -z "$_last_trig" ]] || [[ "$_last_trig" == "n/a" ]]; } && (( _uptime_s < 300 )); then
+                        info "/status snapshot not yet generated — snapmulti-status.timer fires at OnBootSec=4min (uptime ${_uptime_s}s, timer not yet armed)"
+                    else
+                        fail_check "/status snapshot missing on host ($_snap_file). snapmulti-status.timer has not produced one — check 'journalctl -u snapmulti-status.service' for ExecStart errors"
+                    fi
+                elif ! docker exec metadata test -r /audio/system-status.json 2>/dev/null; then
+                    fail_check "/status snapshot present on host ($_snap_file) but metadata container cannot read it — /audio bind-mount missing in docker-compose.yml metadata service, or PUID/PGID mismatch on file"
+                else
+                    _body=$(curl -sS --max-time 5 'http://127.0.0.1:8083/status?format=json' 2>/dev/null | head -c 200 || true)
+                    fail_check "/status snapshot present + readable in metadata container, but service returns HTTP 503. Body: ${_body:-empty}"
+                fi
+                ;;
             *)   fail_check "/status not responding — HTTP ${_status_code:-no-response}" ;;
         esac
     else


### PR DESCRIPTION
Hit on the v0.7.9.3 reflash: \`/status reports no snapshot — check snapmulti-status.timer AND /audio bind-mount on metadata container\`. Both subsystems were fine — the timer just hadn't fired yet (uptime < 4 min). Generic AND-message forced chasing both.

## New 503 branch logic

| Case | Verdict |
|------|---------|
| Snapshot file missing on host, uptime < 5min, timer never triggered | **INFO** ("not yet generated, fires at OnBootSec=4min") |
| Snapshot file missing, timer should have fired | FAIL → `journalctl -u snapmulti-status.service` |
| File on host, metadata container can't read it | FAIL → bind-mount / PUID-PGID |
| File present + readable, service still 503 | FAIL with response body inline |

## Validation
- ✅ snapvideo steady state: hits 200 path correctly
- 503 branches not exercised live (would need to nuke snapshot file to trigger); covered by code path inspection