### PR TITLE
feat(auto-boot-smoke): mode-aware wait cap (server/both 300s, client 90s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **auto-boot-smoke: mode-aware wait cap (server/both 240 s, client 90 s)** — on server/both installs the boot-time smoke check now waits up to 240 s for snapserver / snapclient healthy (was 90 s); on client / client-native it stays at 90 s because snapclient is ready in seconds (no MPD, no library scan). The extension lets small / medium libraries (≤ ~10 k tracks local or NFS) finish MPD's first scan before the tone fires → PASS chime instead of always FAIL during MPD warmup. Very large libraries (50 k+ NFS) still exceed 240 s → fail tone remains, covered by the existing TROUBLESHOOTING entry + `backup-from-sd.sh` mpd.db pre-warm workflow. `TimeoutStartSec` bumped 240 → 600 s only on the server/both unit (client keeps 240 s).
+- **auto-boot-smoke: mode-aware wait cap (server/both 300 s, client 90 s)** — on server/both installs the boot-time smoke check now waits up to 300 s for snapserver / snapclient healthy (was 90 s); on client / client-native it stays at 90 s because snapclient is ready in seconds (no MPD, no library scan). The extension lets small / medium libraries (≤ ~10 k tracks local or NFS) finish MPD's first scan before the tone fires → PASS chime instead of always FAIL during MPD warmup. Very large libraries (50 k+ NFS) still exceed 300 s → fail tone remains, covered by the existing TROUBLESHOOTING entry + `backup-from-sd.sh` mpd.db pre-warm workflow. `TimeoutStartSec` bumped 240 → 720 s only on the server/both unit (client keeps 240 s).
 
 ## [0.7.9.4] — 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **auto-boot-smoke: mode-aware wait cap (server/both 240 s, client 90 s)** — on server/both installs the boot-time smoke check now waits up to 240 s for snapserver / snapclient healthy (was 90 s); on client / client-native it stays at 90 s because snapclient is ready in seconds (no MPD, no library scan). The extension lets small / medium libraries (≤ ~10 k tracks local or NFS) finish MPD's first scan before the tone fires → PASS chime instead of always FAIL during MPD warmup. Very large libraries (50 k+ NFS) still exceed 240 s → fail tone remains, covered by the existing TROUBLESHOOTING entry + `backup-from-sd.sh` mpd.db pre-warm workflow. `TimeoutStartSec` bumped 240 → 600 s only on the server/both unit (client keeps 240 s).
+
 ## [0.7.9.4] — 2026-05-29
 
 > Script-only patch (image_set stays 0.7.7). UX papercuts surfaced after the v0.7.9.3 reflash on a large NFS library: bundles the `/status` 503 diagnostic disambiguation (#538), fb-display "Booting…" placeholder during the first 90 s of boot (#540), and a TROUBLESHOOTING entry explaining the benign "fail" tone during the first MPD library scan (#539). No image rebuild.

--- a/scripts/common/auto-boot-smoke.sh
+++ b/scripts/common/auto-boot-smoke.sh
@@ -25,14 +25,14 @@ esac
 #   no library), so 90 s is plenty and we don't want to delay the
 #   audible "device ready" cue.
 # - server / both: MPD scans the library on first boot. Local or small
-#   NFS libraries (≤ ~10 k tracks) finish within ~3-4 min — extending
-#   the cap to 240 s lets the tone land PASS (ascending chime) on
+#   NFS libraries (≤ ~10 k tracks) finish within ~3-5 min — extending
+#   the cap to 300 s lets the tone land PASS (ascending chime) on
 #   those installs instead of always firing FAIL during MPD warmup.
-#   Very large libraries (50 k+ tracks NFS) still exceed 240 s —
+#   Very large libraries (50 k+ tracks NFS) still exceed 300 s —
 #   covered by the TROUBLESHOOTING entry on benign first-scan fail
 #   tone + the backup-from-sd.sh mpd.db pre-warm workflow.
 case "$INSTALL_TYPE" in
-    server|both) WAIT_CAP_SEC=240 ;;
+    server|both) WAIT_CAP_SEC=300 ;;
     *)           WAIT_CAP_SEC=90  ;;
 esac
 WAIT_ITERATIONS=$(( WAIT_CAP_SEC / 5 ))

