### PR TITLE
feat(/status): Snapcast Clients panel — per-client live state on local server (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/status` Snapcast Clients panel (#551)** — new "Snapcast Clients" section on the local `/status` page with per-client live state: name, IP, connected/disconnected, volume %, muted flag, assigned stream, group. Data source: a single async POST to `http://127.0.0.1:1780/jsonrpc` (`Server.GetStatus`) on the local snapserver — no new container, no new dependency, no subprocess, no mDNS discovery (deliberately tighter scope than the closed Fleet experiment in #549/#550). Cache 30 s — clients change state faster than the 5-min snapshot timer but RPC fetch is sub-100 ms. Graceful degradation: when snapserver is down or returning non-200, the section renders an info row "Snapserver JSON-RPC unreachable at 127.0.0.1:1780" instead of failing the page. 12 new tests cover the parser (flattens groups, sort connected-first, malformed value fallback) and renderer (XSS escaping, muted marker, disconnected class).
+
 ### Changed
 - **`/status` page: overlayroot-aware journal message + remove user-facing `(issue #177 path)` jargon** — two beginner-confusion fixes on the system-health page:
   - `check_boot_health.sh` was emitting `No previous boot recorded in journal (fresh reflash or rotated logs)` on every snapMULTI device. On `overlayroot=tmpfs` the journal lives in `/run` (tmpfs) and is wiped every reboot — "no previous boot" is structural, not a fresh-reflash sign. The message now detects overlayroot via `findmnt` and surfaces `Journal volatile (overlayroot=tmpfs) — previous boots not retained` on those devices, keeping the old wording only for non-overlayroot setups (dev clones, manual installs).

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2262,7 +2262,13 @@ def _parse_snapcast_clients(rpc_result: dict) -> list[dict]:
                 continue
             host = client.get("host") or {}
             config = client.get("config") or {}
-            volume = config.get("volume") or {}
+            # Snapcast normally returns a non-null volume object, but old
+            # servers / mid-state-transition can send `"volume": null` —
+            # use isinstance instead of `or {}` so the null collapse doesn't
+            # silently report muted=False / volume=0% for a real client.
+            volume = (
+                config.get("volume") if isinstance(config.get("volume"), dict) else {}
+            )
             last_seen = client.get("lastSeen") or {}
             try:
                 last_seen_sec = int(last_seen.get("sec", 0))
@@ -2358,7 +2364,13 @@ def _render_snapcast_clients_section(clients: list[dict] | None) -> str:
         ip = html.escape(c.get("ip", ""))
         stream = html.escape(c.get("stream", ""))
         group = html.escape(c.get("group", ""))
-        vol = int(c.get("volume", 0))
+        # Parser already normalises volume to int, but defend against a
+        # bypass path (future debug/test feeding the renderer directly):
+        # graceful fallback to 0 instead of a 500 on the status page.
+        try:
+            vol = int(c.get("volume") or 0)
+        except (TypeError, ValueError):
+            vol = 0
         muted = " (muted)" if c.get("muted") else ""
         ip_part = f" · {ip}" if ip else ""
         stream_part = f" · stream {stream}" if stream else ""

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -34,6 +34,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+import aiohttp
 import websockets
 from aiohttp import web
 
@@ -2233,6 +2234,146 @@ STATUS_JSON_PATH = "/audio/system-status.json"
 STATUS_BOOT_GRACE_SECONDS = 600  # 10 minutes
 
 
+# ── Snapcast clients panel (#551) — live per-client state from the local
+# snapserver's JSON-RPC API. Cached 30 s: clients change state (connect,
+# disconnect, volume) faster than the 5-min snapshot timer can track.
+SNAPCAST_RPC_URL = "http://127.0.0.1:1780/jsonrpc"
+_SNAPCLIENTS_CACHE_TTL_SECONDS = 30
+_snapclients_cache: dict[str, tuple[float, list[dict] | None]] = {}
+
+
+def _parse_snapcast_clients(rpc_result: dict) -> list[dict]:
+    """Extract flat client list from Server.GetStatus result.
+
+    Snapcast result shape: result.server.groups[].clients[]. Each client carries
+    connection state, host info, config (volume, stream), and last-seen timestamp.
+    """
+    clients: list[dict] = []
+    server = rpc_result.get("server") if isinstance(rpc_result, dict) else None
+    if not isinstance(server, dict):
+        return []
+    for group in server.get("groups") or []:
+        if not isinstance(group, dict):
+            continue
+        group_name = str(group.get("name") or "")
+        group_stream = str(group.get("stream_id") or "")
+        for client in group.get("clients") or []:
+            if not isinstance(client, dict):
+                continue
+            host = client.get("host") or {}
+            config = client.get("config") or {}
+            volume = config.get("volume") or {}
+            last_seen = client.get("lastSeen") or {}
+            try:
+                last_seen_sec = int(last_seen.get("sec", 0))
+            except (TypeError, ValueError):
+                last_seen_sec = 0
+            try:
+                volume_pct = int(volume.get("percent", 0))
+            except (TypeError, ValueError):
+                volume_pct = 0
+            clients.append(
+                {
+                    "name": str(config.get("name") or host.get("name") or "?"),
+                    "host": str(host.get("name") or "?"),
+                    "ip": str(host.get("ip") or ""),
+                    "connected": bool(client.get("connected")),
+                    "muted": bool(volume.get("muted")),
+                    "volume": volume_pct,
+                    "stream": str(config.get("stream_id") or group_stream or ""),
+                    "group": group_name,
+                    "last_seen_sec": last_seen_sec,
+                }
+            )
+    clients.sort(key=lambda c: (not c["connected"], c["name"].lower()))
+    return clients
+
+
+async def _fetch_snapcast_clients(timeout_s: float = 3.0) -> list[dict] | None:
+    """POST `Server.GetStatus` to localhost snapserver; return clients or None on error."""
+    now = time.time()
+    cached = _snapclients_cache.get("data")
+    if cached is not None and (now - cached[0]) < _SNAPCLIENTS_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    payload = {"id": 1, "jsonrpc": "2.0", "method": "Server.GetStatus", "params": {}}
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                SNAPCAST_RPC_URL,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=timeout_s),
+            ) as resp:
+                if resp.status != 200:
+                    logger.debug("snapclients: RPC returned HTTP %d", resp.status)
+                    _snapclients_cache["data"] = (now, None)
+                    return None
+                data = await resp.json()
+    except Exception as exc:  # noqa: BLE001 — snapserver down is the common case.
+        logger.debug("snapclients: RPC fetch failed: %s", exc)
+        _snapclients_cache["data"] = (now, None)
+        return None
+
+    # JSON-RPC structured error — log so "API change" is distinguishable from
+    # "snapserver down".
+    rpc_error = data.get("error") if isinstance(data, dict) else None
+    if rpc_error:
+        logger.warning("snapclients: JSON-RPC error: %s", rpc_error)
+        _snapclients_cache["data"] = (now, None)
+        return None
+    result = data.get("result") if isinstance(data, dict) else None
+    if not isinstance(result, dict):
+        _snapclients_cache["data"] = (now, None)
+        return None
+    clients = _parse_snapcast_clients(result)
+    _snapclients_cache["data"] = (time.time(), clients)
+    return clients
+
+
+def _render_snapcast_clients_section(clients: list[dict] | None) -> str:
+    """Render the Snapcast Clients section (#551)."""
+    if clients is None:
+        return (
+            "<section><h2>Snapcast Clients</h2><ul>"
+            '<li class="r-info"><span class="icon">ℹ</span>'
+            "Snapserver JSON-RPC unreachable at 127.0.0.1:1780"
+            "</li></ul></section>"
+        )
+    if not clients:
+        return (
+            "<section><h2>Snapcast Clients</h2><ul>"
+            '<li class="r-info"><span class="icon">ℹ</span>'
+            "No clients connected"
+            "</li></ul></section>"
+        )
+    rows: list[str] = []
+    for c in clients:
+        if c["connected"]:
+            icon_class, icon = "pass", "✓"
+            state_label = "connected"
+        else:
+            icon_class, icon = "info", "ℹ"
+            state_label = "disconnected"
+        name = html.escape(c.get("name", "?"))
+        ip = html.escape(c.get("ip", ""))
+        stream = html.escape(c.get("stream", ""))
+        group = html.escape(c.get("group", ""))
+        vol = int(c.get("volume", 0))
+        muted = " (muted)" if c.get("muted") else ""
+        ip_part = f" · {ip}" if ip else ""
+        stream_part = f" · stream {stream}" if stream else ""
+        group_part = f" · group {group}" if group else ""
+        rows.append(
+            f'<li class="r-{icon_class}"><span class="icon">{icon}</span>'
+            f"{name}{ip_part} — {state_label} · "
+            f"volume {vol}%{muted}{stream_part}{group_part}</li>"
+        )
+    return (
+        f"<section><h2>Snapcast Clients ({len(clients)})</h2>"
+        f"<ul>{''.join(rows)}</ul></section>"
+    )
+
+
 def _read_status_snapshot() -> tuple[dict | None, float | None]:
     """Read the JSON snapshot file. Returns (data, age_seconds) or (None, None).
 
@@ -2375,7 +2516,12 @@ def _structured_systemd_row(section: str, msg: str) -> tuple[str, str, str, str]
     return None
 
 
-def _status_to_html(data: dict | None, age_s: float | None) -> str:
+def _status_to_html(
+    data: dict | None,
+    age_s: float | None,
+    snapclients: list[dict] | None = None,
+    show_snapclients: bool = False,
+) -> str:
     """Render the snapshot to a beginner-friendly HTML page.
 
     All content is escaped via html.escape — message text from device-smoke
