### PR TITLE
feat(fb-display): show "Booting…" instead of ?.?.?.? during first 90s of boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **fb-display: show "Booting…" instead of `?.?.?.?` during the first 90 s of boot (#540)** — the bare placeholder reads as "network broken" on a fresh HDMI screen and triggered unnecessary user reboots during the normal WiFi-association + DHCP window. `_get_lan_ip()` now consults `/proc/uptime` after the socket probes fail: `< 90 s` → `"Booting…"`, `≥ 90 s` → `"?.?.?.?"` (real persistent failure surfaces). `/proc/uptime` unreadable falls through conservatively to `"?.?.?.?"` so an outage is never silently hidden. Cache invariant also bypasses on `"Booting…"` so the display picks up the real IP the moment DHCP completes. 4 new regression tests pin the matrix.
 - **`/status` snapshot smoke check disambiguated** — the HTTP 503 branch used to lump three distinct root causes into one message ("check snapmulti-status.timer AND /audio bind-mount on metadata container"), forcing the operator to chase both. The check now probes directly: (a) snapshot file missing on host — INFO on fresh boot (< 5 min uptime + timer not yet armed), FAIL after; (b) file present on host but metadata container cannot read it — FAIL pointing at the bind-mount + PUID/PGID; (c) file present and readable in container but service still returns 503 — FAIL with the actual response body so the cause is visible. No false-positive on the first-boot window before `OnBootSec=4min`.
 
 ## [0.7.9.3] — 2026-05-29

--- a/client/common/docker/fb-display/fb_display.py
+++ b/client/common/docker/fb-display/fb_display.py
@@ -46,7 +46,18 @@ TARGET_FPS = 20
 
 
 def _get_lan_ip() -> str:
-    """Get LAN IP. Works on offline LANs (no internet required)."""
+    """Get LAN IP. Works on offline LANs (no internet required).
+
+    On total failure: if the device is still in the first 90 s after
+    boot (per /proc/uptime), return "Booting…" instead of "?.?.?.?".
+    The placeholder ?.?.?.? on a fresh-boot HDMI screen reads as
+    "network broken!" and triggered unnecessary user reboots; during
+    the WiFi-association + DHCP window it is normal to have no IP
+    yet, and the right message is "device is starting" not "device
+    is broken". After 90 s the fallback is still ?.?.?.? — a
+    persistent placeholder means a real persistent failure that
+    should surface as such.
+    """
     # Try default gateway first (works without internet)
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
@@ -63,6 +74,17 @@ def _get_lan_ip() -> str:
                 return ip
     except OSError:
         pass
+    # Boot-age gate before the bare placeholder. /proc/uptime first field
+    # is float seconds since boot on every Linux system; if unreadable
+    # (CI container without /proc, exotic mount, etc.), fall through to
+    # the conservative ?.?.?.? rather than ever silently hiding a real
+    # outage as "Booting…".
+    try:
+        uptime = float(open("/proc/uptime").read().split()[0])
+        if uptime < 90:
+            return "Booting…"
+    except (OSError, ValueError, IndexError):
+        pass
     return "?.?.?.?"
 
 
@@ -78,9 +100,10 @@ def get_lan_ip() -> str:
     global _LAN_IP_CACHE
     now = time.time()
     cached_ip, cached_at = _LAN_IP_CACHE
-    # Refresh if TTL expired, OR if we still have the placeholder (keep retrying
-    # cheaply until DHCP gives us something real).
-    if cached_ip == "?.?.?.?" or now - cached_at > _LAN_IP_TTL:
+    # Refresh if TTL expired, OR if we still have a non-IP placeholder
+    # ("?.?.?.?" or "Booting…") — keep retrying cheaply until DHCP gives
+    # us a real address. TTL only locks in once we have an actual IP.
+    if cached_ip in ("?.?.?.?", "Booting…") or now - cached_at > _LAN_IP_TTL:
         _LAN_IP_CACHE = (_get_lan_ip(), now)
     return _LAN_IP_CACHE[0]
 

--- a/client/common/docker/fb-display/fb_display.py
+++ b/client/common/docker/fb-display/fb_display.py
@@ -80,7 +80,8 @@ def _get_lan_ip() -> str:
     # the conservative ?.?.?.? rather than ever silently hiding a real
     # outage as "Booting…".
     try:
-        uptime = float(open("/proc/uptime").read().split()[0])
+        with open("/proc/uptime") as f:
+            uptime = float(f.read().split()[0])
         if uptime < 90:
             return "Booting…"
     except (OSError, ValueError, IndexError):

--- a/client/tests/test_fb_display.py
+++ b/client/tests/test_fb_display.py
@@ -18,6 +18,26 @@ sys.path.insert(
 import fb_display
 
 
+def _mock_proc_uptime(monkeypatch, seconds: float) -> None:
+    """Make `open('/proc/uptime')` return the given uptime value.
+
+    `_get_lan_ip()` reads /proc/uptime to decide between the transient
+    'Booting…' label and the persistent '?.?.?.?' fallback. Tests pin
+    that value so the assertion does not depend on real host uptime
+    (e.g. dev laptop has been up for hours, CI container for seconds).
+    """
+    import io
+
+    real_open = open
+
+    def fake_open(path, *a, **kw):
+        if str(path) == "/proc/uptime":
+            return io.StringIO(f"{seconds} {seconds}\n")
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+
 class TestFormatTime:
     """Test time formatting function."""
 
@@ -498,6 +518,60 @@ class TestGetLanIp:
 
         monkeypatch.setattr(socket, "socket", _raise)
         monkeypatch.setattr(socket, "getaddrinfo", _raise)
+        # Pin uptime to past the 90 s boot-age gate so the test asserts
+        # the bare placeholder (the actual fail-mode contract) and is
+        # not flaky on CI runners whose container uptime is < 90 s.
+        _mock_proc_uptime(monkeypatch, 600.0)
+        assert fb_display._get_lan_ip() == "?.?.?.?"
+
+    def test_booting_placeholder_during_first_90s(self, monkeypatch):
+        """Within 90 s of boot, no-IP should render as 'Booting…' rather
+        than '?.?.?.?' — the placeholder reads as broken-network and
+        triggered unnecessary user reboots on every fresh boot."""
+        import socket
+
+        def _raise(*a, **kw):
+            raise OSError("no network yet")
+
+        monkeypatch.setattr(socket, "socket", _raise)
+        monkeypatch.setattr(socket, "getaddrinfo", _raise)
+        _mock_proc_uptime(monkeypatch, 30.0)
+        assert fb_display._get_lan_ip() == "Booting…"
+
+    def test_placeholder_returns_at_90s_threshold(self, monkeypatch):
+        """At uptime >= 90 s the no-IP state is a real persistent
+        failure and the bare placeholder must surface."""
+        import socket
+
+        def _raise(*a, **kw):
+            raise OSError("no network")
+
+        monkeypatch.setattr(socket, "socket", _raise)
+        monkeypatch.setattr(socket, "getaddrinfo", _raise)
+        _mock_proc_uptime(monkeypatch, 90.0)
+        assert fb_display._get_lan_ip() == "?.?.?.?"
+
+    def test_unreadable_uptime_falls_through_conservative(self, monkeypatch):
+        """If /proc/uptime cannot be read at all (exotic container, no
+        /proc mount, IO error), the boot-age gate must NOT silently
+        cover up a real outage — fall through to '?.?.?.?' so a true
+        failure still surfaces."""
+        import socket
+
+        def _raise(*a, **kw):
+            raise OSError("no network")
+
+        monkeypatch.setattr(socket, "socket", _raise)
+        monkeypatch.setattr(socket, "getaddrinfo", _raise)
+        # Open of /proc/uptime raises OSError → caught → fall through
+        real_open = open
+
+        def fake_open(path, *a, **kw):
+            if str(path) == "/proc/uptime":
+                raise OSError("not mounted")
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", fake_open)
         assert fb_display._get_lan_ip() == "?.?.?.?"
 
 
@@ -514,7 +588,9 @@ class TestDiscoverSnapservers:
 
         class FakeZeroconf:
             def get_service_info(self, type_, name):
-                return FakeServiceInfo([b"\xc0\x00\x02\x68"])  # 192.0.2.104 (0xc0.0x00.0x02.0x68)
+                return FakeServiceInfo(
+                    [b"\xc0\x00\x02\x68"]
+                )  # 192.0.2.104 (0xc0.0x00.0x02.0x68)
 
             def close(self):
                 pass


### PR DESCRIPTION
The bare \`?.?.?.?\` placeholder during the WiFi-association + DHCP window of a fresh boot reads as "network broken" — users were rebooting unnecessarily.

| | |
|--|--|
| Symptom | fb-display shows \`?.?.?.?\` on HDMI in the first ~16-90 s after reflash boot |
| Root cause | binary IP-vs-placeholder; no notion of "device is still starting" |
| Fix | age-gate the placeholder via \`/proc/uptime\`. <90 s → \`"Booting…"\`. ≥90 s → \`"?.?.?.?"\` (real failure) |
| LOC | ~10 in fb_display.py, ~70 in tests |

## Tests (all pass locally)
- existing \`test_fallback_on_total_failure\` pinned to uptime > 90 s (not flaky on short-uptime CI runners)
- new \`test_booting_placeholder_during_first_90s\`
- new \`test_placeholder_returns_at_90s_threshold\`
- new \`test_unreadable_uptime_falls_through_conservative\`

## Design notes
This intentionally undershoots the council-deep plan that distinguished associating vs waiting-for-DHCP via \`/sys/class/net\` probing. The user-actionable distinction is "broken vs starting", not which stage of network setup is in flight. See plan v3 for the self-criticism that walked back from over-engineering.

## Validation
- ✅ pytest \`client/tests/test_fb_display.py::TestGetLanIp\` 6/6 pass
- ✅ ruff format + check clean
- ⏳ live HDMI verification deferred to next snapvideo reflash