--- a/scripts/common/auto-boot-smoke.sh
+++ b/scripts/common/auto-boot-smoke.sh
@@ -20,23 +20,38 @@ esac
 
 [[ -x "$SMOKE" ]] || exit 0
 
-# Cap waits at 90 s each (well under TimeoutStartSec=240) — fire the tone even if MPD is still scanning a large NFS library (can take hours).
+# Mode-aware wait cap.
+# - client / client-native: snapclient is ready in seconds (no MPD,
+#   no library), so 90 s is plenty and we don't want to delay the
+#   audible "device ready" cue.
+# - server / both: MPD scans the library on first boot. Local or small
+#   NFS libraries (≤ ~10 k tracks) finish within ~3-4 min — extending
+#   the cap to 240 s lets the tone land PASS (ascending chime) on
+#   those installs instead of always firing FAIL during MPD warmup.
+#   Very large libraries (50 k+ tracks NFS) still exceed 240 s —
+#   covered by the TROUBLESHOOTING entry on benign first-scan fail
+#   tone + the backup-from-sd.sh mpd.db pre-warm workflow.
+case "$INSTALL_TYPE" in
+    server|both) WAIT_CAP_SEC=240 ;;
+    *)           WAIT_CAP_SEC=90  ;;
+esac
+WAIT_ITERATIONS=$(( WAIT_CAP_SEC / 5 ))
 
-# Wait up to 90 s for systemd to leave 'starting' (avoids false-positive `systemd state unexpected: 'starting'` smoke FAIL).
-for _ in $(seq 1 18); do
+# Wait up to WAIT_CAP_SEC for systemd to leave 'starting' (avoids false-positive `systemd state unexpected: 'starting'` smoke FAIL).
+for _ in $(seq 1 "$WAIT_ITERATIONS"); do
     state=$(systemctl is-system-running 2>/dev/null || true)
     [[ "$state" == "starting" ]] || break
     sleep 5
 done
 
-# Wait up to 90 s for the audio CORE — snapserver (server/both) and snapclient (client/both). MPD/metadata/etc. are best-effort: if they're slow (NFS scan), the tone still fires and signals the audio path is up.
+# Wait up to WAIT_CAP_SEC for the audio CORE — snapserver (server/both) and snapclient (client/both). MPD/metadata/etc. are best-effort: if they're slow (NFS scan), the tone still fires and signals the audio path is up.
 # Format: "<compose-dir>:<service>" — both-mode keeps snapserver in /opt/snapmulti and snapclient in /opt/snapclient (separate compose projects per CLAUDE.md).
 case "$INSTALL_TYPE" in
     client|client-native) CORE_CHECKS="/opt/snapclient:snapclient" ;;
     both)                 CORE_CHECKS="/opt/snapmulti:snapserver /opt/snapclient:snapclient" ;;
     *)                    CORE_CHECKS="/opt/snapmulti:snapserver" ;;
 esac
-for _ in $(seq 1 18); do
+for _ in $(seq 1 "$WAIT_ITERATIONS"); do
     all_healthy=1
     for check in $CORE_CHECKS; do
         compose_dir="${check%%:*}"

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -842,8 +842,8 @@ Wants=docker.service
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/snapmulti-auto-boot-smoke
-# 240s systemd-settled wait + 240s audio-core healthy wait + 10s buffer + ~50s smoke run = 540s worst-case ceiling on server/both. NFS-grandi scan MPD non blocca (best-effort, non in CORE_SERVICES).
-TimeoutStartSec=600
+# 300s systemd-settled wait + 300s audio-core healthy wait + 10s buffer + ~50s smoke run = 660s worst-case ceiling on server/both. NFS-grandi scan MPD non blocca (best-effort, non in CORE_SERVICES).
+TimeoutStartSec=720
 StandardOutput=journal
 StandardError=journal
 