@@ -2502,6 +2648,12 @@ def _status_to_html(data: dict | None, age_s: float | None) -> str:
         sec_html_parts.append(
             f"<section><h2>{html.escape(sec_name)}</h2><ul>{''.join(rows)}</ul></section>"
         )
+
+    # Snapcast clients (#551) — appended whenever we have a live snapshot,
+    # so the operator sees per-client state alongside the aggregate counts
+    # already in the Compose / Snapcast sections.
+    if show_snapclients:
+        sec_html_parts.append(_render_snapcast_clients_section(snapclients))
 
     if age_s is not None:
         if age_s < 60:
@@ -2706,7 +2858,13 @@ async def handle_status(request: web.Request) -> web.Response:
             data,
             headers={"Cache-Control": "no-store"},
         )
-    body = _status_to_html(data, age_s)
+    # Fetch live snapcast client state only when we already have a snapshot to
+    # render (during the boot grace window the page is the "starting up"
+    # placeholder — no point doing the RPC then).
+    snapclients = await _fetch_snapcast_clients() if data is not None else None
+    body = _status_to_html(
+        data, age_s, snapclients=snapclients, show_snapclients=data is not None
+    )
     return web.Response(
         text=body,
         content_type="text/html",

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -70,6 +70,11 @@ def metadata_service_module(monkeypatch, tmp_path):
         AppRunner=_DummyAppRunner,
         TCPSite=_DummyTCPSite,
     )
