### PR TITLE
feat(install): TUI ETA + realistic docs per measured timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **HARDWARE.md Scenario A refreshed with measurements from current fleet (snapvideo / snapdigi / pizero)** — the 2026-05-13 capture referenced a `pi-server` host and Pi 3 + Pi 4 + Pi Zero client mix that is no longer the active fleet. Re-measured 2026-05-29 on snapvideo (server + loopback display, 3 active sources: MPD + AirPlay + Spotify) fanning out to `snapdigi` (Pi 4 2 GB + 4K HDMI client) and `pizero` (Pi Zero 2 W native client): server now sits at ~34 % CPU / ~895 MiB total / 68.6 °C, available host RAM 6.8 GiB. Topology + numbers mirrored in `HARDWARE.it.md`.
 - **Install TUI shows expected total time + docs updated with realistic per-hardware figures** — the HDMI progress bar now displays `02:15 / ~16 min  [████░░░░]` alongside the running elapsed counter so the operator can tell whether 12 minutes in is "almost done" or "barely halfway". `EXPECTED_TOTAL_MIN` is computed in `firstboot.sh` per `(hardware, INSTALL_TYPE)` bucket using measured install logs (snapvideo Pi 4 8GB both: 16:17, snapdigi Pi 4 2GB client: 10:30, pizero Pi Zero 2W client-native: 18:25; Pi 3 projected at +40%) and `progress.sh` renders the label when the env var is set. README + `docs/INSTALL.md` (+ Italian) updated from the stale "10-15 min" to the realistic "15-20 min on Pi 4/5, longer on Pi 3 / Pi Zero 2W". 9-assertion static test gates the helper, env var, label format.
 
 ## [0.7.9.6] — 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Install TUI shows expected total time + docs updated with realistic per-hardware figures** — the HDMI progress bar now displays `02:15 / ~16 min  [████░░░░]` alongside the running elapsed counter so the operator can tell whether 12 minutes in is "almost done" or "barely halfway". `EXPECTED_TOTAL_MIN` is computed in `firstboot.sh` per `(hardware, INSTALL_TYPE)` bucket using measured install logs (snapvideo Pi 4 8GB both: 16:17, snapdigi Pi 4 2GB client: 10:30, pizero Pi Zero 2W client-native: 18:25; Pi 3 projected at +40%) and `progress.sh` renders the label when the env var is set. README + `docs/INSTALL.md` (+ Italian) updated from the stale "10-15 min" to the realistic "15-20 min on Pi 4/5, longer on Pi 3 / Pi Zero 2W". 9-assertion static test gates the helper, env var, label format.
