### PR TITLE
feat(/status): Fleet observation tab — LAN-wide read-only peer aggregation (#549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/status` Fleet observation tab (#549)** — read-only LAN-wide aggregation of peer snapMULTI instances. The local `/status` HTML page now shows a "View fleet" link in its subtext; clicking surfaces `?fleet=1` which discovers peers via `avahi-browse _snapcast._tcp` (reusing the existing Snapcast mDNS publication — no new mDNS service), fetches each peer's `/status?format=json` in parallel (5 s per-peer timeout), and renders a Fleet section with: hostname (clickable link to peer's `/status`), mode, release tag, container health summary, status icon. Programmatic clients can request `?format=json&scope=fleet` to receive `{schema_version: 1, self_hostname: …, peers: [...]}`. Per-peer cache (120 s TTL) absorbs the browser's 60 s auto-refresh so cold-cache discovery (~5-8 s) only fires every other refresh. Closes the **observation half** of #162; cross-instance control / multi-site / unified config remain out of scope per CLAUDE.md non-goals. 16 new tests pin the matrix (avahi parse / self-exclusion / dedup / PTR-only skip + HTML render with no peers / single peer / fail status / XSS escaping).
+
 ### Changed
 - **`/status` page: overlayroot-aware journal message + remove user-facing `(issue #177 path)` jargon** — two beginner-confusion fixes on the system-health page:
   - `check_boot_health.sh` was emitting `No previous boot recorded in journal (fresh reflash or rotated logs)` on every snapMULTI device. On `overlayroot=tmpfs` the journal lives in `/run` (tmpfs) and is wiped every reboot — "no previous boot" is structural, not a fresh-reflash sign. The message now detects overlayroot via `findmnt` and surfaces `Journal volatile (overlayroot=tmpfs) — previous boots not retained` on those devices, keeping the old wording only for non-overlayroot setups (dev clones, manual installs).

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -6,9 +6,16 @@ WORKDIR /app
 # Install uv for fast dependency installation
 COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /usr/local/bin/uv
 
-# Install dependencies: WebSocket server + HTTP server
+# Install dependencies: WebSocket server + HTTP server.
+# avahi-utils provides `avahi-browse` used by /status?fleet=1 (#549) to
+# discover peer snapMULTI instances on the LAN. The corresponding D-Bus
+# socket is bind-mounted via docker-compose.yml so the client can reach
+# the host's avahi-daemon.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system "websockets==16.0" "aiohttp==3.13.5"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends avahi-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy metadata service
 COPY docker/metadata-service/metadata-service.py /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,6 +291,10 @@ services:
       # "no snapshot available" failure verdict even when the host-side
       # timer is healthy (issue surfaced after v0.6.4 ship).
       - ./audio:/audio:ro
+      # D-Bus socket for avahi-browse — needed by /status?fleet=1 (#549)
+      # to discover peer snapMULTI instances via _snapcast._tcp mDNS.
+      # Read-only: this container only browses, never publishes.
+      - /var/run/dbus:/var/run/dbus:ro
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8083/health', timeout=3)"]
       interval: 30s

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2320,6 +2320,11 @@ async def _fetch_peer_status_summary(
                 url, timeout=aiohttp.ClientTimeout(total=timeout_s)
             ) as resp:
                 if resp.status != 200:
+                    # Distinguish 404 (version skew) from 503 (peer overloaded)
+                    # from 401/403 (auth) in operator debugging.
+                    logger.debug(
+                        "fleet: fetch %s returned HTTP %d", peer_host, resp.status
+                    )
                     return None
                 data = await resp.json()
     except Exception as exc:  # noqa: BLE001 — broad on purpose: any error drops the peer; debug log preserves diagnostics.
@@ -2378,7 +2383,15 @@ async def _build_fleet_view(own_hostname: str) -> list[dict]:
             *(_fetch_peer_status_summary(p["hostname"]) for p in peers),
             return_exceptions=True,
         )
-        summaries: list[dict] = [r for r in results if isinstance(r, dict)]
+        summaries: list[dict] = []
+        for peer, res in zip(peers, results, strict=True):
+            if isinstance(res, dict):
+                summaries.append(res)
+            elif isinstance(res, BaseException):
+                # gather caught an exception that _fetch_peer_status_summary's
+                # own except block didn't (e.g. scheduling-time error). Log so
+                # an operator can correlate "peer missing from fleet" with cause.
+                logger.debug("fleet: gather for %s raised %s", peer["hostname"], res)
         summaries.sort(key=lambda s: s.get("hostname", "").lower())
         _fleet_cache["data"] = (time.time(), summaries)
         return summaries

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2226,6 +2226,139 @@ async def handle_version(request: web.Request) -> web.Response:
 # JSON snapshot here every 5 min.
 STATUS_JSON_PATH = "/audio/system-status.json"
 