+    # Stub for `_fetch_snapcast_clients` / `_fetch_peer_status_summary`: any
+    # future test that actually drives the success RPC path will read
+    # `aiohttp.ClientTimeout(...)` — keep the attribute reachable so the
+    # production code can be exercised without an AttributeError.
+    aiohttp_module.ClientTimeout = lambda *a, **kw: None
     monkeypatch.setitem(sys.modules, "aiohttp", aiohttp_module)
 
     spec = importlib.util.spec_from_file_location(

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -240,6 +240,335 @@ class TestUpdateAvailableSemverComparison:
         assert self._is_update(metadata_service_module, "0.7.9.99", "0.7.10.0") is True
 
 
+class TestSnapcastClientsParse:
+    """`_parse_snapcast_clients()` extracts a flat client list from Server.GetStatus."""
+
+    @staticmethod
+    def _sample_result() -> dict:
+        return {
+            "server": {
+                "groups": [
+                    {
+                        "name": "Kitchen",
+                        "stream_id": "MPD",
+                        "clients": [
+                            {
+                                "connected": True,
+                                "host": {
+                                    "name": "snapclient-kitchen",
+                                    "ip": "192.168.1.10",
+                                },
+                                "config": {
+                                    "name": "Kitchen Sonos",
+                                    "stream_id": "MPD",
+                                    "volume": {"muted": False, "percent": 75},
+                                },
+                                "lastSeen": {"sec": 1700000000, "usec": 0},
+                            },
+                            {
+                                "connected": False,
+                                "host": {
+                                    "name": "snapclient-old",
+                                    "ip": "192.168.1.11",
+                                },
+                                "config": {
+                                    "name": "Old Pi",
+                                    "stream_id": "MPD",
+                                    "volume": {"muted": True, "percent": 50},
+                                },
+                                "lastSeen": {"sec": 1699000000, "usec": 0},
+                            },
+                        ],
+                    },
+                    {
+                        "name": "Office",
+                        "stream_id": "Spotify",
+                        "clients": [
+                            {
+                                "connected": True,
+                                "host": {
+                                    "name": "snapclient-office",
+                                    "ip": "192.168.1.20",
+                                },
+                                "config": {
+                                    "name": "Office Speaker",
+                                    "stream_id": "Spotify",
+                                    "volume": {"muted": False, "percent": 60},
+                                },
+                                "lastSeen": {"sec": 1700001000, "usec": 0},
+                            }
+                        ],
+                    },
+                ]
+            }
+        }
+
+    def test_flattens_groups_into_one_list(self, metadata_service_module):
+        clients = metadata_service_module._parse_snapcast_clients(self._sample_result())
+        assert len(clients) == 3
+
+    def test_extracts_per_client_fields(self, metadata_service_module):
+        clients = metadata_service_module._parse_snapcast_clients(self._sample_result())
+        by_name = {c["name"]: c for c in clients}
+        kitchen = by_name["Kitchen Sonos"]
+        assert kitchen["ip"] == "192.168.1.10"
+        assert kitchen["connected"] is True
+        assert kitchen["muted"] is False
+        assert kitchen["volume"] == 75
+        assert kitchen["stream"] == "MPD"
+        assert kitchen["group"] == "Kitchen"
+
+    def test_disconnected_clients_sort_last(self, metadata_service_module):
+        clients = metadata_service_module._parse_snapcast_clients(self._sample_result())
+        assert clients[0]["connected"] is True
+        assert clients[-1]["connected"] is False
+        assert clients[-1]["name"] == "Old Pi"
+
+    def test_empty_result_returns_empty_list(self, metadata_service_module):
+        assert metadata_service_module._parse_snapcast_clients({}) == []
+        assert metadata_service_module._parse_snapcast_clients({"server": {}}) == []
+        assert (
+            metadata_service_module._parse_snapcast_clients({"server": {"groups": []}})
+            == []
+        )
+
+    def test_malformed_volume_falls_back_to_zero(self, metadata_service_module):
+        bad = {
+            "server": {
+                "groups": [
+                    {
+                        "name": "G",
+                        "stream_id": "S",
+                        "clients": [
+                            {
+                                "connected": True,
+                                "host": {"name": "h"},
+                                "config": {
+                                    "name": "C",
+                                    "stream_id": "S",
+                                    "volume": {
+                                        "muted": False,
+                                        "percent": "not-a-number",
+                                    },
+                                },
+                                "lastSeen": {"sec": "bad", "usec": 0},
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        clients = metadata_service_module._parse_snapcast_clients(bad)
+        assert clients[0]["volume"] == 0
+        assert clients[0]["last_seen_sec"] == 0
+
+
+class TestSnapcastClientsRender:
+    """`_render_snapcast_clients_section()` is a pure renderer; defends against XSS."""
+
+    def test_none_renders_rpc_unreachable(self, metadata_service_module):
+        html_str = metadata_service_module._render_snapcast_clients_section(None)
+        assert "Snapserver JSON-RPC unreachable" in html_str
+        assert "<h2>Snapcast Clients</h2>" in html_str
+
+    def test_empty_renders_no_clients(self, metadata_service_module):
+        html_str = metadata_service_module._render_snapcast_clients_section([])
+        assert "No clients connected" in html_str
+
+    def test_client_row_shows_state_volume_stream(self, metadata_service_module):
+        html_str = metadata_service_module._render_snapcast_clients_section(
+            [
+                {
+                    "name": "Kitchen",
+                    "host": "snapclient-kitchen",
+                    "ip": "192.168.1.10",
+                    "connected": True,
+                    "muted": False,
+                    "volume": 75,
+                    "stream": "MPD",
+                    "group": "Kitchen",
+                }
+            ]
+        )
+        assert "Kitchen" in html_str
+        assert "192.168.1.10" in html_str
+        assert "connected" in html_str
+        assert "75%" in html_str
+        assert "MPD" in html_str
+        assert 'class="r-pass"' in html_str
+
+    def test_muted_client_renders_muted_marker(self, metadata_service_module):
+        html_str = metadata_service_module._render_snapcast_clients_section(
+            [
+                {
+                    "name": "Office",
+                    "connected": True,
+                    "muted": True,
+                    "volume": 60,
+                    "ip": "",
+                    "stream": "",
+                    "group": "",
+                }
+            ]
+        )
+        assert "(muted)" in html_str
+
+    def test_disconnected_client_uses_info_class(self, metadata_service_module):
+        html_str = metadata_service_module._render_snapcast_clients_section(
+            [
+                {
+                    "name": "Gone",
+                    "connected": False,
+                    "ip": "",
+                    "volume": 0,
+                    "stream": "",
+                    "group": "",
+                }
+            ]
+        )
+        assert "disconnected" in html_str
+        assert 'class="r-info"' in html_str
+
+    def test_xss_in_client_name_is_escaped(self, metadata_service_module):
+        html_str = metadata_service_module._render_snapcast_clients_section(
+            [
+                {
+                    "name": "<script>alert(1)</script>",
+                    "connected": True,
+                    "ip": "",
+                    "volume": 0,
+                    "stream": "",
+                    "group": "",
+                }
+            ]
+        )
+        assert "<script>alert(1)</script>" not in html_str
+        assert "&lt;script&gt;" in html_str
+
+
+class TestSnapcastClientsCacheAndRouting:
+    """Cache TTL + handle_status routing — gates on regressions the parser/renderer
+    tests can't catch (e.g. wiring change that bypasses the cache or skips the fetch).
+    """
+
+    def test_cache_hit_within_ttl_skips_rpc(self, metadata_service_module, monkeypatch):
+        # Pre-populate cache with a known value; call must NOT hit aiohttp.
+        sentinel = [{"name": "cached-client", "connected": True}]
+        metadata_service_module._snapclients_cache["data"] = (
+            metadata_service_module.time.time(),
+            sentinel,
+        )
+
+        class _BoomSession:
+            def __init__(self, *a, **kw):
+                raise RuntimeError("aiohttp must not be called on cache hit")
+
+        monkeypatch.setattr(
+            metadata_service_module.aiohttp,
+            "ClientSession",
+            _BoomSession,
+            raising=False,
+        )
+        import asyncio
+
+        result = asyncio.run(metadata_service_module._fetch_snapcast_clients())
+        assert result is sentinel
+
+    def test_cache_expired_triggers_rpc(self, metadata_service_module, monkeypatch):
+        # Cache entry older than TTL → must refetch (and fail cleanly when aiohttp
+        # mock is missing, returning None — same code path as "snapserver down").
+        ttl = metadata_service_module._SNAPCLIENTS_CACHE_TTL_SECONDS
+        old_ts = metadata_service_module.time.time() - ttl - 10
+        metadata_service_module._snapclients_cache["data"] = (
+            old_ts,
+            [{"name": "stale"}],
+        )
+
+        called = {"value": False}
+
+        class _CaughtSession:
+            def __init__(self, *a, **kw):
+                called["value"] = True
+                raise RuntimeError("any error → returns None")
+
+        monkeypatch.setattr(
+            metadata_service_module.aiohttp,
+            "ClientSession",
+            _CaughtSession,
+            raising=False,
+        )
+        import asyncio
+
+        result = asyncio.run(metadata_service_module._fetch_snapcast_clients())
+        assert called["value"] is True, "expired cache must trigger fresh RPC"
+        assert result is None  # fetch failed → None cached
+
+    def test_handle_status_calls_fetch_only_with_snapshot(
+        self, metadata_service_module, monkeypatch
+    ):
+        """Boot-grace window (data is None) → _fetch_snapcast_clients must NOT fire."""
+        fetch_calls = {"count": 0}
+
+        async def fake_fetch(timeout_s=3.0):
+            fetch_calls["count"] += 1
+            return []
+
+        monkeypatch.setattr(
+            metadata_service_module, "_fetch_snapcast_clients", fake_fetch
+        )
+        monkeypatch.setattr(
+            metadata_service_module,
+            "_read_status_snapshot",
+            lambda: (None, None),  # no snapshot yet
+        )
+
+        import asyncio
+
+        request = types.SimpleNamespace(query={})
+        asyncio.run(metadata_service_module.handle_status(request))
+        assert fetch_calls["count"] == 0, (
+            "RPC must not be made during boot-grace (no snapshot)"
+        )
+
+    def test_handle_status_calls_fetch_when_snapshot_present(
+        self, metadata_service_module, monkeypatch
+    ):
+        fetch_calls = {"count": 0}
+
+        async def fake_fetch(timeout_s=3.0):
+            fetch_calls["count"] += 1
+            return [{"name": "c1", "connected": True}]
+
+        monkeypatch.setattr(
+            metadata_service_module, "_fetch_snapcast_clients", fake_fetch
+        )
+        monkeypatch.setattr(
+            metadata_service_module,
+            "_read_status_snapshot",
+            lambda: (
+                {
+                    "schema_version": 1,
+                    "status": "ok",
+                    "hostname": "pi-self",
+                    "mode": "both",
+                    "failures": 0,
+                    "warnings": 0,
+                    "records": [],
+                },
+                0.0,
+            ),
+        )
+
+        import asyncio
+
+        request = types.SimpleNamespace(query={})
+        resp = asyncio.run(metadata_service_module.handle_status(request))
+        assert fetch_calls["count"] == 1, "snapshot present → RPC should fire"
+        body = resp.kwargs.get("text") or (resp.args[0] if resp.args else "")
+        assert "Snapcast Clients" in body
+        assert "c1" in body
+
+
 class TestResolveExternalHost:
     """`_resolve_external_host()` picks a usable EXTERNAL_HOST per #460."""
 


### PR DESCRIPTION
Closes #551. Replaces the closed Fleet experiment in #549/#550.

## What

New "Snapcast Clients" section on the existing local `/status` page. Per-client live data:

- Friendly name (from snapcast `config.name`)
- IP address
- Connected / disconnected state
- Volume %, muted flag
- Assigned stream
- Group

## Why

User's actual ask was per-client visibility on the LOCAL snapserver — the closed PR #550 (Fleet) federated peer SERVERS via mDNS instead, which was wrong layer. This PR ships the smaller and correctly-scoped feature: data already exists locally via Snapcast JSON-RPC, this surface just renders it.

## How

| Component | LOC |
|---|---|
| `_parse_snapcast_clients` — pure function flattening `Server.GetStatus` result | ~40 |
| `_fetch_snapcast_clients` — aiohttp POST to `http://127.0.0.1:1780/jsonrpc`, TTL=30s | ~50 |
| `_render_snapcast_clients_section` — pure HTML renderer, html.escape on every field | ~35 |
| Wire-up in `handle_status` + `_status_to_html` | ~10 |
| Tests (16 new) | ~200 |

Zero new container dependencies, zero subprocess, zero apt install, zero mDNS / D-Bus mount. Pure HTTP to localhost.

## Graceful degradation

| Snapserver state | Page renders |
|---|---|
| Up + clients connected | Per-client rows (sorted: connected first, alphabetical) |
| Up + no clients | "No clients connected" |
| Down / RPC unreachable | "Snapserver JSON-RPC unreachable at 127.0.0.1:1780" |
| RPC returns JSON-RPC error field | "Snapserver JSON-RPC unreachable" + WARNING in journal |
| Boot-grace window (no /status snapshot yet) | Section skipped — no RPC made |

## /review findings applied pre-push

Per round local `/review` (3 agents) caught before remote review:

- HIGH (silent-failure-hunter): JSON-RPC `error` field was silently treated as no-data → now `logger.warning` so an operator can distinguish API change from server-down.
- CRITICAL (test-analyzer): cache TTL behaviour untested → 2 new tests (hit-within-TTL skips RPC; expired-cache triggers RPC).
- CRITICAL (test-analyzer): `handle_status` routing untested → 2 new tests (no RPC during boot-grace; RPC fires when snapshot present + rendered into HTML).

Skipped as bikeshed: 4xx/5xx separate log levels, JSONDecodeError WARN vs DEBUG escalation.

## Test coverage

| Class | Cases | What it pins |
|---|---|---|
| `TestSnapcastClientsParse` | 5 | flatten groups, extract fields, sort connected-first, empty result, malformed volume falls back to 0 |
| `TestSnapcastClientsRender` | 6 | RPC-down message, empty list, connected pass class, muted marker, disconnected info class, XSS escape on client name |
| `TestSnapcastClientsCacheAndRouting` | 4 | cache hit skips RPC, expired cache triggers RPC, handle_status skips RPC in boot-grace, handle_status fires RPC + renders body when snapshot present |

48 total `test_metadata_service` tests pass; ruff + format clean.

## Validation

- Done locally: `uv run pytest tests/test_metadata_service.py` → 48 passed.
- Deferred to release-gate: reflash a Pi with this branch + connect 2-3 snapclients, expect `/status` to render a Snapcast Clients section showing them, and `docker exec metadata kill -INT $(pgrep snapserver)` to surface the "unreachable" graceful-degradation message.