### PR TITLE
docs(troubleshooting): first-boot fail tone on large NFS/SMB libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- **TROUBLESHOOTING: first-boot "fail" tone on large NFS / SMB libraries** — added [a new section](docs/TROUBLESHOOTING.md#first-boot-fail-tone-large-library) (EN + IT) explaining that the boot-time acoustic cue can play the descending "fail" tone during the initial MPD library scan when the library is large and `mpd.db` was not pre-warmed via `backup-from-sd.sh`. Includes the `docker exec mpd mpc status` probe to distinguish a real failure (no `Updating DB`) from the benign scan-in-progress state. No code change — the FAIL is genuine while the scan runs; documenting beats hiding it.
+
 ### Changed
 - **`/status` snapshot smoke check disambiguated** — the HTTP 503 branch used to lump three distinct root causes into one message ("check snapmulti-status.timer AND /audio bind-mount on metadata container"), forcing the operator to chase both. The check now probes directly: (a) snapshot file missing on host — INFO on fresh boot (< 5 min uptime + timer not yet armed), FAIL after; (b) file present on host but metadata container cannot read it — FAIL pointing at the bind-mount + PUID/PGID; (c) file present and readable in container but service still returns 503 — FAIL with the actual response body so the cause is visible. No false-positive on the first-boot window before `OnBootSec=4min`.
 

--- a/docs/TROUBLESHOOTING.it.md
+++ b/docs/TROUBLESHOOTING.it.md
@@ -206,6 +206,28 @@ sudo reboot
 
 Dopo il reboot, rilancia il test di salute (`sudo bash /opt/snapmulti/scripts/device-smoke.sh --server`) e verifica che `mount | grep ' on / type overlay'` riporti l'overlay attivo.
 
+## Tono "fail" al primo boot su librerie NFS / SMB grandi <a id="tono-fail-primo-boot-libreria-grande"></a>
+
+**Sintomi.** Subito dopo un reflash fresco con una libreria musicale di rete molto grande (≥ ~50 k tracce), il segnale acustico di fine boot è il tono **fail** discendente a due note (non l'arpeggio **pass** ascendente a tre note). Ogni reboot successivo nella stessa giornata può continuare a suonare **fail** finché la scansione della libreria non finisce. La pagina `/status` mostra il container MPD come `unhealthy`. Nient'altro sembra rotto — i client si connettono, AirPlay / Spotify / Tidal funzionano.
+
+**Causa probabile.** La prima scansione di MPD su NFS/SMB a cache fredda dura più della finestra healthcheck del container. Finché la scansione è in corso (ore su librerie enormi) l'healthcheck riporta `unhealthy`. `device-smoke.sh` lo classifica come fallimento → il verdetto complessivo è FAIL → il tono di boot riflette FAIL. È atteso, non un guasto reale: la scansione è il costo one-shot del primo install.
+
+**Come confermare che è una scansione, non un guasto reale.**
+
+```bash
+docker exec mpd mpc status | head
+# Cerca: la riga "Updating DB (#NNN)" — è la scansione in corso
+# Se presente: la scansione gira davvero, l'unhealthy è benigno
+# Se assente e mpd resta unhealthy: problema MPD vero (vedi "Niente audio" sopra)
+```
+
+**Cosa provare.**
+
+1. **Aspetta.** La prima scansione finisce tra minuti (libreria piccola) e diverse ore (50 k+ tracce su NFS lento). Una volta completata, il tono al prossimo boot sarà **pass** (ascendente).
+2. **Pre-warm del prossimo reflash.** Prima del reflash, lancia `sudo bash /opt/snapmulti/scripts/backup-from-sd.sh` sull'SD vecchia. Lo script estrae `mpd.db` di MPD sulla partizione boot; sul nuovo install MPD carica il database cached in secondi invece di rescansionare tutta la share NFS. Vedi [ADVANCED.it.md — Libreria musicale in rete](ADVANCED.it.md#libreria-musicale-in-rete).
+
+**Se è ancora bloccato.** Se `docker exec mpd mpc status` NON mostra `Updating DB` E mpd resta `unhealthy` per più di un'ora, hai un problema vero — controlla `docker logs mpd` e la raggiungibilità del NAS ([Libreria NAS vuota o non si monta](#libreria-nas-vuota-o-non-si-monta-nfs--smb)).
+
 ## Docker / "no space left on device"
 
 **Sintomi.** I container non partono con `no space left on device` in `docker compose logs`. `df -h` mostra il rootfs quasi pieno o l'overlay tmpfs pieno.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -206,6 +206,28 @@ sudo reboot
 
 After the reboot, re-run the smoke check (`sudo bash /opt/snapmulti/scripts/device-smoke.sh --server`) and verify `mount | grep ' on / type overlay'` reports the overlay is active.
 
+## First-boot "fail" tone on large NFS / SMB libraries <a id="first-boot-fail-tone-large-library"></a>
+
+**Symptoms.** Right after a fresh reflash with a very large network music library (≥ ~50 k tracks), the boot-time acoustic cue is the descending two-note **fail** tone (not the ascending three-note **pass** chime). Every subsequent reboot during the same day may also play **fail** until the library scan completes. The `/status` page shows the MPD container as `unhealthy`. Nothing else appears broken — clients connect, AirPlay / Spotify / Tidal work.
+
+**Likely cause.** MPD's first scan over NFS/SMB on a cold cache takes longer than the container healthcheck window. While the scan is in progress (can be hours on huge libraries), the healthcheck reports `unhealthy`. `device-smoke.sh` classifies that as a failure → the overall verdict is FAIL → the boot tone reflects FAIL. This is expected, not a real fault: the scan is the long-pole single-time cost of the first install.
+
+**How to confirm it's a scan, not a real failure.**
+
+```bash
+docker exec mpd mpc status | head
+# Look for: "Updating DB (#NNN)" line — that's the in-progress scan
+# If present: scan is genuinely running, the unhealthy is benign
+# If absent and mpd is still unhealthy: real MPD problem (see "No audio" above)
+```
+
+**Try this.**
+
+1. **Wait.** First scan finishes between minutes (small library) and several hours (50 k+ tracks over slow NFS). Once it completes the next boot tone will be **pass** (ascending).
+2. **Pre-warm next reflash.** Before reflashing, run `sudo bash /opt/snapmulti/scripts/backup-from-sd.sh` on the old SD card. The script extracts MPD's `mpd.db` file to the boot partition; on the new install, MPD loads the cached database in seconds instead of full-scanning the NFS share. See [ADVANCED.md — Music library on the network](ADVANCED.md#music-library-on-the-network).
+
+**If still broken.** If `docker exec mpd mpc status` does NOT show `Updating DB` AND mpd remains `unhealthy` for more than an hour, you have a real problem — check `docker logs mpd` and the NAS reachability ([NAS library empty or never mounts](#nas-library-empty-or-never-mounts-nfs--smb)).
+
 ## Docker / "no space left on device"
 
 **Symptoms.** Containers fail to start with `no space left on device` in `docker compose logs`. `df -h` shows the rootfs nearly full or shows the overlay tmpfs full.


### PR DESCRIPTION
Documents the descending "fail" boot tone heard after a fresh reflash on a large NFS/SMB library when no \`mpd.db\` backup was carried over.

| | |
|--|--|
| Scope | docs-only — no smoke check / no code path changes |
| EN section | docs/TROUBLESHOOTING.md — anchor \`#first-boot-fail-tone-large-library\` |
| IT section | docs/TROUBLESHOOTING.it.md — anchor \`#tono-fail-primo-boot-libreria-grande\` |
| Diagnostic probe | \`docker exec mpd mpc status\` — \`Updating DB\` line distinguishes scan from real fault |
| Pre-warm workflow | \`scripts/backup-from-sd.sh\` ships mpd.db across reflashes; documented inline |

## Why docs vs code
A code-side downgrade of MPD \`unhealthy\` → \`info\` would mask a permanently broken MPD condition for ALL users to suppress a transient first-boot tone that only some users hear once. The cost asymmetry doesn't justify the code change. Documentation gives the user the actionable probe + the lifecycle context.

## Validation
- ✅ EN + IT in sync (mirror sections, same probe, same anchors style)
- ✅ Internal links resolve: TROUBLESHOOTING ↔ ADVANCED.md (mpd.db backup path), TROUBLESHOOTING ↔ "No audio" + "NAS library empty"
- ✅ CHANGELOG entry under \`[Unreleased]\`