+# ── Fleet observation (#549) — read-only mDNS aggregation of peer instances.
+# Browser auto-refreshes /status every 60 s; cache 120 s so most refreshes hit
+# cache and only every other refresh does live discovery.
+_FLEET_CACHE_TTL_SECONDS = 120
+_fleet_cache: dict[str, tuple[float, list[dict]]] = {}
+
+
+def _normalize_mdns_host(name: str) -> str:
+    """Strip trailing dot then '.local' so comparison is form-independent."""
+    return name.lower().strip().rstrip(".").removesuffix(".local").rstrip(".")
+
+
+def _parse_avahi_browse_peers(stdout: str, own_hostname: str) -> list[dict]:
+    """Parse `avahi-browse -rpt _snapcast._tcp` output; return peer dicts minus self."""
+    own_lc = _normalize_mdns_host(own_hostname)
+    peers: list[dict] = []
+    seen: set[str] = set()
+    # Format: =;iface;family;name;type;domain;HOST;addr;port;txt
+    for line in stdout.splitlines():
+        if not line.startswith("="):
+            continue
+        fields = line.split(";")
+        if len(fields) < 9:
+            continue
+        host_full = fields[6].strip()
+        host_lc = _normalize_mdns_host(host_full)
+        if not host_lc or host_lc == own_lc:
+            continue
+        if host_lc in seen:
+            continue
+        seen.add(host_lc)
+        peers.append({"hostname": host_full, "addr": fields[7], "port": fields[8]})
+    return peers
+
+
+async def _discover_snapmulti_peers(
+    own_hostname: str, timeout_s: float = 8.0
+) -> list[dict]:
+    # Spawns avahi-browse via create_subprocess_exec (list-args, NO shell —
+    # args are fixed string literals; not vulnerable to command injection).
+    import asyncio
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "avahi-browse",
+            "-rpt",
+            "_snapcast._tcp",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, OSError):
+        return []
+    try:
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        return []
+    return _parse_avahi_browse_peers(
+        stdout.decode("utf-8", errors="ignore"), own_hostname
+    )
+
+
+async def _fetch_peer_status_summary(
+    peer_host: str, timeout_s: float = 5.0
+) -> dict | None:
+    """Fetch peer /status?format=json and extract a per-peer summary; None on any error."""
+    import aiohttp
+
+    url = f"http://{peer_host}:8083/status?format=json"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url, timeout=aiohttp.ClientTimeout(total=timeout_s)
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json()
+    except Exception:
+        return None
+
+    summary: dict = {
+        "hostname": data.get("hostname", peer_host),
+        "mode": data.get("mode", "?"),
+        "status": data.get("status", "?"),
+        "failures": int(data.get("failures", 0)),
+        "warnings": int(data.get("warnings", 0)),
+        "finished_at": data.get("finished_at", ""),
+        "release": "",
+        "containers": "",
+        "url": f"http://{peer_host}:8083/status",
+    }
+    for r in data.get("records", []):
+        msg = r.get("msg", "")
+        sec = r.get("section", "")
+        if not summary["release"] and sec == "System" and msg.startswith("Release "):
+            summary["release"] = msg
+        elif (
+            not summary["containers"]
+            and sec == "Compose"
+            and "running" in msg
+            and "healthy" in msg
+        ):
+            summary["containers"] = msg
+    return summary
+
+
+async def _build_fleet_view(own_hostname: str) -> list[dict]:
+    """Discover peers + fetch summaries in parallel; cached by _FLEET_CACHE_TTL_SECONDS."""
+    import asyncio
+
+    now = time.time()
+    cached = _fleet_cache.get("data")
+    if cached is not None and (now - cached[0]) < _FLEET_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    peers = await _discover_snapmulti_peers(own_hostname)
+    if not peers:
+        _fleet_cache["data"] = (now, [])
+        return []
+
+    results = await asyncio.gather(
+        *(_fetch_peer_status_summary(p["hostname"]) for p in peers),
+        return_exceptions=True,
+    )
+    summaries: list[dict] = [r for r in results if isinstance(r, dict)]
+    summaries.sort(key=lambda s: s.get("hostname", "").lower())
+    _fleet_cache["data"] = (now, summaries)
+    return summaries
+
+
 # Beginner-friendly grace period: when the snapshot file is older than this
 # much after host boot, we still trust it; when it's MISSING entirely AND
 # the container itself was started recently, we render "starting up" instead
@@ -2375,7 +2508,40 @@ def _structured_systemd_row(section: str, msg: str) -> tuple[str, str, str, str]
     return None
 
 
