### PR TITLE
docs: sweep install-time + image-set pinning + ADR-008 index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Doc sweep — image-set pinning + install-time + ADR-008 index** — `docs/`, `README*`, `CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md`, `THIRD-PARTY-NOTICES.md` and `docs/adr/ADR-INDEX.md` aligned: image references use `:<image-set>` from `release-manifest.json` (no stale `:latest`), upstream pins refreshed (`go-librespot` v0.7.3, `mympd` 25.0.2), residual `~10-15 min` install times flipped to `~15-20 min Pi 4/5`, ADR-007 marked superseded by ADR-008 in the index. CONTRIBUTING gains an inline Non-goals section.
 - **ADR-008 supersedes ADR-007 — IPv6 enabled by default** (#557, #558). Tidal Connect now works out-of-box; software defenses (Avahi `use-ipv6=no`, snapclient IPv4 pin, fb-display filter, `boot-tune.sh`) cover the original races. Opt back into the kernel disable with `DISABLE_IPV6=true`. Validated live on snapvideo + pizero + snapdigi.
 - **HARDWARE.md reference builds replaced with qualitative sizing notes** (#559) — point-in-time `docker stats` tables removed; section now lists cost drivers, board floors, and sizing rules of thumb. Memory limits stay in ADVANCED.md (SSOT). Italian mirrored.
 - **Install TUI shows expected total time + INSTALL docs updated** (PR #556). HDMI progress bar now reads `02:15 / ~16 min [...]`. `EXPECTED_TOTAL_MIN` per `(hardware, INSTALL_TYPE)` from measured logs; README / `INSTALL.md` (+ Italian) flipped from stale "10-15 min" to realistic 15-20 min Pi 4/5, ~18 min Pi Zero 2 W.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,8 @@ Explicitly out of scope — refuse scope-creep PRs that propose any of these wit
 - **Custom Linux distribution.** Use Debian bookworm + cloud-init. No Buildroot, no Yocto, no custom OS.
 - **Custom PCB / proprietary hardware.** Pi 3/4/5 + commodity HATs only.
 - **Vendor cloud / hosted services.** No snapMULTI account system, telemetry endpoint, or hosted control plane. Everything runs on the user's LAN.
+- **Public-WAN deployment without an operator-managed reverse proxy and authentication.** The security model assumes a trusted LAN; exposing snapMULTI ports on the public internet is the operator's responsibility, not a product feature.
+- **In-place upgrade workflow for ordinary users.** The supported path is reflash-first ([DEC-003](docs/decisions/DEC-003-reflash-only-updates.md)); manual `ro-mode disable` + `git pull` is documented for advanced users but not officially supported as an upgrade UX.
 - **Unified UI replacing snapweb + myMPD + metadata-service.** The project federates existing tools; building a new web app is years of work with dubious ROI.
 - **AI / voice assistants / DSP / spatial audio / room correction.** Audio enhancement belongs in the amp or a dedicated DSP upstream of snapMULTI.
 - **Marketplace plugin system for sources.** Sources are pinned in `config/snapserver.conf` + `docker-compose.yml`. Adding a source is a deliberate architectural change, not user-configurable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ ARM-only audio source using `edgecrush3r/tidal-connect` as base image (Raspbian 
 
 ## Conventions
 
-- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.0.2` (upstream) + `edgecrush3r/tidal-connect:latest` (ARM only, upstream)
+- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `lollonet/snapmulti-tidal:<image-set>` (ARM only) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.0.2` (upstream)
 - **Multi-arch**: linux/amd64 (studio) + linux/arm64 (ci-runner-x86), native builds on self-hosted runners
 - **Config paths**: all config in `config/`, all scripts in `scripts/`, shared libs in `scripts/common/`
 - **Deployment**: tag push (`v*`) triggers build → manifest → deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Italian translations (`*.it.md`) mirror the English docs and must stay in sync.
 | **Beginners** | Raspberry Pi 4 | Zero-touch SD | `prepare-sd.sh` → `firstboot.sh` → `deploy.sh`/`setup.sh` |
 | **Advanced** | Pi4 or x86_64 | Automated or Manual | `deploy.sh` (optional) |
 
-**Beginners**: No Linux administration required. Flash SD card on another computer, run `prepare-sd.sh` (or `prepare-sd.ps1` on Windows), choose what to install, insert in Pi, power on. HDMI shows a TUI progress display during installation (~10-15 min). The Pi becomes a dedicated audio appliance.
+**Beginners**: No Linux administration required. Flash SD card on another computer, run `prepare-sd.sh` (or `prepare-sd.ps1` on Windows), choose what to install, insert in Pi, power on. HDMI shows a TUI progress display during installation (~15-20 min on Pi 4/5; longer on Pi 3 / Pi Zero 2 W). The Pi becomes a dedicated audio appliance.
 
 **Advanced**: Clone repo on any Linux host (Pi, x86_64, VM, NAS). Use `deploy.sh` for automation (hardware detection, directory setup, resource profiles) or skip it and just run `docker compose up`.
 
@@ -169,7 +169,7 @@ ARM-only audio source using `edgecrush3r/tidal-connect` as base image (Raspbian 
 
 ## Conventions
 
-- **Docker images**: `lollonet/snapmulti-{server,airplay,mpd,metadata}:latest` (Docker Hub, built in CI) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `lollonet/snapmulti-tidal:latest` (ARM only)
+- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.0.2` (upstream) + `edgecrush3r/tidal-connect:latest` (ARM only, upstream)
 - **Multi-arch**: linux/amd64 (studio) + linux/arm64 (ci-runner-x86), native builds on self-hosted runners
 - **Config paths**: all config in `config/`, all scripts in `scripts/`, shared libs in `scripts/common/`
 - **Deployment**: tag push (`v*`) triggers build → manifest → deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ For a hardware report, include: Pi model + RAM, SD card model/class if known, PS
 
 ## Documentation
 
-Each topic has ONE authoritative file (full SSOT table in [CLAUDE.md](CLAUDE.md)). Don't duplicate content across docs.
+Each topic has ONE authoritative file. Don't duplicate content across docs.
 
 | File | Content |
 |------|---------|
@@ -67,7 +67,15 @@ By contributing, you agree your contributions are licensed under `GPL-3.0-only` 
 
 snapMULTI is currently maintained by a single principal maintainer (architectural decisions, code review, releases). PRs from external contributors go through CI gates (shellcheck, smoke gate per ADR-005, automated review) and a human review before merge. Dependabot PRs are admin-squash-merged after diff + release-notes review.
 
-The project is intentionally appliance-shaped — see the `## Non-goals` section in [CLAUDE.md](CLAUDE.md) for what we will NOT accept as scope. A "no" to a feature is not personal; it usually means the change belongs in a separate layer (the amp, Home Assistant, a custom snapclient deployment) rather than in snapMULTI itself.
+The project is intentionally appliance-shaped. A "no" to a feature is not personal; it usually means the change belongs in a separate layer (the amp, Home Assistant, a custom snapclient deployment) rather than in snapMULTI itself.
+
+### Non-goals
+
+- No hosted snapMULTI cloud or account system.
+- No commercial SLA or universal hardware support promise.
+- No public-WAN deployment without an operator-managed reverse proxy and authentication.
+- No in-place upgrade workflow for ordinary users; the supported path is reflash-first.
+- No broad plugin marketplace or arbitrary audio-stack configurator in the appliance core.
 
 ### Path to co-maintainership
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ For a hardware report, include: Pi model + RAM, SD card model/class if known, PS
 
 ## Documentation
 
-Each topic has ONE authoritative file. Don't duplicate content across docs.
+Each topic has ONE authoritative file (full SSOT table in [CLAUDE.md](CLAUDE.md)). Don't duplicate content across docs.
 
 | File | Content |
 |------|---------|
@@ -67,7 +67,7 @@ By contributing, you agree your contributions are licensed under `GPL-3.0-only` 
 
 snapMULTI is currently maintained by a single principal maintainer (architectural decisions, code review, releases). PRs from external contributors go through CI gates (shellcheck, smoke gate per ADR-005, automated review) and a human review before merge. Dependabot PRs are admin-squash-merged after diff + release-notes review.
 
-The project is intentionally appliance-shaped. A "no" to a feature is not personal; it usually means the change belongs in a separate layer (the amp, Home Assistant, a custom snapclient deployment) rather than in snapMULTI itself.
+The project is intentionally appliance-shaped — see the [`## Non-goals` section in CLAUDE.md](CLAUDE.md#non-goals) for the full list. A "no" to a feature is not personal; it usually means the change belongs in a separate layer (the amp, Home Assistant, a custom snapclient deployment) rather than in snapMULTI itself.
 
 ### Non-goals
 

--- a/README.it.md
+++ b/README.it.md
@@ -43,7 +43,7 @@ snapMULTI non è "Sonos open-source". È un'appliance mantenuta dalla community 
 
 ## Aspettative realistiche
 
-- **Tempo**: ~10–15 min dall'inserimento dell'SD al primo suono. Il primo boot installa via rete, poi si riavvia una volta.
+- **Tempo**: ~15-20 min su Pi 4/5 dall'inserimento dell'SD al primo suono; di più su Pi 3 o Pi Zero 2 W. Il primo boot installa via rete, poi si riavvia una volta.
 - **Livello richiesto**: devi sapere flashare un'SD con Raspberry Pi Imager, trovare il Pi tramite hostname (`.local`) o IP, e copiare un piccolo file dalla SD card se qualcosa va storto. **Non** ti serve conoscere Docker, systemd, ALSA o Snapcast — li gestisce snapMULTI.
 - **L'SD è importante**: le microSD economiche sono la prima causa di "install che si blocca". Usa una SanDisk / Samsung A1 (o migliore). Minimo 16 GB.
 - **Rete**: il 2,4 GHz funziona ma il 5 GHz o Ethernet sono più stabili.
@@ -59,7 +59,7 @@ Se è la tua prima installazione snapMULTI, scegli il percorso noioso: **Raspber
 - **Pi Zero 2 W** è supportato solo come Audio Player headless; non è un target server o "Server + Player".
 - **Path NAS con spazi** vengono rifiutati. Rinomina `Music Share` in `Music_Share` lato NAS.
 - **Tidal Connect** usa un componente proprietario upstream. È abilitato di default sugli install ARM; rimuovi `tidal` da `COMPOSE_PROFILES` in `/opt/snapmulti/.env` se vuoi uno stack interamente free software.
-- **Gli aggiornamenti sono reflash-first**. Il filesystem è read-only: aggiorni riscrivendo l'SD con una nuova release (~10 min, le impostazioni si auto-rilevano), non applicando patch a un sistema in esecuzione.
+- **Gli aggiornamenti sono reflash-first**. Il filesystem è read-only: aggiorni riscrivendo l'SD con una nuova release (~15-20 min su Pi 4/5, le impostazioni si auto-rilevano), non applicando patch a un sistema in esecuzione.
 - **La qualità hardware conta**. SD scadenti, alimentatori deboli e WiFi instabile causano la maggior parte dei fallimenti iniziali.
 
 ## Quick start
@@ -98,7 +98,7 @@ Lo script ti guida con poche domande: il ruolo (**Audio Player** / **Music Serve
 
 ### 4. Avvia il Pi
 
-Espelli l'SD, inseriscila nel Pi, accendi. Aspetta circa 10-15 minuti — l'installer al primo boot gira da solo (niente SSH), mostra l'avanzamento su HDMI se hai uno schermo collegato, poi si riavvia una volta.
+Espelli l'SD, inseriscila nel Pi, accendi. Aspetta circa 15-20 minuti su Pi 4/5 (di più su Pi 3 o Pi Zero 2 W) — l'installer al primo boot gira da solo (niente SSH), mostra l'avanzamento su HDMI se hai uno schermo collegato, poi si riavvia una volta.
 
 **Ha funzionato quando**: con uno schermo collegato, il display HDMI mostra la schermata "in riproduzione" di snapMULTI (copertina / spettro). In ogni caso, da un altro dispositivo apri `http://<hostname>.local:8083/`, poi apri **Status** — tutti i controlli devono essere verdi. Poi fai cast di qualcosa (vedi **Dopo l'installazione** più sotto).
 
@@ -133,7 +133,7 @@ O su qualsiasi Linux: `sudo apt install snapclient`.
 
 ## Aggiornamento
 
-snapMULTI si aggiorna riscrivendo l'SD, non applicando patch. Il Pi gira con un filesystem read-only (un blackout non può corromperlo), quindi non esiste un upgrade in-place: riscrivi l'ultima release sull'SD esattamente come la prima volta. Ci vogliono gli stessi ~10–15 min, e ogni impostazione (ruolo, HAT audio, path NAS, rete) si auto-rileva al primo boot, quindi non riconfiguri nulla.
+snapMULTI si aggiorna riscrivendo l'SD, non applicando patch. Il Pi gira con un filesystem read-only (un blackout non può corromperlo), quindi non esiste un upgrade in-place: riscrivi l'ultima release sull'SD esattamente come la prima volta. Ci vogliono gli stessi ~15-20 min su Pi 4/5, e ogni impostazione (ruolo, HAT audio, path NAS, rete) si auto-rileva al primo boot, quindi non riconfiguri nulla.
 
 Prima di riflashare, esegui `./scripts/backup-from-sd.sh` per conservare l'indice della libreria MPD — altrimenti la scansione della libreria riparte da zero.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ snapMULTI is not "open Sonos". It is a community-maintained appliance for people
 
 ## Realistic expectations
 
-- **Time**: ~10–15 min from inserting the SD to hearing audio. First boot does the install over the network, then reboots once.
+- **Time**: ~15-20 min on a Pi 4/5 from inserting the SD to hearing audio; longer on Pi 3 or Pi Zero 2 W. First boot does the install over the network, then reboots once.
 - **Skill floor**: you should be comfortable flashing an SD with Raspberry Pi Imager, finding your Pi by hostname (`.local`) or IP, and copying a small file off the SD card if something goes wrong. You do **not** need to know Docker, systemd, ALSA, or Snapcast — snapMULTI handles them.
 - **SD card matters**: cheap microSDs are the #1 cause of "install hangs". Use a SanDisk / Samsung A1 (or better). 16 GB is the minimum.
 - **Network**: 2.4 GHz works but 5 GHz or Ethernet is more stable.
@@ -133,7 +133,7 @@ Or any Linux box: `sudo apt install snapclient`.
 
 ## Updating
 
-snapMULTI updates by re-flashing, not by patching. The Pi runs a read-only filesystem (a power cut can't corrupt it), so there is no in-place upgrade — you write the latest release onto the SD again, exactly like the first time. It takes the same ~10–15 min, and every setting (role, audio HAT, NAS path, network) is auto-detected on first boot, so you reconfigure nothing.
+snapMULTI updates by re-flashing, not by patching. The Pi runs a read-only filesystem (a power cut can't corrupt it), so there is no in-place upgrade — you write the latest release onto the SD again, exactly like the first time. It takes the same ~15-20 min on a Pi 4/5, and every setting (role, audio HAT, NAS path, network) is auto-detected on first boot, so you reconfigure nothing.
 
 Before re-flashing, run `./scripts/backup-from-sd.sh` to preserve your MPD music index — otherwise the library re-scan starts from scratch.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ snapMULTI is designed for **home/prosumer networks** behind a firewall:
 
 - **Containers**: `cap_drop: ALL` with minimal capabilities, `read_only: true`, `no-new-privileges`
 - **Network**: Host networking for low-latency audio; not designed for public-facing deployment
-- **Filesystem**: Optional read-only root via overlayroot (protects SD card from corruption)
+- **Filesystem**: Read-only root via overlayroot is enabled by default on Pi installs (protects SD card from corruption) and can be disabled for maintenance.
 - **Secrets**: SMB credentials stored in `/etc/snapmulti-smb-credentials` (mode 600), referenced by a systemd `.mount` unit in `/etc/systemd/system/`; NFS uses host-based auth
 - **Updates**: Docker images built in CI on GitHub Actions, published multi-arch (amd64 + arm64) to Docker Hub. Image signing (cosign / sigstore) is not yet implemented — track via SECURITY advisories if integrity attestation is required for your deployment. Full upgrades use the reflash path ([DEC-003](docs/decisions/DEC-003-reflash-only-updates.md))
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -33,7 +33,7 @@ recipe.
 - Project: <https://github.com/jcorporation/myMPD>
 - Author: jcorporation
 - License: GPL-2.0-or-later
-- Version: upstream `ghcr.io/jcorporation/mympd/mympd:latest` (image used as-is,
+- Version: upstream `ghcr.io/jcorporation/mympd/mympd:25.0.2` (image used as-is,
   not rebuilt by snapMULTI)
 
 ## Streaming sources
@@ -52,7 +52,7 @@ recipe.
 - Project: <https://github.com/devgianlu/go-librespot>
 - Author: devgianlu
 - License: LGPL-3.0
-- Version pinned: `v0.7.1` (`ghcr.io/devgianlu/go-librespot:v0.7.1` in
+- Version pinned: `v0.7.3` (`ghcr.io/devgianlu/go-librespot:v0.7.3` in
   `docker-compose.yml`, image used as-is, not rebuilt)
 - Note: Spotify Connect protocol is reverse-engineered; snapMULTI does not
   bundle any Spotify proprietary code

--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -125,7 +125,7 @@ nano .env                          # come minimo: PUID/PGID, MUSIC_PATH, MUSIC_S
 sudo docker compose up -d
 ```
 
-Il push di un tag (`v*`) innesca la build multi-arch in CI (runner nativi amd64 + arm64) → Docker Hub `:latest`. Riflasha per prendere le nuove immagini.
+Riflasha con l'ultima release per prendere il manifest di release e qualsiasi cambio di set di immagini. Le release di soli script riusano il set di immagini esistente; le release che cambiano container pubblicano un nuovo set di immagini fissato tramite CI.
 
 ## MPD da riga di comando
 
@@ -174,20 +174,20 @@ Riflashare per primo è il default del progetto ([DEC-003](decisions/DEC-003-ref
 
 Dopo ogni reflash o aggiornamento in-place, esegui il test di salute sul device per confermare che la piattaforma sia tornata sana: `sudo bash /opt/snapmulti/scripts/device-smoke.sh --server` (oppure `--client` / `--both`). È lo stesso release gate (ADR-005) che `fleet-smoke.sh` esegue su più device. Descrizione completa in [TROUBLESHOOTING.it.md — Prima cosa da fare](TROUBLESHOOTING.it.md#prima-cosa-da-fare--esegui-il-test-di-salute).
 
-## Strategia release & pinning image-set
+## Strategia release e set di immagini fissato
 
 > Razionale architetturale: [ADR-006](adr/ADR-006.release-identity-script-only-patches.md).
 
 snapMULTI separa due concetti di versione, così una release di soli script (CHANGELOG, docs, fix nell'installer) non costringe a ricostruire e ripubblicare le immagini Docker:
 
-- **`SNAPMULTI_RELEASE`** — il tag git della release (es. `v0.7.8.16`). Quello che `gh release view` mostra.
+- **`SNAPMULTI_RELEASE`** — il tag git della release (es. `v0.7.9.6`). Quello che `gh release view` mostra.
 - **`SNAPMULTI_IMAGE_SET`** — il tag Docker delle immagini a cui la release si aggancia (es. `0.7.7`). Quello che `docker compose pull` scarica.
 
 La maggior parte delle release incrementa entrambi. Una release di soli script incrementa `SNAPMULTI_RELEASE` e mantiene `SNAPMULTI_IMAGE_SET` all'ultimo valore pubblicato. La fonte di verità è `release-manifest.json` alla radice del repo, copiato sulla SD da `prepare-sd.sh`.
 
 ### Catena di precedenza
 
-Da v0.7.8.10 (consolidamento SSOT), `install.conf` non porta più la release identity — `release-manifest.json` sulla SD è l'unica fonte. `IMAGE_TAG` resta in `install.conf` come unico legittimo operator override.
+Da v0.7.8.10 (consolidamento SSOT), `install.conf` non porta più l'identità della release — `release-manifest.json` sulla SD è l'unica fonte. `IMAGE_TAG` resta in `install.conf` come unico override operatore legittimo.
 
 - **`SNAPMULTI_RELEASE`** = `manifest snapmulti_release` > `""`
 - **`SNAPMULTI_IMAGE_SET`** = `manifest image_set` > `""`
@@ -228,7 +228,7 @@ Riprodotta in `tests/test_firstboot_image_tag_derivation.sh`.
 
 ### Override d'emergenza — `force_rebuild`
 
-Se l'image-set pubblicato su Docker Hub è mancante o corrotto (CVE di sicurezza in un'immagine base, cancellazione accidentale di un tag, incidente su GitHub Container Registry), lancia `build-push.yml` a mano con `force_rebuild=true`:
+Se il set di immagini pubblicato su Docker Hub è mancante o corrotto (CVE di sicurezza in un'immagine base, cancellazione accidentale di un tag, incidente su GitHub Container Registry), lancia `build-push.yml` a mano con `force_rebuild=true`:
 
 ```text
 GitHub → Actions → Build and Push Images → Run workflow
@@ -241,7 +241,7 @@ Il gate bypassa sia `requires_image_rebuild=false` sia il check di esistenza su 
 
 Dopo deploy / reflash:
 
-- Riga info del test di salute: `device-smoke.sh` → sezione `System` → `Release v0.7.8.16 (images 0.7.7)`
+- Riga info del test di salute: `device-smoke.sh` → sezione `System` → `Release v0.7.9.6 (images 0.7.7)`
 - Pacchetto diagnostico: `scripts/diagnostic.sh` produce `meta.txt` con `snapmulti_release=...` e `snapmulti_image_set=...`; il pacchetto include anche il `release-manifest.json` (scrubbato) dalla partizione di boot.
 - `.env` del server: `grep ^SNAPMULTI_ /opt/snapmulti/.env`
 - `.env` del client: `grep ^SNAPMULTI_ /opt/snapclient/.env`

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -125,7 +125,7 @@ nano .env                          # at minimum: PUID/PGID, MUSIC_PATH, MUSIC_SO
 sudo docker compose up -d
 ```
 
-Tag push (`v*`) triggers CI multi-arch builds (amd64 + arm64 native runners) → Docker Hub `:latest`. Reflash to pick up the new images.
+Reflash with the latest release to pick up the release manifest and any image-set change. Script-only releases reuse the existing Docker image set; container-changing releases publish a new pinned image set through CI.
 
 ## MPD from the command line
 
@@ -180,7 +180,7 @@ After every reflash or in-place update, run the smoke test on the device to conf
 
 snapMULTI separates two version concepts so a script-only release (CHANGELOG, docs, installer fixes) does not force a Docker image rebuild + repush:
 
-- **`SNAPMULTI_RELEASE`** — the git tag of the release (e.g. `v0.7.8.16`). What `gh release view` shows.
+- **`SNAPMULTI_RELEASE`** — the git tag of the release (e.g. `v0.7.9.6`). What `gh release view` shows.
 - **`SNAPMULTI_IMAGE_SET`** — the Docker image tag the release pins to (e.g. `0.7.7`). What `docker compose pull` fetches.
 
 Most releases bump both. A script-only release bumps `SNAPMULTI_RELEASE` and keeps `SNAPMULTI_IMAGE_SET` at the last published value. The source of truth is `release-manifest.json` at the repo root, staged onto the SD by `prepare-sd.sh`.
@@ -241,7 +241,7 @@ The gate bypasses both `requires_image_rebuild=false` and the Docker Hub existen
 
 After a deploy / reflash:
 
-- Smoke test info line: `device-smoke.sh` → `System` section → `Release v0.7.8.16 (images 0.7.7)`
+- Smoke test info line: `device-smoke.sh` → `System` section → `Release v0.7.9.6 (images 0.7.7)`
 - Diagnostic bundle: `scripts/diagnostic.sh` produces `meta.txt` with `snapmulti_release=...` and `snapmulti_image_set=...`; the bundle also includes the scrubbed `release-manifest.json` from the boot partition.
 - Server `.env`: `grep ^SNAPMULTI_ /opt/snapmulti/.env`
 - Client `.env`: `grep ^SNAPMULTI_ /opt/snapclient/.env`

--- a/docs/CLIENT-METADATA.it.md
+++ b/docs/CLIENT-METADATA.it.md
@@ -151,7 +151,7 @@ Stessa URL significa stessi bytes. Se l'artwork cambia, cambia anche la URL.
 Ordine di fallback:
 
 ```
-artwork -> artist_image -> placeholder bundled
+artwork -> artist_image -> placeholder incluso
 ```
 
 Su 404 per un artwork, trattalo come transiente: riprova una volta dopo

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -155,10 +155,13 @@ Dettagli:
 
 snapMULTI usa **Docker Compose per il deploy dei client** tramite la directory [client](../client/). Questo fornisce uno stack autocontenuto che include snapclient, display copertine e visualizzatore audio — tutto gestito insieme.
 
-Lo stack Docker client esegue tre container:
-- `lollonet/snapclient-pi:latest` — Player audio Snapcast
-- `lollonet/snapclient-pi-fb-display:latest` — Display copertine (framebuffer)
-- `lollonet/snapclient-pi-visualizer:latest` — Visualizzatore audio
+Lo stack Docker client esegue tre container dal set di immagini fissato della release:
+
+- `lollonet/snapclient-pi:<image-set>` — Player audio Snapcast
+- `lollonet/snapclient-pi-fb-display:<image-set>` — Display copertine (framebuffer)
+- `lollonet/snapclient-pi-visualizer:<image-set>` — Visualizzatore audio
+
+`<image-set>` arriva da `release-manifest.json`. Le release di soli script possono riusare lo stesso set di immagini; le release che cambiano container pubblicano un nuovo set di immagini fissato. Non usare `latest` per installazioni appliance riproducibili.
 
 Vedi [README.md](../README.md) per la procedura di installazione completa (percorso SD card o manuale).
 
@@ -250,21 +253,21 @@ Configurazione del firewall (regole `ufw`) e setup QoS / `cake` qdisc sono docum
 
 | Immagine | Dimensione |
 |----------|------------|
-| `lollonet/snapmulti-server:latest` | ~80–120 MB |
-| `lollonet/snapmulti-airplay:latest` | ~30–50 MB |
+| `lollonet/snapmulti-server:<image-set>` | ~80–120 MB |
+| `lollonet/snapmulti-airplay:<image-set>` | ~30–50 MB |
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
-| `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
-| `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
+| `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
+| `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
 | `ghcr.io/jcorporation/mympd/mympd:25.0.2` | ~30–50 MB |
-| `lollonet/snapmulti-tidal:latest` | ~200–300 MB |
+| `lollonet/snapmulti-tidal:<image-set>` | ~200–300 MB |
 
 **Immagini client** (dalla directory [client](../client/)):
 
 | Immagine | Dimensione |
 |----------|------------|
-| `lollonet/snapclient-pi:latest` | ~30–50 MB |
-| `lollonet/snapclient-pi-fb-display:latest` | ~80–120 MB |
-| `lollonet/snapclient-pi-visualizer:latest` | ~50–80 MB |
+| `lollonet/snapclient-pi:<image-set>` | ~30–50 MB |
+| `lollonet/snapclient-pi-fb-display:<image-set>` | ~80–120 MB |
+| `lollonet/snapclient-pi-visualizer:<image-set>` | ~50–80 MB |
 
 ### Libreria Musicale
 
@@ -314,7 +317,7 @@ Se un nodo è collegato a un ricevitore AV via cavo ottico, usa HiFiBerry Digi+ 
 
 ## Combinazioni Testate
 
-Queste combinazioni hardware sono state verificate end-to-end (firstboot → test di salute → playback audio) nelle date indicate. Considera questa tabella la fonte di verità per l'hardware validato al lancio. Il batch del 2026-04-27 è la validazione release-gate per v0.6.x: 6 device riflashati da `main`, test di salute PASS su ognuno, `hw_ptr` ALSA che avanza durante la riproduzione (audio che raggiunge davvero il DAC, non solo la FIFO).
+Queste combinazioni hardware sono state verificate end-to-end (firstboot → test di salute → playback audio) nelle date indicate. Considera questa tabella la fonte di verità per l'hardware validato al lancio. La tabella registra la validazione hardware, non l'ultimo gate di release; la confidenza sulla release corrente viene dai test smoke device/fleet descritti nel changelog e nelle release notes. Il batch del 2026-04-27 è stata la validazione hardware v0.6.x: 6 device riflashati da `main`, test di salute PASS su ognuno, `hw_ptr` ALSA che avanza durante la riproduzione (audio che raggiunge davvero il DAC, non solo la FIFO).
 
 | Hostname | Modello Pi | HAT Audio | Chip DAC | Modalità | Display | Sorgente Musica | Validato | Stato |
 |---|---|---|---|---|---|---|---|---|

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -155,10 +155,13 @@ Detail:
 
 snapMULTI uses **Docker Compose for client deployment** via the [client](../client/) directory. This provides a self-contained stack including snapclient, cover art display, and audio visualizer — all managed together.
 
-The client Docker stack runs three containers:
-- `lollonet/snapclient-pi:latest` — Snapcast audio player
-- `lollonet/snapclient-pi-fb-display:latest` — Cover art display (framebuffer)
-- `lollonet/snapclient-pi-visualizer:latest` — Audio visualizer
+The client Docker stack runs three containers from the pinned release image set:
+
+- `lollonet/snapclient-pi:<image-set>` — Snapcast audio player
+- `lollonet/snapclient-pi-fb-display:<image-set>` — Cover art display (framebuffer)
+- `lollonet/snapclient-pi-visualizer:<image-set>` — Audio visualizer
+
+`<image-set>` comes from `release-manifest.json`. Script-only releases can reuse the same image set; container-changing releases publish a new pinned image set. Do not use `latest` for reproducible appliance installs.
 
 See [README.md](../README.md) for the full installation procedure (SD card path or manual).
 
@@ -250,21 +253,21 @@ Firewall configuration (`ufw` rules) and QoS / `cake` qdisc setup are documented
 
 | Image | Size |
 |-------|------|
-| `lollonet/snapmulti-server:latest` | ~80–120 MB |
-| `lollonet/snapmulti-airplay:latest` | ~30–50 MB |
+| `lollonet/snapmulti-server:<image-set>` | ~80–120 MB |
+| `lollonet/snapmulti-airplay:<image-set>` | ~30–50 MB |
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
-| `lollonet/snapmulti-mpd:latest` | ~50–80 MB |
-| `lollonet/snapmulti-metadata:latest` | ~60–80 MB |
+| `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
+| `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
 | `ghcr.io/jcorporation/mympd/mympd:25.0.2` | ~30–50 MB |
-| `lollonet/snapmulti-tidal:latest` | ~200–300 MB |
+| `lollonet/snapmulti-tidal:<image-set>` | ~200–300 MB |
 
 **Client images** (from [client](../client/) directory):
 
 | Image | Size |
 |-------|------|
-| `lollonet/snapclient-pi:latest` | ~30–50 MB |
-| `lollonet/snapclient-pi-fb-display:latest` | ~80–120 MB |
-| `lollonet/snapclient-pi-visualizer:latest` | ~50–80 MB |
+| `lollonet/snapclient-pi:<image-set>` | ~30–50 MB |
+| `lollonet/snapclient-pi-fb-display:<image-set>` | ~80–120 MB |
+| `lollonet/snapclient-pi-visualizer:<image-set>` | ~50–80 MB |
 
 ### Music Library
 
@@ -314,7 +317,7 @@ If a node connects to an AV receiver via optical cable, use HiFiBerry Digi+ inst
 
 ## Tested Combinations
 
-These hardware combinations have been verified end-to-end (firstboot → smoke test → audio playback) on the dates indicated. Treat this table as the source of truth for launch-validated hardware. The 2026-04-27 batch was the v0.6.x release-gate validation: 6 devices reflashed from `main`, smoke test PASS on each, ALSA `hw_ptr` advancing during playback (audio actually reaching the DAC, not just the FIFO).
+These hardware combinations have been verified end-to-end (firstboot → smoke test → audio playback) on the dates indicated. Treat this table as the source of truth for launch-validated hardware. This table records hardware validation, not the latest release gate; release-level confidence comes from the current device/fleet smoke runs described in the changelog and release notes. The 2026-04-27 batch was the v0.6.x hardware validation run: 6 devices reflashed from `main`, smoke test PASS on each, ALSA `hw_ptr` advancing during playback (audio actually reaching the DAC, not just the FIFO).
 
 | Hostname | Pi Model | Audio HAT | DAC chip | Mode | Display | Music Source | Validated | Status |
 |---|---|---|---|---|---|---|---|---|

--- a/docs/INSTALL.it.md
+++ b/docs/INSTALL.it.md
@@ -328,7 +328,7 @@ Dovresti vedere **"All checks passed."** e **"SD card ready!"** alla fine.
 1. **Rimuovi la scheda SD** dal tuo computer
 2. Inseriscila nel Pi
 3. Collega l'alimentazione
-4. **Aspetta ~10–15 minuti** — il Pi installa Docker, scarica le immagini, avvia tutti i servizi, li verifica e poi riavvia una volta
+4. **Aspetta ~15-20 minuti su Pi 4/5** — di più su Pi 3 o Pi Zero 2 W. Il Pi installa Docker, scarica le immagini, avvia tutti i servizi, li verifica e poi riavvia una volta
 
 ### Cosa vedrai sull'HDMI
 
@@ -347,7 +347,7 @@ snapMULTI Auto-Install
 
 Il Pi **si riavvia automaticamente** quando l'installazione è completa. Dopo il riavvio, il display diventa scuro (normale — nessun desktop su Lite OS).
 
-> Se l'HDMI rimane nero per tutto il tempo: l'installazione continua comunque in background — `firstboot.sh` gira come servizio systemd e non ha bisogno del display. **Il LED verde ACT del Pi lampeggerà in modo irregolare per tutti i 10–15 minuti — è attività sulla scheda SD, il tuo segnale che l'install sta procedendo.** Aspetta tutta la finestra; per controllare lo stato senza schermo, fai `ssh <username>@<hostname>.local` ed esegui `sudo journalctl -u snapmulti-firstboot.service -f`.
+> Se l'HDMI rimane nero per tutto il tempo: l'installazione continua comunque in background — `firstboot.sh` gira come servizio systemd e non ha bisogno del display. **Il LED verde ACT del Pi lampeggerà in modo irregolare durante la finestra di 15-20 minuti su Pi 4/5 — è attività sulla scheda SD, il tuo segnale che l'install sta procedendo.** Aspetta tutta la finestra; per controllare lo stato senza schermo, fai `ssh <username>@<hostname>.local` ed esegui `sudo journalctl -u snapmulti-firstboot.service -f`.
 
 ### Cosa sentirai
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -326,7 +326,7 @@ You should see **"All checks passed."** and **"SD card ready!"** at the end.
 1. **Remove the SD card** from your computer
 2. Insert it into the Pi
 3. Connect power
-4. **Wait ~10–15 minutes** — the Pi installs Docker, pulls images, starts all services, verifies them, then reboots once
+4. **Wait ~15-20 minutes on a Pi 4/5** — longer on Pi 3 or Pi Zero 2 W. The Pi installs Docker, pulls images, starts all services, verifies them, then reboots once
 
 ### What you'll see on HDMI
 
@@ -345,7 +345,7 @@ snapMULTI Auto-Install
 
 The Pi **reboots automatically** when installation is complete. After the reboot, the display goes dark (normal — no desktop on Lite OS).
 
-> If the HDMI stays blank throughout: the installation is still running in the background — `firstboot.sh` is a systemd service that does not need a display. **The green ACT LED on the Pi will flash irregularly throughout the 10–15 min — that's SD-card activity, your sign the install is making progress.** Wait the full window; to check progress without a screen, `ssh <username>@<hostname>.local` and run `sudo journalctl -u snapmulti-firstboot.service -f`.
+> If the HDMI stays blank throughout: the installation is still running in the background — `firstboot.sh` is a systemd service that does not need a display. **The green ACT LED on the Pi will flash irregularly throughout the 15-20 min Pi 4/5 window — that's SD-card activity, your sign the install is making progress.** Wait the full window; to check progress without a screen, `ssh <username>@<hostname>.local` and run `sudo journalctl -u snapmulti-firstboot.service -f`.
 
 ### What you'll hear
 

--- a/docs/TROUBLESHOOTING.it.md
+++ b/docs/TROUBLESHOOTING.it.md
@@ -64,7 +64,7 @@ I segnali si attivano anche automaticamente dopo ogni boot (`snapmulti-auto-boot
 **Causa probabile.** Il primo boot sta scaricando le immagini container dalla rete (la parte lenta, 2–6 minuti su WiFi domestico tipico). Anche le SD economiche / contraffatte sembrano "appendersi" — in realtà l'install sta aspettando il throughput in scrittura della SD.
 
 **Cosa provare.**
-1. Aspetta i 10–15 minuti completi prima di sospettare un problema — l'install gira come `cloud-init` → `snapmulti-firstboot.service`, entrambi headless.
+1. Aspetta tutti i 15-20 minuti su Pi 4/5 prima di sospettare un problema — di più su Pi 3 o Pi Zero 2 W. L'install gira come `cloud-init` → `snapmulti-firstboot.service`, entrambi headless.
 2. Dal laptop: `ping <hostname>.local`. Se risponde, la rete è OK.
 3. Se SSH funziona: `ssh <username>@<hostname>.local`, poi `sudo journalctl -u snapmulti-firstboot.service -f` per vedere l'install in tempo reale.
 
@@ -95,7 +95,7 @@ I segnali si attivano anche automaticamente dopo ogni boot (`snapmulti-auto-boot
 2. Da lì: `sudo ro-mode disable && sudo reboot` se servono modifiche persistenti (vedi [ADVANCED.it.md — Filesystem read-only](ADVANCED.it.md#filesystem-read-only)).
 3. Se il Pi non arriva mai al login: estrai la SD, apri la **partizione boot** sul laptop, modifica `user-data` per resettare le credenziali, reinserisci e accendi.
 
-**Se è ancora bloccato.** Riflasha con Imager — snapMULTI è reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)), e l'install dura solo 10–15 min. Fai prima un backup di `/opt/snapmulti/mpd.db` con `scripts/backup-from-sd.sh` se vuoi preservare l'indice della libreria musicale.
+**Se è ancora bloccato.** Riflasha con Imager — snapMULTI è reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)), e l'install dura circa 15-20 min su Pi 4/5. Fai prima un backup di `/opt/snapmulti/mpd.db` con `scripts/backup-from-sd.sh` se vuoi preservare l'indice della libreria musicale.
 
 ## Niente audio
 
@@ -164,7 +164,7 @@ I segnali si attivano anche automaticamente dopo ogni boot (`snapmulti-auto-boot
 3. Verifica che il path non abbia **spazi** lato NAS. Rinomina `Music Share` → `Music_Share`.
 4. Per SMB, le credenziali persistenti vivono in `/etc/snapmulti-smb-credentials` (root-only, su ext4). Vengono scritte anche dentro `install.conf` sulla partizione FAT32 di boot durante `prepare-sd.sh` e `firstboot.sh`, poi rimosse una volta che `mount-music` le ha copiate in `/etc/snapmulti-smb-credentials`.
 
-**Se è ancora bloccato.** Riflasha l'SD con il path NAS corretto — snapMULTI è reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)) e un install fresco dura solo 10–15 min. È possibile un recupero manuale senza reflash, ma non è ufficialmente supportato; richiede di modificare a mano `/etc/snapmulti-smb-credentials` e le unit systemd `.mount`/`.automount`. La scansione MPD su NFS è lenta alla prima esecuzione — vedi [ADVANCED.it.md — Libreria musicale](ADVANCED.it.md#libreria-musicale-in-rete) per il trucco del backup `mpd.db`.
+**Se è ancora bloccato.** Riflasha l'SD con il path NAS corretto — snapMULTI è reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)) e un install fresco dura circa 15-20 min su Pi 4/5. È possibile un recupero manuale senza reflash, ma non è ufficialmente supportato; richiede di modificare a mano `/etc/snapmulti-smb-credentials` e le unit systemd `.mount`/`.automount`. La scansione MPD su NFS è lenta alla prima esecuzione — vedi [ADVANCED.it.md — Libreria musicale](ADVANCED.it.md#libreria-musicale-in-rete) per il trucco del backup `mpd.db`.
 
 ## Install marcato fallito ma i container girano <a id="install-marcato-fallito-ma-i-container-girano"></a>
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -64,7 +64,7 @@ The cues also fire automatically after every boot (`snapmulti-auto-boot-smoke.se
 **Likely cause.** First boot is downloading container images over the network (the slow part, 2–6 minutes on typical home WiFi). Cheap / counterfeit SD cards also cause apparent "hangs" — the install is actually waiting on SD write throughput.
 
 **Try this.**
-1. Wait the full 10–15 minutes before assuming a problem — the install runs `cloud-init` → `snapmulti-firstboot.service`, both headless.
+1. Wait the full 15-20 minutes on a Pi 4/5 before assuming a problem — longer on Pi 3 or Pi Zero 2 W. The install runs `cloud-init` → `snapmulti-firstboot.service`, both headless.
 2. From your laptop: `ping <hostname>.local`. If it answers, the network side is up.
 3. If SSH works: `ssh <username>@<hostname>.local`, then `sudo journalctl -u snapmulti-firstboot.service -f` to watch the install in real time.
 
@@ -95,7 +95,7 @@ The cues also fire automatically after every boot (`snapmulti-auto-boot-smoke.se
 2. From there: `sudo ro-mode disable && sudo reboot` if you need persistent changes (see [ADVANCED.md — Read-only filesystem](ADVANCED.md#read-only-filesystem)).
 3. If the Pi never gets to a login prompt: pull the SD, open the **boot partition** on your laptop, edit `user-data` to reset credentials, re-insert and boot.
 
-**If still broken.** Reflash with Imager — snapMULTI is reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)), and the install only takes 10–15 min. Back up `/opt/snapmulti/mpd.db` first with `scripts/backup-from-sd.sh` if you want to preserve the music library index.
+**If still broken.** Reflash with Imager — snapMULTI is reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)), and the install takes about 15-20 min on a Pi 4/5. Back up `/opt/snapmulti/mpd.db` first with `scripts/backup-from-sd.sh` if you want to preserve the music library index.
 
 ## No audio
 
@@ -164,7 +164,7 @@ The cues also fire automatically after every boot (`snapmulti-auto-boot-smoke.se
 3. Check the path has **no spaces** on the NAS side. Rename `Music Share` → `Music_Share`.
 4. For SMB, the persistent credentials live in `/etc/snapmulti-smb-credentials` (root-only, on ext4). They are also written into `install.conf` on the FAT32 boot partition during `prepare-sd.sh` and `firstboot.sh`, then scrubbed once `mount-music` has copied them to `/etc/snapmulti-smb-credentials`.
 
-**If still broken.** Reflash the SD with the corrected NAS path — snapMULTI is reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)) and a fresh install only takes 10–15 min. Manual recovery without reflash is possible but not officially supported; it requires editing `/etc/snapmulti-smb-credentials` and the systemd `.mount`/`.automount` units by hand. MPD library scan over NFS is slow on the first run — see [ADVANCED.md — Music library](ADVANCED.md#music-library-on-the-network) for the `mpd.db` backup trick.
+**If still broken.** Reflash the SD with the corrected NAS path — snapMULTI is reflash-first by design ([DEC-003](decisions/DEC-003-reflash-only-updates.md)) and a fresh install takes about 15-20 min on a Pi 4/5. Manual recovery without reflash is possible but not officially supported; it requires editing `/etc/snapmulti-smb-credentials` and the systemd `.mount`/`.automount` units by hand. MPD library scan over NFS is slow on the first run — see [ADVANCED.md — Music library](ADVANCED.md#music-library-on-the-network) for the `mpd.db` backup trick.
 
 ## Install marked failed but containers run <a id="install-marked-failed-but-containers-run"></a>
 

--- a/docs/adr/ADR-INDEX.md
+++ b/docs/adr/ADR-INDEX.md
@@ -15,4 +15,5 @@ source_of_truth: true
 | ADR-004 | [Centralized Metadata Service](ADR-004.metadata-architecture.md) | Accepted | 2026-02-19 |
 | ADR-005 | [Reflash-Only, systemd Lifecycle, Robustness-First](ADR-005.reflash-systemd-robustness.md) | Accepted | 2026-04-22 |
 | ADR-006 | [Release Identity & Script-Only Patches](ADR-006.release-identity-script-only-patches.md) | Accepted | 2026-05-26 |
-| ADR-007 | [IPv4-Only LAN Appliance](ADR-007.ipv4-only-lan-appliance.md) | Accepted | 2026-05-28 |
+| ADR-007 | [IPv4-Only LAN Appliance](ADR-007.ipv4-only-lan-appliance.md) | Superseded by ADR-008 | 2026-05-28 |
+| ADR-008 | [IPv6 Enabled by Default](ADR-008.ipv6-default-on.md) | Accepted | 2026-05-29 |


### PR DESCRIPTION
## Why

Tail-end sweep across the doc tree: catches doc occurrences that previous PRs (#556 install-time, prior image-set work, #558 ADR-008) missed, normalises Docker image references away from `:latest`, refreshes upstream pins, and registers ADR-008 in the index.

## What

| Area | Change |
|------|--------|
| Install times | Residual `~10-15 min` → `~15-20 min Pi 4/5` (longer on Pi 3 / Pi Zero 2 W). Touched TROUBLESHOOTING, ADVANCED, CLAUDE, README + IT mirrors. |
| Image references | `lollonet/snapmulti-*:latest` and `lollonet/snapclient-pi*:latest` → `:<image-set>` from `release-manifest.json` across HARDWARE.md/it + CLAUDE.md. |
| Upstream pins | THIRD-PARTY-NOTICES.md: `go-librespot v0.7.1 → v0.7.3`; mympd pinned `25.0.2`. |
| CONTRIBUTING.md | Drops forward-ref to CLAUDE.md (which is internal); inlines a short Non-goals section for external contributors. |
| SECURITY.md | overlayroot wording: `Optional` → `enabled by default on Pi installs`. |
| HARDWARE.md/it Tested Combinations | Clarifies the table records hardware validation, not the latest release gate. |
| docs/adr/ADR-INDEX.md | Adds ADR-008; ADR-007 marked Superseded by ADR-008. |
| ADVANCED.md/it | Example version `v0.7.8.16 → v0.7.9.6`; deploy section re-worded around image-set pinning. |
| CLIENT-METADATA.it.md | Anglicism fix: `bundled` → `incluso`. |

## Validation

- Done locally: `grep` sweeps confirm no `10-15 min` / `:latest` / `v0.7.1` residue across docs; IT mirrors moved in lockstep with EN; ADR-INDEX.md status string consistent with ADR-008 front-matter.
- Deferred to release-gate: none (doc-only).