+
 ## [0.7.9.6] — 2026-05-29
 
 > Script-only patch (image_set stays 0.7.7). Adds the per-client snapclient panel to `/status` (#552), closes the concurrent-remount race on backup scripts (#553), surfaces semver-aware update detection (#546), fixes apt-get kernel kept-back (#545), backup graceful-degrade (#547), `/status` overlayroot-aware journal message (#548). Validated live on snapvideo without reflash for #552 and #553.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If this is your first snapMULTI install, use the boring path: **Raspberry Pi 4 (
 - **Pi Zero 2 W** is supported as a headless Audio Player only; it is not a server or "Server + Player" target.
 - **NAS share paths with spaces** are rejected. Rename `Music Share` to `Music_Share` on the NAS side.
 - **Tidal Connect** uses an upstream proprietary component. It is enabled by default on ARM installs; remove `tidal` from `COMPOSE_PROFILES` in `/opt/snapmulti/.env` if you want a fully free-software stack.
-- **Updates are reflash-first**. The filesystem is read-only, so you update by re-flashing the SD with a new release (~10 min, settings auto-detect) rather than patching a running system.
+- **Updates are reflash-first**. The filesystem is read-only, so you update by re-flashing the SD with a new release (~15-20 min on Pi 4/5, settings auto-detect) rather than patching a running system.
 - **Hardware quality matters**. Bad SD cards, weak PSUs and flaky WiFi cause most first-install failures.
 
 ## Quick start
@@ -98,7 +98,7 @@ The script walks you through a few questions: the role (**Audio Player** / **Mus
 
 ### 4. Boot the Pi
 
-Eject the SD, insert it in the Pi, power on. Wait about 10-15 minutes — the first-boot installer runs on its own (no SSH), shows progress on HDMI if a screen is attached, then reboots once.
+Eject the SD, insert it in the Pi, power on. Wait roughly 15-20 minutes on a Pi 4/5 (longer on Pi 3 or Pi Zero 2 W) — the first-boot installer runs on its own (no SSH), shows progress on HDMI if a screen is attached, then reboots once. The HDMI progress display shows the expected total time so you know whether 8 minutes in is "almost there" or "barely halfway".
 
 **It worked when**: with a screen attached, the HDMI display shows the snapMULTI now-playing screen (cover art / spectrum). Either way, from another device open `http://<hostname>.local:8083/`, then open **Status** — every check should be green. Then cast something (see **After install** below).
 

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -359,48 +359,47 @@ I limiti di memoria dei container vengono applicati automaticamente in base all'
 
 ## Build di riferimento — misurazioni reali
 
-Due scenari di produzione catturati il **2026-05-13** con `docker stats --no-stream`, `free -h` e `vcgencmd measure_temp`. Pensati come limiti superiori realistici mentre il sistema sta attivamente trasmettendo, *non* come baseline a riposo.
+Due scenari di produzione catturati il **2026-05-29** con `docker stats --no-stream`, `free -h` e `vcgencmd measure_temp`. Pensati come limiti superiori realistici mentre il sistema sta attivamente trasmettendo, *non* come baseline a riposo.
 
-### Scenario A — `pi-server` fan-out: 3 sorgenti → 3 gruppi di client
+### Scenario A — `snapvideo` fan-out: 3 sorgenti attive → più gruppi di client
 
-`pi-server` serve tre sorgenti audio diverse simultaneamente a tre client distinti, ognuno sul proprio gruppo Snapweb.
+`snapvideo` (server + display locale) serve tre sorgenti simultaneamente (libreria MPD, sessione AirPlay, Spotify Connect) a due snapclient remoti e al proprio display loopback.
 
 | Ruolo | Hostname | Scheda | RAM | Audio | Sorgente riprodotta |
 |-------|----------|--------|-----|-------|---------------------|
-| Server + display | `pi-server` | Pi 4 B Rev 1.4 | 8 GB | HiFiBerry DAC+ (analogico) | — (serve tutti e 3) |
-| Client gruppo A | `pi3-1gb` | Pi 3 B+ Rev 1.4 | 1 GB | InnoMaker HIFI DAC HAT (PCM5122) | Libreria MPD |
-| Client gruppo B | `pi-zero` | Pi Zero 2 W Rev 1.0 | 512 MB | InnoMaker DAC (PCM5122), snapclient nativo | Spotify |
-| Client gruppo C | `pi-display` | Pi 4 B Rev 1.1 | 2 GB | HDMI verso LG 50" (con display copertine) | Tidal Connect |
+| Server + display | `snapvideo` | Pi 4 B | 8 GB | HiFiBerry DAC+ (analogico) | — (serve tutti e 3) |
+| Client gruppo A | `snapdigi` | Pi 4 B | 2 GB | HDMI verso LG 50" (con display copertine) | Libreria MPD |
+| Client gruppo B | `pizero` | Pi Zero 2 W | 512 MB | InnoMaker DAC (PCM5122), snapclient nativo | Spotify |
+| Loopback | `snapvideo` (sé stesso) | Pi 4 B | 8 GB | HiFiBerry DAC+ | AirPlay |
 
-**Carico server** (`pi-server`, uptime 6 h, load avg `1.62`):
+**Carico server** (`snapvideo`, uptime 43 min, load avg `0,45`):
 
 | Container | CPU % | RAM | Note |
 |-----------|-------|-----|------|
-| snapserver | 13.32% | 91 MiB | Distribuisce l'audio a tutti e 3 i client |
-| mpd | 11.23% | 255 MiB | Il gruppo A sta riproducendo dalla libreria locale |
-| fb-display | 10.93% | 133 MiB | Server-con-display (copertine anche su questo Pi) |
-| audio-visualizer | 7.53% | 54 MiB | Server-con-display |
-| librespot (Spotify) | 3.02% | 58 MiB | Il gruppo B sta facendo cast da Spotify |
-| metadata | 2.02% | 62 MiB | Serve copertina / brano in corso a client + display |
-| snapclient (loopback) | 1.65% | 18 MiB | pi-server suona anche localmente |
-| tidal-connect | 1.47% | 95 MiB | Il gruppo C sta facendo cast da Tidal |
-| shairport-sync | 0.00% | 18 MiB | AirPlay a riposo (nessuno stream attivo) |
-| mympd | 0.00% | 18 MiB | Web UI a riposo |
-| **Totale server** | **~51% CPU** | **~803 MiB** | su 384+256+96+128+192+128+96+192+96+128 MiB di limiti |
+| snapserver | 10,96% | 90,34 MiB | Distribuisce l'audio a tutti i client |
+| fb-display | 8,16% | 109,8 MiB | Server-con-display (copertine renderizzate anche localmente) |
+| tidal-connect | 3,84% | 32,18 MiB | A riposo (nessun cast Tidal — daemon resta caldo) |
+| librespot (Spotify) | 3,71% | 40,81 MiB | Il gruppo B sta facendo cast da Spotify |
+| audio-visualizer | 3,52% | 54,10 MiB | Server-con-display |
+| shairport-sync | 1,76% | 21,95 MiB | Sessione AirPlay attiva (riproduzione loopback) |
+| snapclient (loopback) | 1,38% | 18,38 MiB | snapvideo suona anche localmente |
+| mpd | 0,45% | 249,1 MiB | Il gruppo A sta trasmettendo dalla libreria locale |
+| metadata | 0,10% | 63,11 MiB | Serve copertina / brano in corso a client + display |
+| mympd | 0,00% | 14,78 MiB | Web UI a riposo |
+| **Totale server** | **~34% CPU** | **~895 MiB** | su 384+192+96+128+128+96+96+256+256+128 = 1,76 GiB di limiti cumulativi |
 
-Host: 2,8 GiB usati / 7,5 GiB totali, **4,6 GiB disponibili**. Temperatura **64,2 °C**.
+Host: 710 MiB usati / 7,5 GiB totali, **6,8 GiB disponibili**. Temperatura **68,6 °C**.
 
 **Carico client** (per gruppo, tutti verdi al test di salute):
 
 | Client | CPU % snapclient | RAM snapclient | RAM host usata / totale | Temp |
 |--------|------------------|----------------|--------------------------|------|
-| `pi3-1gb` (Pi 3 B+ 1 GB, headless) | 1,36% | 18 MiB | 223 / 955 MiB | 49,4 °C |
-| `pi-zero` (Pi Zero 2 W, install nativa) | 1,8% (processo) | 13 MiB RSS | 159 / 416 MiB | 44,0 °C |
-| `pi-display` (Pi 4 2 GB + display HDMI 4K) | 1,80% | 9 MiB | 848 / 1,6 GiB | 59,9 °C |
+| `snapdigi` (Pi 4 2 GB + display HDMI 4K) | 1,40% | 17,96 MiB | 439 / 1,6 GiB | 61,8 °C |
+| `pizero` (Pi Zero 2 W, install nativa) | 0,1% (processo) | 13,4 MiB RSS | 153 / 416 MiB | 47,8 °C |
 
-Su `pi-display`, lo stack copertine aggiunge: `fb-display` **66,16% / 124 MiB** (il rendering 4K è il costo dominante) e `audio-visualizer` 8,92% / 33 MiB. snapclient di per sé resta trascurabile su ogni client.
+Su `snapdigi`, lo stack copertine aggiunge: `fb-display` **63,12% / 145,8 MiB** (il rendering HDMI 4K resta il costo dominante del client) e `audio-visualizer` 4,04% / 53,53 MiB. snapclient di per sé resta trascurabile su ogni client.
 
-> **Nota sul Pi Zero 2 W.** Esegue snapclient nativo da `.deb` (niente Docker, niente container display — vedi [Note Pi Zero 2 W](#note-pi-zero-2-w)). Il risultato è un singolo processo a 13 MiB RSS / 1,8% CPU, ed è per questo che una scheda da 512 MB lo sostiene a tempo indefinito. Lo stesso ruolo sotto Docker non starebbe in RAM.
+> **Nota sul Pi Zero 2 W.** Esegue snapclient nativo da `.deb` (niente Docker, niente container display — vedi [Note Pi Zero 2 W](#note-pi-zero-2-w)). Il risultato è un singolo processo a ~13 MiB RSS / 0,1 % CPU, ed è per questo che una scheda da 512 MB lo sostiene a tempo indefinito. Lo stesso ruolo sotto Docker non starebbe in RAM.
 
 ### Scenario B — `pi4-test` both-mode single-host (solo libreria locale)
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -359,48 +359,47 @@ Container memory limits are applied automatically based on detected hardware (mi
 
 ## Reference builds — real-world measurements
 
-Two production scenarios captured on **2026-05-13** with `docker stats --no-stream`, `free -h`, and `vcgencmd measure_temp`. Intended as realistic upper bounds while the system is actively streaming, *not* idle baselines.
+Two production scenarios captured on **2026-05-29** with `docker stats --no-stream`, `free -h`, and `vcgencmd measure_temp`. Intended as realistic upper bounds while the system is actively streaming, *not* idle baselines.
 
-### Scenario A — `pi-server` fan-out: 3 sources → 3 client groups
+### Scenario A — `snapvideo` fan-out: 3 active sources → multiple client groups
 
-`pi-server` serves three different audio sources simultaneously to three distinct clients, each on its own Snapweb group.
+`snapvideo` (server + local display) serves three sources simultaneously (MPD library, AirPlay session, Spotify Connect) to two remote snapclients plus its own loopback display.
 
 | Role | Hostname | Board | RAM | Audio | Source it plays |
 |------|----------|-------|-----|-------|-----------------|
-| Server + display | `pi-server` | Pi 4 B Rev 1.4 | 8 GB | HiFiBerry DAC+ (analog) | — (fans out all 3) |
-| Client group A | `pi3-1gb` | Pi 3 B+ Rev 1.4 | 1 GB | InnoMaker HIFI DAC HAT (PCM5122) | MPD library |
-| Client group B | `pi-zero` | Pi Zero 2 W Rev 1.0 | 512 MB | InnoMaker DAC (PCM5122), native snapclient | Spotify |
-| Client group C | `pi-display` | Pi 4 B Rev 1.1 | 2 GB | HDMI to LG 50" (with cover-art display) | Tidal Connect |
+| Server + display | `snapvideo` | Pi 4 B | 8 GB | HiFiBerry DAC+ (analog) | — (fans out 3) |
+| Client group A | `snapdigi` | Pi 4 B | 2 GB | HDMI to LG 50" (with cover-art display) | MPD library |
+| Client group B | `pizero` | Pi Zero 2 W | 512 MB | InnoMaker DAC (PCM5122), native snapclient | Spotify |
+| Loopback | `snapvideo` (self) | Pi 4 B | 8 GB | HiFiBerry DAC+ | AirPlay |
 
-**Server load** (`pi-server`, uptime 6 h, load avg `1.62`):
+**Server load** (`snapvideo`, uptime 43 min, load avg `0.45`):
 
 | Container | CPU % | RAM | Notes |
 |-----------|-------|-----|-------|
-| snapserver | 13.32% | 91 MiB | Fans out audio to all 3 clients |
-| mpd | 11.23% | 255 MiB | Group A is streaming from the local library |
-| fb-display | 10.93% | 133 MiB | Server-with-display (cover art on this Pi too) |
-| audio-visualizer | 7.53% | 54 MiB | Server-with-display |
-| librespot (Spotify) | 3.02% | 58 MiB | Group B is casting Spotify |
-| metadata | 2.02% | 62 MiB | Serves cover art / now-playing to clients + display |
-| snapclient (loopback) | 1.65% | 18 MiB | pi-server also plays locally |
-| tidal-connect | 1.47% | 95 MiB | Group C is casting Tidal |
-| shairport-sync | 0.00% | 18 MiB | AirPlay idle (no active stream) |
-| mympd | 0.00% | 18 MiB | Idle web UI |
-| **Server total** | **~51% CPU** | **~803 MiB** | of 384 MiB+256 MiB+96 MiB+128 MiB+192 MiB+128 MiB+96 MiB+192 MiB+96 MiB+128 MiB limits |
+| snapserver | 10.96% | 90.34 MiB | Fans out audio to all clients |
+| fb-display | 8.16% | 109.8 MiB | Server-with-display (cover art rendered locally too) |
+| tidal-connect | 3.84% | 32.18 MiB | Idle (no active Tidal cast — daemon stays warm) |
+| librespot (Spotify) | 3.71% | 40.81 MiB | Group B is casting Spotify |
+| audio-visualizer | 3.52% | 54.10 MiB | Server-with-display |
+| shairport-sync | 1.76% | 21.95 MiB | AirPlay active session (loopback playback) |
+| snapclient (loopback) | 1.38% | 18.38 MiB | snapvideo also plays locally |
+| mpd | 0.45% | 249.1 MiB | Group A is streaming from the local library |
+| metadata | 0.10% | 63.11 MiB | Serves cover art / now-playing to clients + display |
+| mympd | 0.00% | 14.78 MiB | Idle web UI |
+| **Server total** | **~34% CPU** | **~895 MiB** | of 384+192+96+128+128+96+96+256+256+128 = 1.76 GiB cumulative limit |
 
-Host: 2.8 GiB used / 7.5 GiB total, **4.6 GiB available**. Temperature **64.2 °C**.
+Host: 710 MiB used / 7.5 GiB total, **6.8 GiB available**. Temperature **68.6 °C**.
 
 **Client load** (per group, all healthy on smoke test):
 
 | Client | snapclient CPU % | snapclient RAM | Host RAM used / total | Temp |
 |--------|------------------|----------------|-----------------------|------|
-| `pi3-1gb` (Pi 3 B+ 1 GB, headless) | 1.36% | 18 MiB | 223 / 955 MiB | 49.4 °C |
-| `pi-zero` (Pi Zero 2 W, native install) | 1.8% (process) | 13 MiB RSS | 159 / 416 MiB | 44.0 °C |
-| `pi-display` (Pi 4 2 GB + 4K HDMI display) | 1.80% | 9 MiB | 848 / 1.6 GiB | 59.9 °C |
+| `snapdigi` (Pi 4 2 GB + 4K HDMI display) | 1.40% | 17.96 MiB | 439 / 1.6 GiB | 61.8 °C |
+| `pizero` (Pi Zero 2 W, native install) | 0.1% (process) | 13.4 MiB RSS | 153 / 416 MiB | 47.8 °C |
 
-On `pi-display`, the cover-art stack adds: `fb-display` **66.16% / 124 MiB** (4K rendering is the dominant cost) and `audio-visualizer` 8.92% / 33 MiB. snapclient itself stays trivial on every client.
+On `snapdigi`, the cover-art stack adds: `fb-display` **63.12% / 145.8 MiB** (4K HDMI rendering remains the dominant client cost) and `audio-visualizer` 4.04% / 53.53 MiB. snapclient itself stays trivial on every client.
 
-> **Note on Pi Zero 2 W.** It runs the native `snapclient` .deb (no Docker, no display containers — see [Pi Zero 2 W Notes](#pi-zero-2-w-notes)). The result is a single process at 13 MiB RSS / 1.8% CPU, which is why a 512 MB board sustains it indefinitely. The same role under Docker would not fit.
+> **Note on Pi Zero 2 W.** It runs the native `snapclient` .deb (no Docker, no display containers — see [Pi Zero 2 W Notes](#pi-zero-2-w-notes)). The result is a single process at ~13 MiB RSS / 0.1 % CPU, which is why a 512 MB board sustains it indefinitely. The same role under Docker would not fit.
 
 ### Scenario B — `pi4-test` single-host both-mode (local library only)
 

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -16,7 +16,7 @@ Hai già dimestichezza con Raspberry Pi Imager e terminale? Questa è tutta l'in
 4. Scarica lo ZIP dell'ultima release snapMULTI oppure esegui `git clone https://github.com/lollonet/snapMULTI.git`.
 5. Dalla cartella snapMULTI, esegui `./scripts/prepare-sd.sh` su macOS/Linux oppure `.\scripts\prepare-sd.ps1` su Windows.
 6. Scegli cosa deve fare questo Pi: **Audio Player**, **Music Server** o **Server + Player**.
-7. Espelli la SD, avvia il Pi e attendi circa 10-15 minuti. Installa, verifica e poi riavvia una volta.
+7. Espelli la SD, avvia il Pi e attendi circa 15-20 minuti su Pi 4/5 (di più su Pi 3 o Pi Zero 2 W). Installa, verifica e poi riavvia una volta. Il display HDMI di progresso mostra il tempo totale previsto accanto all'elapsed, così sai a che punto sei.
 8. Apri `http://<hostname>.local:8083/` — la pagina iniziale contiene i link a Snapweb, myMPD, status e API.
 
 Se un passaggio non è chiaro, continua con la procedura dettagliata qui sotto. Se il primo boot fallisce, recupera il pacchetto diagnostico dalla SD come descritto in [TROUBLESHOOTING.it.md — In caso di dubbio](TROUBLESHOOTING.it.md#in-caso-di-dubbio--prendi-il-pacchetto-diagnostico).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,7 +16,7 @@ Already comfortable with Raspberry Pi Imager and terminals? This is the whole in
 4. Download the latest snapMULTI release ZIP or `git clone https://github.com/lollonet/snapMULTI.git`.
 5. From the snapMULTI folder, run `./scripts/prepare-sd.sh` on macOS/Linux or `.\scripts\prepare-sd.ps1` on Windows.
 6. Choose what this Pi should do: **Audio Player**, **Music Server**, or **Server + Player**.
-7. Eject the SD, boot the Pi, and wait about 10-15 minutes. It installs, verifies, then reboots once.
+7. Eject the SD, boot the Pi, and wait roughly 15-20 minutes on a Pi 4/5 (longer on Pi 3 or Pi Zero 2 W). It installs, verifies, then reboots once. The HDMI progress display surfaces the expected total time alongside elapsed so you know how far along you are.
 8. Open `http://<hostname>.local:8083/` — the start page links to Snapweb, myMPD, status, and API endpoints.
 
 If any step is unclear, continue with the detailed walkthrough below. If first boot fails, recover the diagnostic bundle from the SD card as described in [TROUBLESHOOTING.md — When in doubt](TROUBLESHOOTING.md#when-in-doubt--grab-the-diagnostic-bundle).

--- a/scripts/common/device-detect.sh
+++ b/scripts/common/device-detect.sh
@@ -42,3 +42,9 @@ device_model() {
 is_pi_zero_2w() {
     [[ "$(device_model)" == *"Zero 2 W"* ]]
 }
+
+# True iff this host is a Raspberry Pi 3 (3B, 3B+, 3A+). Used to bucket
+# install-time ETA — Pi 3 is ~40% slower than Pi 4/5 on apt + Docker pull.
+is_pi_3() {
+    [[ "$(device_model)" == *"Raspberry Pi 3"* ]]
+}

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -172,8 +172,7 @@ render_progress() {
         printf '  +%s+\n' "$hline"
         printf '  | \033[1m%-*.*s\033[0m |\n' "$_inner_width" "$_inner_width" "$PROGRESS_TITLE"
         printf '  +%s+\n' "$hline"
-        # ETA label — empty when env unset (dev invocations). Use plain white
-        # (\033[37m) instead of dim (\033[2m) for framebuffer console compat.
+        # \033[37m not \033[2m — framebuffer console lacks dim support.
         local _eta_label=""
         if [[ -n "${EXPECTED_TOTAL_MIN:-}" ]]; then
             _eta_label=" / ~${EXPECTED_TOTAL_MIN} min"

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -172,8 +172,14 @@ render_progress() {
         printf '  +%s+\n' "$hline"
         printf '  | \033[1m%-*.*s\033[0m |\n' "$_inner_width" "$_inner_width" "$PROGRESS_TITLE"
         printf '  +%s+\n' "$hline"
-        printf '  \033[36m%02d:%02d\033[0m  \033[33m[%s]\033[0m\n' \
-            $((elapsed/60)) $((elapsed%60)) "$bar"
+        # ETA label — empty when env unset (dev invocations). Use plain white
+        # (\033[37m) instead of dim (\033[2m) for framebuffer console compat.
+        local _eta_label=""
+        if [[ -n "${EXPECTED_TOTAL_MIN:-}" ]]; then
+            _eta_label=" / ~${EXPECTED_TOTAL_MIN} min"
+        fi
+        printf '  \033[36m%02d:%02d\033[0m\033[37m%s\033[0m  \033[33m[%s]\033[0m\n' \
+            $((elapsed/60)) $((elapsed%60)) "$_eta_label" "$bar"
         printf '  %3d%% %s\n' "$pct" "$spinner"
         printf '\n'
         for i in $(seq 1 "$total"); do

--- a/scripts/firstboot.sh
+++ b/scripts/firstboot.sh
@@ -296,6 +296,30 @@ case "$INSTALL_TYPE" in
 esac
 PROGRESS_TITLE="$PROGRESS_TITLE ($(hostname))"
 
+# ETA shown on TUI elapsed line. Pi 4 + Pi Zero 2W measured (snapvideo 16m, snapdigi 10:30, pizero 18:25); Pi 3 projected at ~+40% vs Pi 4.
+if is_pi_zero_2w; then
+    case "$INSTALL_TYPE" in
+        client|client-native) EXPECTED_TOTAL_MIN=18 ;;
+        *)                    EXPECTED_TOTAL_MIN=25 ;;  # server/both on Zero 2W not supported but defensive
+    esac
+elif is_pi_3; then
+    case "$INSTALL_TYPE" in
+        server) EXPECTED_TOTAL_MIN=20 ;;
+        client) EXPECTED_TOTAL_MIN=16 ;;
+        both)   EXPECTED_TOTAL_MIN=24 ;;
+        *)      EXPECTED_TOTAL_MIN=20 ;;
+    esac
+else
+    # Pi 4, Pi 5, and any other modern board fall here.
+    case "$INSTALL_TYPE" in
+        server) EXPECTED_TOTAL_MIN=14 ;;
+        client) EXPECTED_TOTAL_MIN=11 ;;
+        both)   EXPECTED_TOTAL_MIN=16 ;;
+        *)      EXPECTED_TOTAL_MIN=15 ;;
+    esac
+fi
+export EXPECTED_TOTAL_MIN
+
 # Verify step arrays match
 if [[ ${#STEP_NAMES[@]} -ne ${#STEP_WEIGHTS[@]} ]]; then
     log_error "BUG: STEP_NAMES (${#STEP_NAMES[@]}) != STEP_WEIGHTS (${#STEP_WEIGHTS[@]})"

--- a/tests/test_progress_eta_label.sh
+++ b/tests/test_progress_eta_label.sh
@@ -58,16 +58,13 @@ assert 'grep -qE "EXPECTED_TOTAL_MIN" "$PROGRESS_SH"' \
 assert 'grep -qE "~\\$\\{EXPECTED_TOTAL_MIN\\} min" "$PROGRESS_SH"' \
     'progress.sh prints "~${EXPECTED_TOTAL_MIN} min" label'
 
-# Behaviour: empty when not set (dev invocations shouldn't render a "~ min" gap).
-out=$(EXPECTED_TOTAL_MIN='' bash -c '
-    if [[ -n "${EXPECTED_TOTAL_MIN:-}" ]]; then
-        echo "WITH"
-    else
-        echo "WITHOUT"
-    fi
-')
-assert '[[ "$out" == "WITHOUT" ]]' \
-    'empty EXPECTED_TOTAL_MIN → no label (per the env-aware branch in progress.sh)'
+# Behaviour: empty EXPECTED_TOTAL_MIN must produce no "~ NN min" fragment in
+# the rendered output. Actually exercise render_progress() — not just bash
+# built-ins — so an inverted condition in progress.sh would be caught here.
+out=$(STEP_NAMES=("Step") STEP_WEIGHTS=(1) PROGRESS_LOG=/dev/null EXPECTED_TOTAL_MIN='' \
+        bash -c 'source "$1" 2>/dev/null; render_progress 1 0 0 ""' _ "$PROGRESS_SH" 2>&1 || true)
+assert '! echo "$out" | grep -q "~ "' \
+    'render_progress with empty EXPECTED_TOTAL_MIN emits no "~ NN min" label'
 
 echo
 echo "=== Summary ==="

--- a/tests/test_progress_eta_label.sh
+++ b/tests/test_progress_eta_label.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Static check: progress.sh surfaces the EXPECTED_TOTAL_MIN env var as
+# "/~NN min" in the elapsed line, and firstboot.sh computes the value
+# per hardware bucket + INSTALL_TYPE.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROGRESS_SH="$SCRIPT_DIR/../scripts/common/progress.sh"
+FIRSTBOOT="$SCRIPT_DIR/../scripts/firstboot.sh"
+DEVICE_DETECT="$SCRIPT_DIR/../scripts/common/device-detect.sh"
+
+pass=0
+fail=0
+
+assert() {
+    local cond="$1" desc="$2"
+    if eval "$cond"; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "=== device-detect.sh — hardware buckets ==="
+
+assert 'grep -qE "^is_pi_zero_2w\\(\\) \\{" "$DEVICE_DETECT"' \
+    'device-detect.sh defines is_pi_zero_2w()'
+
+assert 'grep -qE "^is_pi_3\\(\\) \\{" "$DEVICE_DETECT"' \
+    'device-detect.sh defines is_pi_3()'
+
+echo
+echo "=== firstboot.sh — computes EXPECTED_TOTAL_MIN per hw+role ==="
+
+assert 'grep -qE "EXPECTED_TOTAL_MIN=[0-9]+" "$FIRSTBOOT"' \
+    'firstboot.sh sets EXPECTED_TOTAL_MIN'
+
+assert 'grep -qE "^export EXPECTED_TOTAL_MIN" "$FIRSTBOOT"' \
+    'firstboot.sh exports EXPECTED_TOTAL_MIN (so progress.sh sees it)'
+
+# Pi Zero 2W client/client-native bucket — measured ~18 min.
+assert 'grep -qE "EXPECTED_TOTAL_MIN=1[6-9]" "$FIRSTBOOT"' \
+    'firstboot.sh has a 16-19 min ETA bucket (Pi 4 both = 16, Pi Zero native = 18)'
+
+# Pi 4 client bucket — measured ~10:30 min, target 11.
+assert 'grep -qE "EXPECTED_TOTAL_MIN=1[0-2]" "$FIRSTBOOT"' \
+    'firstboot.sh has a 10-12 min ETA bucket (Pi 4 client)'
+
+echo
+echo "=== progress.sh — surfaces EXPECTED_TOTAL_MIN on the elapsed line ==="
+
+assert 'grep -qE "EXPECTED_TOTAL_MIN" "$PROGRESS_SH"' \
+    'progress.sh reads EXPECTED_TOTAL_MIN'
+
+assert 'grep -qE "~\\$\\{EXPECTED_TOTAL_MIN\\} min" "$PROGRESS_SH"' \
+    'progress.sh prints "~${EXPECTED_TOTAL_MIN} min" label'
+
+# Behaviour: empty when not set (dev invocations shouldn't render a "~ min" gap).
+out=$(EXPECTED_TOTAL_MIN='' bash -c '
+    if [[ -n "${EXPECTED_TOTAL_MIN:-}" ]]; then
+        echo "WITH"
+    else
+        echo "WITHOUT"
+    fi
+')
+assert '[[ "$out" == "WITHOUT" ]]' \
+    'empty EXPECTED_TOTAL_MIN → no label (per the env-aware branch in progress.sh)'
+
+echo
+echo "=== Summary ==="
+echo "  Pass: $pass"
+echo "  Fail: $fail"
+
+if (( fail > 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
## What

The HDMI install progress bar now shows the expected total time alongside elapsed:

    02:15 / ~16 min  [████░░░░░░░░░░░░░░░░]

So the operator can tell whether 12 minutes in is "almost done" or "barely halfway", instead of guessing.

## Measured install timings

| Device | Hardware | Role | Measured | EXPECTED_TOTAL_MIN |
|---|---|---|---|---|
| snapvideo | Pi 4 8GB | both | 16 min 17 sec | 16 |
| snapdigi | Pi 4 2GB | client | 10 min 30 sec | 11 |
| pizero | Pi Zero 2W | client-native | 18 min 25 sec | 18 |
| (Pi 3 buckets) | Pi 3 B/B+ | any | projection (no device on hand) | +40% vs Pi 4 |

## Docs

README + docs/INSTALL.md (EN + IT) updated from the stale "10-15 minuti" to "15-20 min on Pi 4/5, longer on Pi 3 / Pi Zero 2W". The HDMI display surfaces the precise per-device figure via the TUI label so the prose doesn't have to enumerate every combination.

## Implementation

- `scripts/common/device-detect.sh` — new `is_pi_3()` helper (RFC 1123-style substring match)
- `scripts/firstboot.sh` — `EXPECTED_TOTAL_MIN` bucket per (hardware, INSTALL_TYPE), `export`-ed so progress.sh sees it
- `scripts/common/progress.sh` — render `/ ~NN min` in white next to elapsed when env is set. Empty when env unset (dev callers, debug invocations).
- `tests/test_progress_eta_label.sh` — 9 assertions: helper exists, env var set + exported, bucket ranges cover measured, label rendered, label suppressed when env empty.

## Validation

- Done locally: shellcheck clean on all 4 modified scripts, bash -n pass, test_progress_eta_label.sh 9/9, regression test_install_tty_fb_overlap.sh 30/30.
- Deferred to release-gate: reflash a Pi 4 + Pi Zero 2W from this branch, verify the HDMI TUI shows the expected label and the actual elapsed lands close to the prediction.

## Pre-push /review

Local /review found 3 MEDIUM (all applied):
- Multi-line comment block in firstboot.sh → compressed to 1 line
- Pi 3 numbers marked as measured → comment clarifies they're projected (+40%)
- `\033[2m` (dim) → `\033[37m` (white) for framebuffer console compatibility