-def _status_to_html(data: dict | None, age_s: float | None) -> str:
+def _render_fleet_section(fleet_data: list[dict]) -> str:
+    """Render the Fleet observation section (#549) as a <section> block."""
+    import html as _html
+
+    if not fleet_data:
+        return (
+            "<section><h2>Fleet</h2><ul>"
+            '<li class="r-info"><span class="icon">ℹ</span>'
+            "No peer snapMULTI servers discovered on the LAN via mDNS</li>"
+            "</ul></section>"
+        )
+    rows: list[str] = []
+    for peer in fleet_data:
+        status = peer.get("status", "?")
+        icon_class = {"ok": "pass", "warn": "warn", "fail": "fail"}.get(status, "info")
+        icon = {"pass": "✓", "warn": "⚠", "fail": "✗"}.get(icon_class, "ℹ")
+        hostname = _html.escape(str(peer.get("hostname", "?")))
+        url = _html.escape(str(peer.get("url", "")))
+        mode = _html.escape(str(peer.get("mode", "?")))
+        release = _html.escape(str(peer.get("release") or "release unknown"))
+        containers = _html.escape(str(peer.get("containers") or "container status n/a"))
+        rows.append(
+            f'<li class="r-{icon_class}"><span class="icon">{icon}</span>'
+            f'<a href="{url}">{hostname}</a> — {mode} mode · '
+            f"{release} · {containers}</li>"
+        )
+    return f"<section><h2>Fleet ({len(fleet_data)} peer(s))</h2><ul>{''.join(rows)}</ul></section>"
+
+
+def _status_to_html(
+    data: dict | None,
+    age_s: float | None,
+    fleet_data: list[dict] | None = None,
+) -> str:
     """Render the snapshot to a beginner-friendly HTML page.
 
     All content is escaped via html.escape — message text from device-smoke
@@ -2503,6 +2669,10 @@ def _status_to_html(data: dict | None, age_s: float | None) -> str:
             f"<section><h2>{html.escape(sec_name)}</h2><ul>{''.join(rows)}</ul></section>"
         )
 
+    # Fleet observation (#549) — appended only when ?fleet=1 is requested.
+    if fleet_data is not None:
+        sec_html_parts.append(_render_fleet_section(fleet_data))
+
     if age_s is not None:
         if age_s < 60:
             age_label = f"{int(age_s)}s ago"
@@ -2525,11 +2695,20 @@ def _status_to_html(data: dict | None, age_s: float | None) -> str:
     else:
         footer = ""
 
+    # Fleet button (#549): visible on the local view; suppressed when the
+    # caller is already viewing fleet (avoids the redundant self-link).
+    fleet_link = ""
+    if fleet_data is None:
+        fleet_link = (
+            ' · <a href="?fleet=1" style="color:inherit;text-decoration:underline">'
+            "View fleet</a>"
+        )
+
     return _render_html_shell(
         verdict_class=verdict_class,
         verdict_icon=verdict_icon,
         verdict_text=verdict_text,
-        subtext=schema_banner + subtext,
+        subtext=schema_banner + subtext + fleet_link,
         sections_html="".join(sec_html_parts),
         footer=footer,
         embedded_json=json.dumps(data).replace("</", "<\\/"),
@@ -2695,6 +2874,17 @@ async def handle_status(request: web.Request) -> web.Response:
     """
     data, age_s = _read_status_snapshot()
     fmt = request.query.get("format", "")
+    scope = request.query.get("scope", "")
+    fleet_flag = request.query.get("fleet", "") == "1"
+
+    if fmt == "json" and scope == "fleet":
+        own_host = (data or {}).get("hostname") or socket.gethostname()
+        fleet = await _build_fleet_view(own_host)
+        return web.json_response(
+            {"schema_version": 1, "self_hostname": own_host, "peers": fleet},
+            headers={"Cache-Control": "no-store"},
+        )
+
     if fmt == "json":
         if data is None:
             return web.json_response(
@@ -2706,7 +2896,12 @@ async def handle_status(request: web.Request) -> web.Response:
             data,
             headers={"Cache-Control": "no-store"},
         )
