### PR TITLE
fix(smoke): two false-positive FAILs during first-boot window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **smoke: two false-positive FAILs during first-boot window** —
+  - `check_boot_health.sh`: `systemd state unexpected: 'starting'` was fired when smoke was invoked by `snapmulti-status.timer` (no `SNAPMULTI_AUTO_BOOT` env var) during the first ~10 min after boot, while MPD was still scanning a large library and other services were still settling. The 'starting' tolerance now ALSO holds when uptime < 600 s — bypass via env var or boot window, whichever applies.
+  - `device-smoke.sh` `/status` snapshot check: PR #538 demoted "snapshot missing" to INFO only when uptime < 300 s AND the timer had never fired. Misses the case where the timer DID fire on schedule (OnBootSec=4min) but `snapmulti-status.service` is currently in ExecStartPre (waiting up to 5 min for MPD healthy on first boot) — service state `activating`, snapshot legitimately not yet on disk. Now demotes to INFO when `systemctl is-active snapmulti-status.service` reports `activating`.
+
 ### Changed
 - **auto-boot-smoke: mode-aware wait cap (server/both 300 s, client 90 s)** — on server/both installs the boot-time smoke check now waits up to 300 s for snapserver / snapclient healthy (was 90 s); on client / client-native it stays at 90 s because snapclient is ready in seconds (no MPD, no library scan). The extension lets small / medium libraries (≤ ~10 k tracks local or NFS) finish MPD's first scan before the tone fires → PASS chime instead of always FAIL during MPD warmup. Very large libraries (50 k+ NFS) still exceed 300 s → fail tone remains, covered by the existing TROUBLESHOOTING entry + `backup-from-sd.sh` mpd.db pre-warm workflow. `TimeoutStartSec` bumped 240 → 720 s only on the server/both unit (client keeps 240 s).
 

--- a/scripts/device-smoke.sh
+++ b/scripts/device-smoke.sh
@@ -1000,7 +1000,12 @@ if [[ "$MODE" == "server" || "$MODE" == "both" ]]; then
                 #
                 #   (a) Snapshot file missing on host. On fresh boot the
                 #       timer fires at OnBootSec=4min — INFO until then,
-                #       FAIL after.
+                #       FAIL after. Plus snapmulti-status.service has an
+                #       ExecStartPre that waits up to 5 min for MPD
+                #       healthy on first boot with a large NFS library;
+                #       during that wait the service is in 'activating'
+                #       state and the snapshot is legitimately not yet
+                #       on disk — also INFO.
                 #   (b) File present on host but metadata container can't
                 #       see it. Bind-mount missing or wrong perms.
                 #   (c) File present + readable in container but service
@@ -1010,8 +1015,11 @@ if [[ "$MODE" == "server" || "$MODE" == "both" ]]; then
                 _uptime_s=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 999999)
                 if [[ ! -e "$_snap_file" ]]; then
                     _last_trig=$(systemctl show snapmulti-status.timer -p LastTriggerUSec --value 2>/dev/null || true)
+                    _svc_state=$(systemctl is-active snapmulti-status.service 2>/dev/null || true)
                     if { [[ -z "$_last_trig" ]] || [[ "$_last_trig" == "n/a" ]]; } && (( _uptime_s < 300 )); then
                         info "/status snapshot not yet generated — snapmulti-status.timer fires at OnBootSec=4min (uptime ${_uptime_s}s, timer not yet armed)"
+                    elif [[ "$_svc_state" == "activating" ]]; then
+                        info "/status snapshot pending — snapmulti-status.service in ExecStartPre wait (up to 5 min for MPD healthy on first boot with large NFS library)"
                     else
                         fail_check "/status snapshot missing on host ($_snap_file). snapmulti-status.timer has not produced one — check 'journalctl -u snapmulti-status.service' for ExecStart errors"
                     fi

--- a/scripts/smoke/check_boot_health.sh
+++ b/scripts/smoke/check_boot_health.sh
@@ -99,12 +99,24 @@ check_boot_health() {
 
     local sys_state
     sys_state=$(systemctl is-system-running 2>/dev/null || true)
-    # Self-referential paradox: when smoke runs from snapmulti-auto-boot-smoke.service,
-    # system state cannot be 'running' yet — it's pending on the auto-boot-smoke
-    # service itself. Treat 'starting' as info in that context. SNAPMULTI_AUTO_BOOT
-    # is set by the auto-boot wrapper (scripts/common/auto-boot-smoke.sh).
-    if [[ "$sys_state" == "starting" && "${SNAPMULTI_AUTO_BOOT:-}" == "1" ]]; then
-        info "systemd still 'starting' (expected — smoke is itself a pending boot unit)"
+    # 'starting' tolerance — two paths:
+    #
+    # (a) Self-referential paradox: when smoke runs from
+    #     snapmulti-auto-boot-smoke.service, system state cannot be
+    #     'running' yet — it's pending on the auto-boot-smoke service
+    #     itself. SNAPMULTI_AUTO_BOOT=1 is set by the auto-boot wrapper.
+    #
+    # (b) First-boot window: when smoke runs from
+    #     snapmulti-status.timer (no env var), the snapshot is
+    #     produced while MPD may still be scanning the library and
+    #     snapmulti-server.service may still be activating. Under
+    #     ~10 min uptime the 'starting' state is expected; after
+    #     that, it is a real problem worth surfacing.
+    local _uptime_s
+    _uptime_s=$(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 999999)
+    if [[ "$sys_state" == "starting" ]] \
+        && { [[ "${SNAPMULTI_AUTO_BOOT:-}" == "1" ]] || (( _uptime_s < 600 )); }; then
+        info "systemd still 'starting' (boot window — uptime ${_uptime_s}s, services may still be settling)"
         return 0
     fi
     case "$sys_state" in


### PR DESCRIPTION
Reflash of v0.7.9.4 on snapvideo (76k-track NFS library) surfaces two FAILs that are legitimate first-boot transients, not real problems.

| FAIL | Real cause | Fix |
|------|-----------|-----|
| \`systemd state unexpected: 'starting'\` | MPD scanning + other services still activating in first ~10min post-boot | extend tolerance to \`SNAPMULTI_AUTO_BOOT=1\` OR uptime < 600s |
| \`/status snapshot missing on host\` | \`snapmulti-status.service\` in ExecStartPre wait for MPD healthy (up to 5 min) | demote to INFO when \`systemctl is-active\` reports \`activating\` |

## Validation
- ✅ syntax checks pass
- ⏳ live verification deferred to next snapvideo reboot (current uptime is past the 600s window, can't repro without reboot)

## Trade-off
After 10 min uptime, 'starting' state is still treated as FAIL — that's correct. A device stuck in 'starting' past the 10-min mark IS a problem worth surfacing.