### PR TITLE
docs(hardware): qualitative sizing notes instead of dated benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **ADR-008 supersedes ADR-007 — IPv6 enabled by default** (#557, #558). Tidal Connect now works out-of-box; software defenses (Avahi `use-ipv6=no`, snapclient IPv4 pin, fb-display filter, `boot-tune.sh`) cover the original races. Opt back into the kernel disable with `DISABLE_IPV6=true`. Validated live on snapvideo + pizero + snapdigi.
-- **HARDWARE.md Scenario A refreshed with 2026-05-29 measurements** from snapvideo + snapdigi + pizero (replaces stale 2026-05-13 `pi-server`/Pi 3 mix). 3-source fan-out: server ~34 % CPU / ~895 MiB / 68.6 °C, host 6.8 GiB available. Italian mirrored.
+- **HARDWARE.md reference builds replaced with qualitative sizing notes** (#559) — point-in-time `docker stats` tables removed; section now lists cost drivers, board floors, and sizing rules of thumb. Memory limits stay in ADVANCED.md (SSOT). Italian mirrored.
 - **Install TUI shows expected total time + INSTALL docs updated** (PR #556). HDMI progress bar now reads `02:15 / ~16 min [...]`. `EXPECTED_TOTAL_MIN` per `(hardware, INSTALL_TYPE)` from measured logs; README / `INSTALL.md` (+ Italian) flipped from stale "10-15 min" to realistic 15-20 min Pi 4/5, ~18 min Pi Zero 2 W.
 
 ## [0.7.9.6] — 2026-05-29

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -357,77 +357,52 @@ I limiti di memoria dei container vengono applicati automaticamente in base all'
 
 ---
 
-## Build di riferimento — misurazioni reali
+## Build di riferimento — caratteristiche di carico
 
-Due scenari di produzione catturati il **2026-05-29** con `docker stats --no-stream`, `free -h` e `vcgencmd measure_temp`. Pensati come limiti superiori realistici mentre il sistema sta attivamente trasmettendo, *non* come baseline a riposo.
+I limiti di memoria per servizio sono in [ADVANCED.it.md — Profili risorse](ADVANCED.it.md#profili-risorse). Le note qui sotto descrivono *come* il sistema si comporta sotto carico, così da dimensionare l'hardware senza inseguire benchmark puntuali.
 
-### Scenario A — `snapvideo` fan-out: 3 sorgenti attive → più gruppi di client
+### Scenario A — fan-out server (più sorgenti → più gruppi di client)
 
-`snapvideo` (server + display locale) serve tre sorgenti simultaneamente (libreria MPD, sessione AirPlay, Spotify Connect) a due snapclient remoti e al proprio display loopback.
+Un Pi server-con-display che alimenta diversi snapclient remoti più il proprio loopback. Carico tipico: libreria MPD, AirPlay e Spotify Connect attivi simultaneamente, ognuno instradato verso un gruppo client diverso.
 
-| Ruolo | Hostname | Scheda | RAM | Audio | Sorgente riprodotta |
-|-------|----------|--------|-----|-------|---------------------|
-| Server + display | `snapvideo` | Pi 4 B | 8 GB | HiFiBerry DAC+ (analogico) | — (serve tutti e 3) |
-| Client gruppo A | `snapdigi` | Pi 4 B | 2 GB | HDMI verso LG 50" (con display copertine) | Libreria MPD |
-| Client gruppo B | `pizero` | Pi Zero 2 W | 512 MB | InnoMaker DAC (PCM5122), snapclient nativo | Spotify |
-| Loopback | `snapvideo` (sé stesso) | Pi 4 B | 8 GB | HiFiBerry DAC+ | AirPlay |
+| Ruolo | Scheda minima | Catena audio |
+|-------|---------------|--------------|
+| Server + display | Pi 4 4 GB+ (8 GB consigliato per margine) | HAT DAC, analogico o digitale |
+| Client con display | Pi 4 2 GB+ | HDMI / HAT DAC |
+| Client headless | Pi 3 / Pi Zero 2 W nativo | HAT DAC |
+| Loopback (il server suona anche localmente) | stesso Pi del server | HAT DAC del server |
 
-**Carico server** (`snapvideo`, uptime 43 min, load avg `0,45`):
+**Costi dominanti da dimensionare:**
 
-| Container | CPU % | RAM | Note |
-|-----------|-------|-----|------|
-| snapserver | 10,96% | 90,34 MiB | Distribuisce l'audio a tutti i client |
-| fb-display | 8,16% | 109,8 MiB | Server-con-display (copertine renderizzate anche localmente) |
-| tidal-connect | 3,84% | 32,18 MiB | A riposo (nessun cast Tidal — daemon resta caldo) |
-| librespot (Spotify) | 3,71% | 40,81 MiB | Il gruppo B sta facendo cast da Spotify |
-| audio-visualizer | 3,52% | 54,10 MiB | Server-con-display |
-| shairport-sync | 1,76% | 21,95 MiB | Sessione AirPlay attiva (riproduzione loopback) |
-| snapclient (loopback) | 1,38% | 18,38 MiB | snapvideo suona anche localmente |
-| mpd | 0,45% | 249,1 MiB | Il gruppo A sta trasmettendo dalla libreria locale |
-| metadata | 0,10% | 63,11 MiB | Serve copertina / brano in corso a client + display |
-| mympd | 0,00% | 14,78 MiB | Web UI a riposo |
-| **Totale server** | **~34% CPU** | **~895 MiB** | su 384+192+96+128+128+96+96+256+256+128 = 1,76 GiB di limiti cumulativi |
+- **Lo streaming dalla libreria MPD** è il carico server-side più pesante — cresce con la dimensione della libreria e con la latenza NFS/SMB, non con il numero di gruppi client in fan-out. La generazione delle copertine amplifica il footprint RAM.
+- **Il fan-out di snapserver in sé è economico.** Aggiungere gruppi client remoti incide solo marginalmente sulla CPU; il costo principale resta nei decoder delle sorgenti.
+- **La CPU per client è dominata dallo stack display, non da `snapclient`.** Un display copertine HDMI 4K può consumare un ordine di grandezza più CPU del client audio. I client headless costano praticamente nulla.
+- **I demoni Spotify/Tidal/AirPlay restano caldi anche a riposo** — mantengono una RAM baseline modesta così il passaggio tra sorgenti è immediato.
 
-Host: 710 MiB usati / 7,5 GiB totali, **6,8 GiB disponibili**. Temperatura **68,6 °C**.
+**Regola pratica per dimensionare il server:** Pi 4 4 GB è il limite inferiore confortevole quando il server fa girare anche il display copertine; 8 GB dà margine per scansioni MPD, cambi sorgente e una libreria in crescita. Un Pi 3 / Pi 4 2 GB può servire fan-out audio ma diventa stretto non appena lo stack display locale entra in gioco.
 
-**Carico client** (per gruppo, tutti verdi al test di salute):
+> **Il Pi Zero 2 W resta utilizzabile come client** *solo* via install nativo `.deb` (niente Docker, niente container display — vedi [Note Pi Zero 2 W](#note-pi-zero-2-w)). Sotto Docker lo stesso ruolo non starebbe in 512 MB; nativo, è un singolo processo leggero e regge a tempo indefinito.
 
-| Client | CPU % snapclient | RAM snapclient | RAM host usata / totale | Temp |
-|--------|------------------|----------------|--------------------------|------|
-| `snapdigi` (Pi 4 2 GB + display HDMI 4K) | 1,40% | 17,96 MiB | 439 / 1,6 GiB | 61,8 °C |
-| `pizero` (Pi Zero 2 W, install nativa) | 0,1% (processo) | 13,4 MiB RSS | 153 / 416 MiB | 47,8 °C |
-
-Su `snapdigi`, lo stack copertine aggiunge: `fb-display` **63,12% / 145,8 MiB** (il rendering HDMI 4K resta il costo dominante del client) e `audio-visualizer` 4,04% / 53,53 MiB. snapclient di per sé resta trascurabile su ogni client.
-
-> **Nota sul Pi Zero 2 W.** Esegue snapclient nativo da `.deb` (niente Docker, niente container display — vedi [Note Pi Zero 2 W](#note-pi-zero-2-w)). Il risultato è un singolo processo a ~13 MiB RSS / 0,1 % CPU, ed è per questo che una scheda da 512 MB lo sostiene a tempo indefinito. Lo stesso ruolo sotto Docker non starebbe in RAM.
-
-### Scenario B — `pi4-test` both-mode single-host (solo libreria locale)
+### Scenario B — both-mode single-host (solo libreria locale)
 
 Un singolo Pi che esegue server + client simultaneamente, riproducendo dalla propria libreria MPD verso il proprio snapclient. Nessun fan-out, nessun client remoto.
 
-| Container | CPU % | RAM |
-|-----------|-------|-----|
-| snapserver | 4,24% | 77 MiB |
-| mpd | 3,12% | 182 MiB |
-| tidal-connect | 4,31% | 20 MiB |
-| metadata | 0,99% | 53 MiB |
-| snapclient (loopback) | 1,09% | 18 MiB |
-| librespot | 0,00% | 17 MiB |
-| shairport-sync | 0,00% | 14 MiB |
-| mympd | 0,00% | 10 MiB |
-| **Totale** | **~18% CPU** | **~390 MiB** |
+**Caratteristiche:**
 
-Scheda: Pi 4 B Rev 1.5 / **2 GB RAM**. Host: 798 / 1,9 GiB usati (1,1 GiB disponibili). Temperatura 53 °C. Uptime 5 h.
+- Tutti i costi dei container collassano su un'unica scheda, ma senza fan-out la catena di snapserver è leggera.
+- Il contributore singolo più pesante è MPD durante scansione o riproduzione di una libreria grande.
+- I demoni Tidal/Spotify/AirPlay restano residenti ma quiescenti se non attivamente in cast.
+- Un Pi 4 2 GB ha margine evidente per il both-mode senza display server-side; passare a 4 GB è sovradimensionato in questo caso. La soglia di 4 GB+ conta solo quando i container display copertine entrano nello stack.
 
-### Osservazioni
+**Regola pratica per il both-mode:** Pi 4 2 GB basta per audio puro (senza display). Aggiungere lo stack display copertine → salire a 4 GB+. Both-mode su Pi 3 / Pi Zero non è supportato — vedi la [matrice di compatibilità hardware](ADVANCED.it.md#matrice-di-compatibilità-hardware).
 
-- **Il Pi 4 8 GB regge comodamente un fan-out 3 sorgenti × 3 gruppi** anche con il display copertine lato server attivo. ~51% CPU e ~800 MiB di RAM container lasciano il resto della scheda libero per i picchi (scansioni MPD, cambi simultanei Spotify / Tidal). Il costo dominante era lo streaming dalla libreria MPD, non il fan-out di snapserver in sé.
-- **La CPU per client è dominata dallo stack display, non da `snapclient`.** Su `pi-display`, `fb-display` a 4K HDMI prende il 66% di CPU mentre `snapclient` resta sotto il 2%. I client headless costano praticamente nulla.
-- **L'install nativo del Pi Zero 2 W è decisamente più leggero di Docker** — 13 MiB RSS / 1,8% CPU contro ~64 MiB e l'overhead del demone Docker. È questo che rende una scheda da 512 MB usabile per snapMULTI.
-- **Un singolo Pi 4 2 GB regge comodamente la modalità both** quando non ci sono client in fan-out (Scenario B): ~18% CPU e ~390 MiB. Il modello da 2 GB ha margine evidente; 4 GB è sovradimensionato per questo caso d'uso.
-- **Le temperature sono ampiamente sotto il margine** su tutte e cinque le schede — la più calda (`pi-server` a 64 °C) è lontana dalla soglia di throttling (80 °C). Il raffreddamento passivo è stato sufficiente.
+### Osservazioni generali
 
-> **Come è stato raccolto.** Su ogni dispositivo: `docker stats --no-stream` (o `ps -o pcpu,pmem,rss -C snapclient` per l'install nativa del Pi Zero 2 W), `free -h`, `vcgencmd measure_temp`. Il test di salute (`scripts/device-smoke.sh`) era verde su ogni dispositivo prima dello snapshot. Le percentuali CPU sono campioni puntuali e variano con l'attività di riproduzione.
+- **Le temperature restano sotto il margine** su tutte le schede Pi 4 sotto il tipico carico domestico di streaming — il raffreddamento passivo (case con dissipatore) è sufficiente, niente ventola attiva richiesta. Il componente più caldo tende a essere il server quando fa rendering copertine in parallelo al fan-out audio.
+- **I limiti di memoria dei container puntano allo steady-state, non ai picchi.** Brevi sforamenti durante scansioni MPD, restart container o cambi sorgente sono normali; i tetti per servizio in [ADVANCED.it.md](ADVANCED.it.md#profili-risorse) lasciano spazio per assorbirli.
+- **Il deployment reflash-first significa che l'uso effettivo di RAM decresce dopo il primo boot.** Il database MPD in cache elimina il costo peggiore di scansione ai boot successivi — vedi [TROUBLESHOOTING.it.md](TROUBLESHOOTING.it.md) per la finestra di primo scan su librerie NFS grandi.
+
+> **Servono numeri puntuali?** Esegui `docker stats --no-stream`, `free -h` e `vcgencmd measure_temp` sul tuo dispositivo dopo che il test di salute passa verde — i valori reali dipendono da dimensione libreria, mix sorgenti e attività di riproduzione, quindi uno snapshot in questa doc invecchia nel giro di mesi.
 
 ---
 

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -394,7 +394,7 @@ Un singolo Pi che esegue server + client simultaneamente, riproducendo dalla pro
 - I demoni Tidal/Spotify/AirPlay restano residenti ma quiescenti se non attivamente in cast.
 - Un Pi 4 2 GB ha margine evidente per il both-mode senza display server-side; passare a 4 GB è sovradimensionato in questo caso. La soglia di 4 GB+ conta solo quando i container display copertine entrano nello stack.
 
-**Regola pratica per il both-mode:** Pi 4 2 GB basta per audio puro (senza display). Aggiungere lo stack display copertine → salire a 4 GB+. Both-mode su Pi 3 / Pi Zero non è supportato — vedi la [matrice di compatibilità hardware](ADVANCED.it.md#matrice-di-compatibilità-hardware).
+**Regola pratica per il both-mode:** Pi 4 2 GB basta per audio puro (senza display). Aggiungere lo stack display copertine → salire a 4 GB+. Both-mode su Pi 3 / Pi Zero non è supportato — vedi la [matrice di compatibilità hardware](ADVANCED.it.md#matrice-compatibilità-hardware).
 
 ### Osservazioni generali
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -357,77 +357,52 @@ Container memory limits are applied automatically based on detected hardware (mi
 
 ---
 
-## Reference builds — real-world measurements
+## Reference builds — load characteristics
 
-Two production scenarios captured on **2026-05-29** with `docker stats --no-stream`, `free -h`, and `vcgencmd measure_temp`. Intended as realistic upper bounds while the system is actively streaming, *not* idle baselines.
+Per-service memory limits live in [ADVANCED.md — Resource profiles](ADVANCED.md#resource-profiles). The notes below describe how the system *behaves* under load, so you can size hardware without chasing point-in-time benchmarks.
 
-### Scenario A — `snapvideo` fan-out: 3 active sources → multiple client groups
+### Scenario A — server fan-out (multi-source → multiple client groups)
 
-`snapvideo` (server + local display) serves three sources simultaneously (MPD library, AirPlay session, Spotify Connect) to two remote snapclients plus its own loopback display.
+A server-with-display Pi feeding several remote snapclients plus its own loopback. Typical workload: MPD library, AirPlay, and Spotify Connect active at the same time, each routed to a different client group.
 
-| Role | Hostname | Board | RAM | Audio | Source it plays |
-|------|----------|-------|-----|-------|-----------------|
-| Server + display | `snapvideo` | Pi 4 B | 8 GB | HiFiBerry DAC+ (analog) | — (fans out 3) |
-| Client group A | `snapdigi` | Pi 4 B | 2 GB | HDMI to LG 50" (with cover-art display) | MPD library |
-| Client group B | `pizero` | Pi Zero 2 W | 512 MB | InnoMaker DAC (PCM5122), native snapclient | Spotify |
-| Loopback | `snapvideo` (self) | Pi 4 B | 8 GB | HiFiBerry DAC+ | AirPlay |
+| Role | Board floor | Audio path |
+|------|-------------|------------|
+| Server + display | Pi 4 4 GB+ (8 GB recommended for headroom) | HAT DAC, analog or digital |
+| Client group with display | Pi 4 2 GB+ | HDMI / HAT DAC |
+| Client group, headless | Pi 3 / Pi Zero 2 W native | HAT DAC |
+| Loopback (server plays locally too) | same Pi as server | server HAT DAC |
 
-**Server load** (`snapvideo`, uptime 43 min, load avg `0.45`):
+**Dominant costs to size for:**
 
-| Container | CPU % | RAM | Notes |
-|-----------|-------|-----|-------|
-| snapserver | 10.96% | 90.34 MiB | Fans out audio to all clients |
-| fb-display | 8.16% | 109.8 MiB | Server-with-display (cover art rendered locally too) |
-| tidal-connect | 3.84% | 32.18 MiB | Idle (no active Tidal cast — daemon stays warm) |
-| librespot (Spotify) | 3.71% | 40.81 MiB | Group B is casting Spotify |
-| audio-visualizer | 3.52% | 54.10 MiB | Server-with-display |
-| shairport-sync | 1.76% | 21.95 MiB | AirPlay active session (loopback playback) |
-| snapclient (loopback) | 1.38% | 18.38 MiB | snapvideo also plays locally |
-| mpd | 0.45% | 249.1 MiB | Group A is streaming from the local library |
-| metadata | 0.10% | 63.11 MiB | Serves cover art / now-playing to clients + display |
-| mympd | 0.00% | 14.78 MiB | Idle web UI |
-| **Server total** | **~34% CPU** | **~895 MiB** | of 384+192+96+128+128+96+96+256+256+128 = 1.76 GiB cumulative limit |
+- **MPD library streaming** is the heaviest server-side workload — it grows with library size and NFS/SMB latency, not with the number of fan-out clients. Cover-art generation amplifies the RAM footprint.
+- **snapserver fan-out itself is cheap.** Adding remote client groups bumps CPU only marginally; the main cost stays in the source decoders.
+- **Per-client CPU is dominated by the display stack, not `snapclient`.** A 4K HDMI cover-art display can take an order of magnitude more CPU than the audio client. Headless clients are essentially free.
+- **Spotify/Tidal/AirPlay daemons stay warm even when idle** — they hold modest baseline RAM so handoff between sources is immediate.
 
-Host: 710 MiB used / 7.5 GiB total, **6.8 GiB available**. Temperature **68.6 °C**.
+**Sizing rule of thumb for the server:** Pi 4 4 GB is the comfortable floor when the server also runs the cover-art display; 8 GB gives margin for MPD scans, source switches, and a growing library. A Pi 3 / Pi 4 2 GB can serve audio fan-out but will feel tight as soon as the local display stack joins in.
 
-**Client load** (per group, all healthy on smoke test):
+> **Pi Zero 2 W stays viable as a client** *only* via the native `.deb` install (no Docker, no display containers — see [Pi Zero 2 W Notes](#pi-zero-2-w-notes)). Under Docker the same role would not fit in 512 MB; native, it is a single lightweight process and runs indefinitely.
 
-| Client | snapclient CPU % | snapclient RAM | Host RAM used / total | Temp |
-|--------|------------------|----------------|-----------------------|------|
-| `snapdigi` (Pi 4 2 GB + 4K HDMI display) | 1.40% | 17.96 MiB | 439 / 1.6 GiB | 61.8 °C |
-| `pizero` (Pi Zero 2 W, native install) | 0.1% (process) | 13.4 MiB RSS | 153 / 416 MiB | 47.8 °C |
-
-On `snapdigi`, the cover-art stack adds: `fb-display` **63.12% / 145.8 MiB** (4K HDMI rendering remains the dominant client cost) and `audio-visualizer` 4.04% / 53.53 MiB. snapclient itself stays trivial on every client.
-
-> **Note on Pi Zero 2 W.** It runs the native `snapclient` .deb (no Docker, no display containers — see [Pi Zero 2 W Notes](#pi-zero-2-w-notes)). The result is a single process at ~13 MiB RSS / 0.1 % CPU, which is why a 512 MB board sustains it indefinitely. The same role under Docker would not fit.
-
-### Scenario B — `pi4-test` single-host both-mode (local library only)
+### Scenario B — single-host both-mode (local library only)
 
 A single Pi running server + client at the same time, playing from its own MPD library to its own snapclient. No fan-out, no remote clients.
 
-| Container | CPU % | RAM |
-|-----------|-------|-----|
-| snapserver | 4.24% | 77 MiB |
-| mpd | 3.12% | 182 MiB |
-| tidal-connect | 4.31% | 20 MiB |
-| metadata | 0.99% | 53 MiB |
-| snapclient (loopback) | 1.09% | 18 MiB |
-| librespot | 0.00% | 17 MiB |
-| shairport-sync | 0.00% | 14 MiB |
-| mympd | 0.00% | 10 MiB |
-| **Total** | **~18% CPU** | **~390 MiB** |
+**Characteristics:**
 
-Board: Pi 4 B Rev 1.5 / **2 GB RAM**. Host: 798 / 1.9 GiB used (1.1 GiB available). Temperature 53 °C. Uptime 5 h.
+- All container costs collapse onto one board, but with no fan-out the snapserver path is light.
+- The heaviest single contributor is MPD when scanning or playing from a large library.
+- Tidal/Spotify/AirPlay daemons remain resident but quiet when not actively casting.
+- A Pi 4 2 GB has clear margin for both-mode without a server-side display; jumping to 4 GB is overkill for this case. The 4 GB+ floor only matters once cover-art display containers join the stack.
 
-### Takeaways
+**Sizing rule of thumb for both-mode:** Pi 4 2 GB is enough for pure audio (no display). Add the cover-art display stack → step up to 4 GB+. Both-mode on Pi 3 / Pi Zero is not supported — see the [hardware compatibility matrix](ADVANCED.md#hardware-compatibility-matrix).
 
-- **Pi 4 8 GB is comfortable for a 3-source × 3-group fan-out** even with a server-side cover-art display active. ~51% CPU and ~800 MiB of container RAM leave the rest of the board for spikes (MPD scans, simultaneous Spotify / Tidal switches). The dominant cost was MPD library streaming, not snapserver fan-out itself.
-- **Per-client CPU is dominated by the display stack, not by `snapclient`.** On `pi-display`, `fb-display` at 4K HDMI takes 66% CPU while `snapclient` stays under 2%. Headless clients are essentially free.
-- **The Pi Zero 2 W native install is decisively lighter than Docker** — 13 MiB RSS / 1.8% CPU vs. ~64 MiB and Docker daemon overhead. This is what makes a 512 MB board viable for snapMULTI.
-- **A single Pi 4 2 GB sustains both-mode comfortably** when there are no fan-out clients (Scenario B): ~18% CPU and ~390 MiB. The 2 GB model has clear margin; 4 GB is overkill for this use case.
-- **Thermals are well within margin** on all five boards — the hottest (`pi-server` at 64 °C) is far from the throttling threshold (80 °C). Passive cooling sufficed.
+### General observations
 
-> **How this was collected.** On every device: `docker stats --no-stream` (or `ps -o pcpu,pmem,rss -C snapclient` for the Pi Zero 2 W native install), `free -h`, `vcgencmd measure_temp`. The smoke test (`scripts/device-smoke.sh`) was green on every device before the snapshot. CPU percentages are point-in-time samples and vary with playback activity.
+- **Thermals stay within margin** on all Pi 4 boards under typical home-streaming load — passive cooling (heatsink case) is sufficient, no active fan required. The hottest component tends to be the server when running cover-art rendering alongside audio fan-out.
+- **Container memory limits target steady-state, not peaks.** Brief headroom during MPD scans, container restarts, or source switches is normal; the per-service ceilings in [ADVANCED.md](ADVANCED.md#resource-profiles) leave room for it.
+- **Reflash-first deployment means actual RAM usage decays after first boot.** The MPD cached database removes the worst-case scan cost on subsequent boots — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for the first-boot scan window on large NFS libraries.
+
+> **Want point-in-time numbers?** Run `docker stats --no-stream`, `free -h`, and `vcgencmd measure_temp` on your own device after smoke test passes — actual figures depend on library size, source mix, and playback activity, so a snapshot in this doc rots within months.
 
 ---
 


### PR DESCRIPTION
## Why

`docs/HARDWARE.md` *Reference builds* was anchored to a 2026-05-29 `docker stats` snapshot — hostname-specific (snapvideo/snapdigi/pizero), MiB-precise CPU%/RAM/°C. These rot in months and offer no actionable guidance for someone sizing different hardware.

## What

| Was | Is |
|---|---|
| Per-container CPU%/RAM tables for two scenarios | Qualitative sizing rules per scenario (fan-out vs both-mode) |
| Pi-specific temperature + uptime readings | Dominant cost drivers + minimum board floors |
| "Server total ~895 MiB" | "MPD streaming is the heaviest server-side workload; snapserver fan-out itself is cheap" |
| Take-aways pinned to specific devices | General observations on thermals, memory limit ceilings, reflash-first decay |

Memory limits remain the SSOT in `ADVANCED.md#resource-profiles` — `HARDWARE.md` links there for the actual numbers.

`docs/HARDWARE.it.md` mirrored.

## Validation

- Done locally: section headers consistent, cross-refs to ADVANCED.md and TROUBLESHOOTING.md still resolve, no stale hostnames remain
- Deferred to release-gate: none (doc-only)