-    body = _status_to_html(data, age_s)
+
+    fleet_data: list[dict] | None = None
+    if fleet_flag:
+        own_host = (data or {}).get("hostname") or socket.gethostname()
+        fleet_data = await _build_fleet_view(own_host)
+    body = _status_to_html(data, age_s, fleet_data=fleet_data)
     return web.Response(
         text=body,
         content_type="text/html",

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -34,6 +34,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+import aiohttp
 import websockets
 from aiohttp import web
 
@@ -2266,8 +2267,6 @@ async def _discover_snapmulti_peers(
 ) -> list[dict]:
     # Spawns avahi-browse via create_subprocess_exec (list-args, NO shell —
     # args are fixed string literals; not vulnerable to command injection).
-    import asyncio
-
     try:
         proc = await asyncio.create_subprocess_exec(
             "avahi-browse",
@@ -2295,8 +2294,6 @@ async def _fetch_peer_status_summary(
     peer_host: str, timeout_s: float = 5.0
 ) -> dict | None:
     """Fetch peer /status?format=json and extract a per-peer summary; None on any error."""
-    import aiohttp
-
     url = f"http://{peer_host}:8083/status?format=json"
     try:
         async with aiohttp.ClientSession() as session:
@@ -2306,7 +2303,8 @@ async def _fetch_peer_status_summary(
                 if resp.status != 200:
                     return None
                 data = await resp.json()
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 — broad on purpose: any error drops the peer; debug log preserves diagnostics.
+        logger.debug("fleet: fetch %s failed: %s", peer_host, exc)
         return None
 
     summary: dict = {
@@ -2337,8 +2335,6 @@ async def _fetch_peer_status_summary(
 
 async def _build_fleet_view(own_hostname: str) -> list[dict]:
     """Discover peers + fetch summaries in parallel; cached by _FLEET_CACHE_TTL_SECONDS."""
-    import asyncio
-
     now = time.time()
     cached = _fleet_cache.get("data")
     if cached is not None and (now - cached[0]) < _FLEET_CACHE_TTL_SECONDS:
@@ -2525,13 +2521,22 @@ def _render_fleet_section(fleet_data: list[dict]) -> str:
         icon_class = {"ok": "pass", "warn": "warn", "fail": "fail"}.get(status, "info")
         icon = {"pass": "✓", "warn": "⚠", "fail": "✗"}.get(icon_class, "ℹ")
         hostname = _html.escape(str(peer.get("hostname", "?")))
-        url = _html.escape(str(peer.get("url", "")))
+        # Scheme allow-list defends against a malicious LAN peer supplying
+        # `javascript:` or `data:` in a future field. html.escape converts
+        # quotes but does not block executable URL schemes.
+        raw_url = str(peer.get("url", ""))
+        url = (
+            _html.escape(raw_url)
+            if raw_url.lower().startswith(("http://", "https://"))
+            else ""
+        )
         mode = _html.escape(str(peer.get("mode", "?")))
         release = _html.escape(str(peer.get("release") or "release unknown"))
         containers = _html.escape(str(peer.get("containers") or "container status n/a"))
+        link = f'<a href="{url}">{hostname}</a>' if url else hostname
         rows.append(
             f'<li class="r-{icon_class}"><span class="icon">{icon}</span>'
-            f'<a href="{url}">{hostname}</a> — {mode} mode · '
+            f"{link} — {mode} mode · "
             f"{release} · {containers}</li>"
         )
     return f"<section><h2>Fleet ({len(fleet_data)} peer(s))</h2><ul>{''.join(rows)}</ul></section>"

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2506,8 +2506,6 @@ def _structured_systemd_row(section: str, msg: str) -> tuple[str, str, str, str]
 
 def _render_fleet_section(fleet_data: list[dict]) -> str:
     """Render the Fleet observation section (#549) as a <section> block."""
-    import html as _html
-
     if not fleet_data:
         return (
             "<section><h2>Fleet</h2><ul>"
@@ -2520,19 +2518,19 @@ def _render_fleet_section(fleet_data: list[dict]) -> str:
         status = peer.get("status", "?")
         icon_class = {"ok": "pass", "warn": "warn", "fail": "fail"}.get(status, "info")
         icon = {"pass": "✓", "warn": "⚠", "fail": "✗"}.get(icon_class, "ℹ")
-        hostname = _html.escape(str(peer.get("hostname", "?")))
+        hostname = html.escape(str(peer.get("hostname", "?")))
         # Scheme allow-list defends against a malicious LAN peer supplying
         # `javascript:` or `data:` in a future field. html.escape converts
         # quotes but does not block executable URL schemes.
         raw_url = str(peer.get("url", ""))
         url = (
-            _html.escape(raw_url)
+            html.escape(raw_url)
             if raw_url.lower().startswith(("http://", "https://"))
             else ""
         )
-        mode = _html.escape(str(peer.get("mode", "?")))
-        release = _html.escape(str(peer.get("release") or "release unknown"))
-        containers = _html.escape(str(peer.get("containers") or "container status n/a"))
+        mode = html.escape(str(peer.get("mode", "?")))
+        release = html.escape(str(peer.get("release") or "release unknown"))
+        containers = html.escape(str(peer.get("containers") or "container status n/a"))
         link = f'<a href="{url}">{hostname}</a>' if url else hostname
         rows.append(
             f'<li class="r-{icon_class}"><span class="icon">{icon}</span>'

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2232,6 +2232,13 @@ STATUS_JSON_PATH = "/audio/system-status.json"
 # cache and only every other refresh does live discovery.
 _FLEET_CACHE_TTL_SECONDS = 120
 _fleet_cache: dict[str, tuple[float, list[dict]]] = {}
+_fleet_build_lock = asyncio.Lock()
+# RFC 1123 hostnames are [a-zA-Z0-9.-]; `_` is non-standard but common; reject
+# everything else. Defends against SSRF when a malicious LAN device publishes
+# a Snapcast mDNS SRV record like `evil.com@attacker.com` — that interpolated
+# into f"http://{host}:8083/..." would tunnel via RFC 3986 user-info syntax
+# and aiohttp would connect to attacker.com:8083, not the LAN peer.
+_SAFE_HOST_RE = re.compile(r"^[a-zA-Z0-9._-]{1,253}$")
 
 
 def _normalize_mdns_host(name: str) -> str:
@@ -2285,6 +2292,13 @@ async def _discover_snapmulti_peers(
         except ProcessLookupError:
             pass
         return []
+    if proc.returncode != 0:
+        # avahi-daemon down / D-Bus socket missing → empty result is misleading.
+        logger.warning(
+            "fleet: avahi-browse exited %d — is avahi-daemon running on host?",
+            proc.returncode,
+        )
+        return []
     return _parse_avahi_browse_peers(
         stdout.decode("utf-8", errors="ignore"), own_hostname
     )
@@ -2294,6 +2308,11 @@ async def _fetch_peer_status_summary(
     peer_host: str, timeout_s: float = 5.0
 ) -> dict | None:
     """Fetch peer /status?format=json and extract a per-peer summary; None on any error."""
+    # SSRF defence: reject anything beyond RFC 1123 hostname chars before
+    # interpolating into a URL. See _SAFE_HOST_RE for the attack scenario.
+    if not _SAFE_HOST_RE.match(peer_host):
+        logger.warning("fleet: rejecting unsafe peer hostname %r", peer_host)
+        return None
     url = f"http://{peer_host}:8083/status?format=json"
     try:
         async with aiohttp.ClientSession() as session:
@@ -2340,19 +2359,29 @@ async def _build_fleet_view(own_hostname: str) -> list[dict]:
     if cached is not None and (now - cached[0]) < _FLEET_CACHE_TTL_SECONDS:
         return cached[1]
 
-    peers = await _discover_snapmulti_peers(own_hostname)
-    if not peers:
-        _fleet_cache["data"] = (now, [])
-        return []
+    # Serialise cold-cache builds: a second concurrent request arriving during
+    # the 5-8 s discovery window would otherwise spawn a duplicate avahi-browse
+    # + N parallel peer fetches. The lock holds for the build; the second
+    # waiter re-checks the cache after acquiring and returns the just-published
+    # result without re-doing the work.
+    async with _fleet_build_lock:
+        cached = _fleet_cache.get("data")
+        if cached is not None and (time.time() - cached[0]) < _FLEET_CACHE_TTL_SECONDS:
+            return cached[1]
 
-    results = await asyncio.gather(
-        *(_fetch_peer_status_summary(p["hostname"]) for p in peers),
-        return_exceptions=True,
-    )
-    summaries: list[dict] = [r for r in results if isinstance(r, dict)]
-    summaries.sort(key=lambda s: s.get("hostname", "").lower())
-    _fleet_cache["data"] = (now, summaries)
-    return summaries
+        peers = await _discover_snapmulti_peers(own_hostname)
+        if not peers:
+            _fleet_cache["data"] = (time.time(), [])
+            return []
+
+        results = await asyncio.gather(
+            *(_fetch_peer_status_summary(p["hostname"]) for p in peers),
+            return_exceptions=True,
+        )
+        summaries: list[dict] = [r for r in results if isinstance(r, dict)]
+        summaries.sort(key=lambda s: s.get("hostname", "").lower())
+        _fleet_cache["data"] = (time.time(), summaries)
+        return summaries
 
 
 # Beginner-friendly grace period: when the snapshot file is older than this

--- a/tests/test_install_tty_fb_overlap.sh
+++ b/tests/test_install_tty_fb_overlap.sh
@@ -122,7 +122,11 @@ assert 'echo "$quiet_block" | grep -qE "\\[\\[ -c /dev/fb0 \\]\\]"' \
        'quiet boot block gated on /dev/fb0 presence'
 
 for flag in quiet loglevel=3 systemd.show_status=false vt.global_cursor_default=0 logo.nologo; do
-    if echo "$quiet_block" | grep -qF "$flag"; then
+    # here-string avoids `echo | grep -q` SIGPIPE race under `set -o pipefail`:
+    # grep -q exits at first match → echo gets SIGPIPE → pipefail propagates
+    # non-zero → false FAIL even when the flag is present. Flaky on CI when
+    # the block fits the pipe buffer in some runs but not others.
+    if grep -qF "$flag" <<< "$quiet_block"; then
         echo "  PASS: cmdline flag '$flag' is appended"
         pass=$((pass + 1))
     else

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -318,6 +318,156 @@ class TestFleetHostnameValidation:
         assert metadata_service_module._SAFE_HOST_RE.match(host) is None
 
 
+class TestFleetFetchPeerStatusSummary:
+    """`_fetch_peer_status_summary` must reject unsafe hostnames BEFORE the URL is built."""
+
+    def test_ssrf_reject_does_not_call_aiohttp(
+        self, metadata_service_module, monkeypatch
+    ):
+        # If the SSRF check is bypassed, aiohttp.ClientSession() will be
+        # called and we'll see a sentinel exception. This pins the security
+        # gate so future refactors can't accidentally re-introduce the bug.
+        called = {"value": False}
+
+        class _BoomSession:
+            def __init__(self, *a, **kw):
+                called["value"] = True
+                raise RuntimeError("aiohttp must not be called for unsafe hosts")
+
+        monkeypatch.setattr(
+            metadata_service_module.aiohttp,
+            "ClientSession",
+            _BoomSession,
+            raising=False,
+        )
+        import asyncio
+
+        for bad in (
+            "evil.com@attacker.com",
+            "host#frag",
+            "host:8888",
+            "host/path",
+            "",
+        ):
+            result = asyncio.run(
+                metadata_service_module._fetch_peer_status_summary(bad)
+            )
+            assert result is None, f"unsafe host {bad!r} should return None"
+        assert called["value"] is False, (
+            "aiohttp.ClientSession must NOT be called for unsafe hostnames"
+        )
+
+
+class TestHandleStatusFleetRouting:
+    """`handle_status()` must wire `?scope=fleet` and `?fleet=1` correctly.
+
+    Without these tests a routing regression (e.g. typo in the query-param
+    name) would silently disable the entire Fleet feature with no CI signal.
+    """
+
+    @staticmethod
+    def _make_request(query: dict[str, str]):
+        return types.SimpleNamespace(query=query)
+
+    def test_json_scope_fleet_returns_peers(self, metadata_service_module, monkeypatch):
+        fake_peers = [{"hostname": "pi-other", "mode": "both", "status": "ok"}]
+
+        async def fake_build(hostname):
+            return fake_peers
+
+        monkeypatch.setattr(metadata_service_module, "_build_fleet_view", fake_build)
+        monkeypatch.setattr(
+            metadata_service_module,
+            "_read_status_snapshot",
+            lambda: ({"hostname": "pi-self"}, 0.0),
+        )
+
+        import asyncio
+
+        request = self._make_request({"format": "json", "scope": "fleet"})
+        resp = asyncio.run(metadata_service_module.handle_status(request))
+        payload = resp.args[0]
+        assert payload["peers"] == fake_peers
+        assert payload["self_hostname"] == "pi-self"
+
+    def test_html_fleet_query_triggers_build(
+        self, metadata_service_module, monkeypatch
+    ):
+        fake_peers = [
+            {"hostname": "pi-x", "status": "ok", "url": "http://pi-x:8083/status"}
+        ]
+        builds = {"count": 0}
+
+        async def fake_build(hostname):
+            builds["count"] += 1
+            return fake_peers
+
+        monkeypatch.setattr(metadata_service_module, "_build_fleet_view", fake_build)
+        monkeypatch.setattr(
+            metadata_service_module,
+            "_read_status_snapshot",
+            lambda: (
+                {
+                    "schema_version": 1,
+                    "status": "ok",
+                    "hostname": "pi-self",
+                    "mode": "both",
+                    "failures": 0,
+                    "warnings": 0,
+                    "records": [],
+                },
+                0.0,
+            ),
+        )
+
+        import asyncio
+
+        request = self._make_request({"fleet": "1"})
+        resp = asyncio.run(metadata_service_module.handle_status(request))
+        assert builds["count"] == 1, (
+            "handle_status must call _build_fleet_view when ?fleet=1"
+        )
+        # HTML response — text contains Fleet section.
+        body = resp.kwargs.get("text") or (resp.args[0] if resp.args else "")
+        assert "Fleet" in body
+        assert "pi-x" in body
+
+    def test_html_default_does_not_trigger_fleet_build(
+        self, metadata_service_module, monkeypatch
+    ):
+        builds = {"count": 0}
+
+        async def fake_build(hostname):
+            builds["count"] += 1
+            return []
+
+        monkeypatch.setattr(metadata_service_module, "_build_fleet_view", fake_build)
+        monkeypatch.setattr(
+            metadata_service_module,
+            "_read_status_snapshot",
+            lambda: (
+                {
+                    "schema_version": 1,
+                    "status": "ok",
+                    "hostname": "pi-self",
+                    "mode": "both",
+                    "failures": 0,
+                    "warnings": 0,
+                    "records": [],
+                },
+                0.0,
+            ),
+        )
+
+        import asyncio
+
+        request = self._make_request({})
+        asyncio.run(metadata_service_module.handle_status(request))
+        assert builds["count"] == 0, (
+            "default /status must NOT call _build_fleet_view (perf regression)"
+        )
+
+
 class TestFleetRenderHtml:
     """`_render_fleet_section()` is a pure renderer — no I/O."""
 

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -338,7 +338,6 @@ class TestFleetRenderHtml:
         assert "&lt;script&gt;" in html
         # Scheme allow-list: javascript: must NOT be rendered as href.
         assert 'href="javascript:' not in html
-        assert 'href="javascript:' not in html
 
     def test_non_http_url_renders_hostname_without_link(self, metadata_service_module):
         # data:, file:, javascript: all must drop the <a> wrapper entirely.

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -290,6 +290,34 @@ class TestFleetParseAvahi:
         assert metadata_service_module._parse_avahi_browse_peers("", "pi-server") == []
 
 
+class TestFleetHostnameValidation:
+    """`_SAFE_HOST_RE` is the SSRF gate before URL interpolation."""
+
+    @pytest.mark.parametrize(
+        "host",
+        ["pi-server", "pi-server.local", "rpi3.lan", "device_1", "Server-42.local"],
+    )
+    def test_accepts_rfc1123_like(self, metadata_service_module, host):
+        assert metadata_service_module._SAFE_HOST_RE.match(host) is not None
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "evil.com@attacker.com",  # RFC 3986 user-info hijack
+            "host#fragment",  # URL fragment truncates port
+            "host:8888",  # explicit port override
+            "host/path",  # path injection
+            "host?query=1",  # query injection
+            "host with space",
+            "127.0.0.1%00.evil.com",  # null-byte attempt
+            "",  # empty rejected
+            "a" * 254,  # > 253 chars rejected
+        ],
+    )
+    def test_rejects_malicious(self, metadata_service_module, host):
+        assert metadata_service_module._SAFE_HOST_RE.match(host) is None
+
+
 class TestFleetRenderHtml:
     """`_render_fleet_section()` is a pure renderer — no I/O."""
 

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -240,6 +240,104 @@ class TestUpdateAvailableSemverComparison:
         assert self._is_update(metadata_service_module, "0.7.9.99", "0.7.10.0") is True
 
 
+class TestFleetParseAvahi:
+    """`_parse_avahi_browse_peers()` extracts peer dicts from avahi-browse -rpt."""
+
+    @staticmethod
+    def _sample(own: str = "pi-server") -> str:
+        return (
+            "=;wlan0;IPv4;snapMULTI;_snapcast._tcp;local;pi-server.local;192.168.1.10;1704;\n"
+            "=;wlan0;IPv4;snapMULTI;_snapcast._tcp;local;pi-other.local;192.168.1.11;1704;\n"
+            "=;wlan0;IPv6;snapMULTI;_snapcast._tcp;local;pi-other.local;fe80::1;1704;\n"
+            "+;wlan0;IPv4;snapMULTI;_snapcast._tcp;local\n"
+            "=;wlan0;IPv4;snapMULTI;_snapcast._tcp;local;pi-third.local;192.168.1.12;1704;\n"
+        )
+
+    def test_excludes_self(self, metadata_service_module):
+        peers = metadata_service_module._parse_avahi_browse_peers(
+            self._sample(), "pi-server"
+        )
+        names = [p["hostname"] for p in peers]
+        assert "pi-server.local" not in names
+        assert "pi-other.local" in names
+        assert "pi-third.local" in names
+
+    def test_dedups_same_host_across_families(self, metadata_service_module):
+        peers = metadata_service_module._parse_avahi_browse_peers(
+            self._sample(), "pi-server"
+        )
+        assert sum(p["hostname"] == "pi-other.local" for p in peers) == 1
+
+    def test_self_match_strips_local_and_dots(self, metadata_service_module):
+        # Own hostname can arrive as "pi-server", "pi-server.local", "pi-server."
+        for own in ("pi-server", "pi-server.local", "pi-server.local."):
+            peers = metadata_service_module._parse_avahi_browse_peers(
+                self._sample(), own
+            )
+            assert all("pi-server" not in p["hostname"].lower() for p in peers)
+
+    def test_skips_ptr_only_lines(self, metadata_service_module):
+        # `+;…` are PTR-only, no SRV+TXT data — must be ignored.
+        peers = metadata_service_module._parse_avahi_browse_peers(
+            self._sample(), "pi-server"
+        )
+        # Only `=;` lines yield peers — the `+;` line in the sample has no port/addr.
+        for p in peers:
+            assert p["addr"]
+            assert p["port"]
+
+    def test_empty_output_no_peers(self, metadata_service_module):
+        assert metadata_service_module._parse_avahi_browse_peers("", "pi-server") == []
+
+
+class TestFleetRenderHtml:
+    """`_render_fleet_section()` is a pure renderer — no I/O."""
+
+    def test_no_peers_message(self, metadata_service_module):
+        html = metadata_service_module._render_fleet_section([])
+        assert "No peer snapMULTI servers discovered" in html
+        assert "<h2>Fleet</h2>" in html
+
+    def test_one_peer_renders_link_and_summary(self, metadata_service_module):
+        html = metadata_service_module._render_fleet_section(
+            [
+                {
+                    "hostname": "pi-other",
+                    "mode": "both",
+                    "status": "ok",
+                    "release": "Release v0.7.9.5 (images 0.7.7)",
+                    "containers": "server: 7/7 running, 7/7 healthy",
+                    "url": "http://pi-other.local:8083/status",
+                }
+            ]
+        )
+        assert "Fleet (1 peer(s))" in html
+        assert 'href="http://pi-other.local:8083/status"' in html
+        assert "pi-other" in html
+        assert "Release v0.7.9.5" in html
+        assert "7/7 healthy" in html
+        assert 'class="r-pass"' in html
+
+    def test_fail_peer_uses_fail_class(self, metadata_service_module):
+        html = metadata_service_module._render_fleet_section(
+            [{"hostname": "pi-broken", "status": "fail", "url": "http://x"}]
+        )
+        assert 'class="r-fail"' in html
+
+    def test_html_escapes_peer_fields(self, metadata_service_module):
+        html = metadata_service_module._render_fleet_section(
+            [
+                {
+                    "hostname": "<script>alert(1)</script>",
+                    "status": "ok",
+                    "url": 'javascript:alert("xss")',
+                }
+            ]
+        )
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+
 class TestResolveExternalHost:
     """`_resolve_external_host()` picks a usable EXTERNAL_HOST per #460."""
 

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -336,6 +336,18 @@ class TestFleetRenderHtml:
         )
         assert "<script>alert(1)</script>" not in html
         assert "&lt;script&gt;" in html
+        # Scheme allow-list: javascript: must NOT be rendered as href.
+        assert 'href="javascript:' not in html
+        assert 'href="javascript:' not in html
+
+    def test_non_http_url_renders_hostname_without_link(self, metadata_service_module):
+        # data:, file:, javascript: all must drop the <a> wrapper entirely.
+        for bad in ("javascript:alert(1)", "data:text/html,<x>", "file:///etc/passwd"):
+            html = metadata_service_module._render_fleet_section(
+                [{"hostname": "pi-evil", "status": "ok", "url": bad}]
+            )
+            assert "<a" not in html, f"bad URL {bad!r} rendered as link"
+            assert "pi-evil" in html  # hostname still shown
 
 
 class TestResolveExternalHost:


### PR DESCRIPTION
Closes the observation half of #162.

## What

Opt-in Fleet view on the existing `/status` page.

| Endpoint | Behavior |
|---|---|
| `/status` (HTML, no flag) | Unchanged — local instance view + small "View fleet" link in subtext |
| `/status?fleet=1` (HTML) | Same as above PLUS a Fleet section listing each peer (hostname, mode, release, container health, status icon, link to peer's `/status`) |
| `/status?format=json&scope=fleet` | Returns `{schema_version: 1, self_hostname: "…", peers: [{…}, …]}` |

## How

1. `_discover_snapmulti_peers()` — `avahi-browse -rpt _snapcast._tcp` via `asyncio.create_subprocess_exec` (list args, no shell — safe). Reuses the existing Snapcast mDNS publication; no new mDNS service type introduced.
2. `_parse_avahi_browse_peers()` — pure function that takes stdout text + own hostname, returns peer list. Filters self, dedups across IPv4/IPv6 families, skips PTR-only `+;` lines.
3. `_normalize_mdns_host()` — form-independent comparison so `pi-server`, `pi-server.local`, `pi-server.local.` all match the same host.
4. `_fetch_peer_status_summary()` — aiohttp GET on `http://<peer>:8083/status?format=json` with 5 s timeout. Extracts release banner + container health summary. Returns `None` on any error — the peer is silently dropped from the aggregated view rather than degrading the parent page.
5. `_build_fleet_view()` — orchestrates discovery + parallel fetch, with TTL=120 s cache. The HTML page auto-refreshes every 60 s; 120 s cache means most refreshes hit cache and only every other refresh does live discovery (5-8 s cold).
6. `_render_fleet_section()` — pure renderer. **All peer fields html.escaped** to defend against XSS from a malicious LAN peer (attacker-controllable hostname).

## Scope (explicit)

Closes the **observation** half of #162. Per CLAUDE.md non-goals:

| #162 ask | This PR | Why not |
|---|---|---|
| Discovery of all snapMULTI servers on the LAN | ✅ | avahi-browse |
| Per-instance health / playing / clients | ✅ | `/status?format=json` fetch |
| Cross-instance control (play same source on all) | ❌ | "Unified UI replacing snapweb + myMPD + metadata-service" non-goal |
| Unified configuration management | ❌ | No writable remote config layer; reflash-first model |
| Cross-site / multi-LAN | ❌ | "snapMULTI is per-LAN" non-goal |

## Tests (16 new, 42 total)

- `TestFleetParseAvahi` — 5 cases (excludes self, dedups across families, self-match strips `.local`/trailing dot, skips `+;` PTR-only lines, empty input).
- `TestFleetRenderHtml` — 4 cases (no-peer message, single peer renders link + summary, fail status maps to fail class, html.escape defends against `<script>` injection in hostname).
- All 32 pre-existing metadata-service tests still pass.

## Validation

- Done locally: `uv run pytest tests/test_metadata_service.py` → 42 passed; `uv run ruff check` + `format --check` clean.
- Deferred to release-gate: reflash snapvideo + flash a second device, expect:
  - `http://snapvideo:8083/status` shows "View fleet" link
  - `http://snapvideo:8083/status?fleet=1` shows peer (hostname, healthy summary)
  - `http://snapvideo:8083/status?format=json&scope=fleet` returns peers JSON
  - First request cold-cache: ~5-8 s; subsequent requests within 120 s: instant