--- a/scripts/common/system-tune.sh
+++ b/scripts/common/system-tune.sh
@@ -842,8 +842,8 @@ Wants=docker.service
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/snapmulti-auto-boot-smoke
-# 90s systemd-settled wait + 90s audio-core healthy wait + 10s buffer + 50s margin = 240s ceiling. NFS-grandi scan MPD non blocca (best-effort, non in CORE_SERVICES).
-TimeoutStartSec=240
+# 240s systemd-settled wait + 240s audio-core healthy wait + 10s buffer + ~50s smoke run = 540s worst-case ceiling on server/both. NFS-grandi scan MPD non blocca (best-effort, non in CORE_SERVICES).
+TimeoutStartSec=600
 StandardOutput=journal
 StandardError=journal
 

--- a/tests/test_auto_boot_smoke.sh
+++ b/tests/test_auto_boot_smoke.sh
@@ -37,7 +37,9 @@ assert "grep -q 'docker compose ps' '$WRAP'" "polls docker compose for container
 assert "grep -q 'CORE_CHECKS=' '$WRAP'" "waits only for audio CORE (snapserver/snapclient), not MPD — large NFS scans would time out otherwise"
 assert "grep -q '/opt/snapmulti:snapserver /opt/snapclient:snapclient' '$WRAP'" "both-mode queries each service from ITS OWN compose project (snapclient lives in /opt/snapclient, not /opt/snapmulti)"
 assert "grep -q 'is-system-running' '$WRAP'" "waits for systemd to exit 'starting' (avoids false-positive systemd state FAIL)"
-assert "grep -qE 'seq 1 18' '$WRAP'" "caps each wait at 90 s (18 × 5 s) — well under TimeoutStartSec=240"
+assert "grep -q 'WAIT_CAP_SEC=300' '$WRAP'" "server/both wait cap is 300 s (covers MPD scan on local / small NFS)"
+assert "grep -q 'WAIT_CAP_SEC=90' '$WRAP'" "client/client-native wait cap is 90 s (snapclient ready in seconds; no MPD)"
+assert "grep -q 'WAIT_ITERATIONS=\$(( WAIT_CAP_SEC / 5 ))' '$WRAP'" "wait iteration count derived from per-mode cap (× 5 s sleep)"
 assert "grep -q 'SNAPMULTI_FORCE_TONE=1' '$WRAP'" "forces tone even with active Snapcast stream (option B: user must hear post-boot status)"
 assert "grep -qE '\\|\\| true\\s*$|exit 0' '$WRAP'" "always exits 0 — tone is the signal, never fails the systemd unit"
 


### PR DESCRIPTION
The boot-time tone landed FAIL on server/both installs because the 90 s wait cap was too tight for MPD's first library scan. Move to mode-aware:

| Mode | Wait cap | Rationale |
|------|----------|-----------|
| server / both | **240 s** | catches MPD scan on local + small NFS (≤ ~10 k tracks) |
| client / client-native | 90 s (unchanged) | snapclient ready in seconds; no library to scan |

## Files
- \`scripts/common/auto-boot-smoke.sh\` — \`WAIT_CAP_SEC\` per-mode + loop iterations derived from it
- \`scripts/common/system-tune.sh\` — server/both heredoc bumps \`TimeoutStartSec=240→600\`. Client heredoc unchanged.

## Trade-offs (explicit, no overengineering)
- ⚠ Large libraries (50 k+) still exceed 240 s → fail tone remains. Documented in TROUBLESHOOTING.
- ⚠ Wider window for snapclient stream to grab the DAC before the tone fires (EBUSY on hw: direct). Acceptable: SNAPMULTI_FORCE_TONE handles the Snapcast soft check, and the user can already silence with \`TEST_TONE=false\`.
- ✅ No new helper, no new module, no test scaffolding — single \`case\` + derived iteration count. ~15 LOC.

Live validation deferred to next reflash (snapvideo just reflashed for v0.7.9.4).