### PR TITLE
feat(status): add Resource Profile section to /status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/status` Resource Profile section** — new "Resource Profile" panel surfaces the active server profile (`minimal` / `standard` / `performance`) and the per-service memory limits (`SNAPSERVER_MEM_LIMIT`, `MPD_MEM_LIMIT`, etc.) `deploy.sh` wrote to `.env`. Env-driven (no subprocess, no file I/O): `deploy.sh` writes `SNAPMULTI_PROFILE=<name>` inside each `# Hardware Profile: BEGIN…END` block; `docker-compose.yml` propagates that plus the `*_MEM_LIMIT` set to the `metadata` container. Dev clones / manual `docker compose up` (where `SNAPMULTI_PROFILE` is empty) hide the section entirely. 8 new unit tests cover the env reader and renderer (XSS escaping on profile name and limit values).
+
 ### Changed
 - **ADR-008 supersedes ADR-007 — IPv6 enabled by default** (#557, #558). Tidal Connect now works out-of-box; software defenses (Avahi `use-ipv6=no`, snapclient IPv4 pin, fb-display filter, `boot-tune.sh`) cover the original races. Opt back into the kernel disable with `DISABLE_IPV6=true`. Validated live on snapvideo + pizero + snapdigi.
 - **HARDWARE.md reference builds replaced with qualitative sizing notes** (#559) — point-in-time `docker stats` tables removed; section now lists cost drivers, board floors, and sizing rules of thumb. Memory limits stay in ADVANCED.md (SSOT). Italian mirrored.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,7 +279,8 @@ services:
       - SNAPMULTI_IMAGE_SET=${SNAPMULTI_IMAGE_SET:-}
       # SNAPMULTI_PROFILE + per-service *_MEM_LIMIT propagate the active resource
       # profile to the /status "Resource profile" section. Empty defaults: dev
-      # clones / manual `docker compose up` without deploy.sh render "unknown".
+      # clones / manual `docker compose up` without deploy.sh hide the section
+      # entirely rather than showing a placeholder.
       - SNAPMULTI_PROFILE=${SNAPMULTI_PROFILE:-}
       - SNAPSERVER_MEM_LIMIT=${SNAPSERVER_MEM_LIMIT:-}
       - AIRPLAY_MEM_LIMIT=${AIRPLAY_MEM_LIMIT:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,6 +277,17 @@ services:
       # SNAPMULTI_RELEASE / SNAPMULTI_IMAGE_SET from .env let /version distinguish git tag from Docker tag; empty defaults so dev clones still start.
       - SNAPMULTI_RELEASE=${SNAPMULTI_RELEASE:-}
       - SNAPMULTI_IMAGE_SET=${SNAPMULTI_IMAGE_SET:-}
+      # SNAPMULTI_PROFILE + per-service *_MEM_LIMIT propagate the active resource
+      # profile to the /status "Resource profile" section. Empty defaults: dev
+      # clones / manual `docker compose up` without deploy.sh render "unknown".
+      - SNAPMULTI_PROFILE=${SNAPMULTI_PROFILE:-}
+      - SNAPSERVER_MEM_LIMIT=${SNAPSERVER_MEM_LIMIT:-}
+      - AIRPLAY_MEM_LIMIT=${AIRPLAY_MEM_LIMIT:-}
+      - SPOTIFY_MEM_LIMIT=${SPOTIFY_MEM_LIMIT:-}
+      - MPD_MEM_LIMIT=${MPD_MEM_LIMIT:-}
+      - MYMPD_MEM_LIMIT=${MYMPD_MEM_LIMIT:-}
+      - METADATA_MEM_LIMIT=${METADATA_MEM_LIMIT:-}
+      - TIDAL_MEM_LIMIT=${TIDAL_MEM_LIMIT:-}
     volumes:
       - ./artwork:/app/artwork
       # Bind-mount the renderer source so a fix lands without an image

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2386,6 +2386,68 @@ def _render_snapcast_clients_section(clients: list[dict] | None) -> str:
     )
 
 
+_PROFILE_SERVICE_LIMITS: tuple[tuple[str, str], ...] = (
+    ("snapserver", "SNAPSERVER_MEM_LIMIT"),
+    ("airplay", "AIRPLAY_MEM_LIMIT"),
+    ("spotify", "SPOTIFY_MEM_LIMIT"),
+    ("mpd", "MPD_MEM_LIMIT"),
+    ("mympd", "MYMPD_MEM_LIMIT"),
+    ("metadata", "METADATA_MEM_LIMIT"),
+    ("tidal", "TIDAL_MEM_LIMIT"),
+)
+
+
+def _get_resource_profile() -> dict | None:
+    """Active profile from env vars set by deploy.sh / docker-compose.yml.
+
+    Returns None when SNAPMULTI_PROFILE is empty (dev clone or manual
+    `docker compose up` without deploy.sh): the section is hidden entirely
+    rather than rendered with a misleading "unknown" placeholder.
+    """
+    name = os.environ.get("SNAPMULTI_PROFILE", "").strip()
+    if not name:
+        return None
+    limits: list[tuple[str, str]] = []
+    for label, var in _PROFILE_SERVICE_LIMITS:
+        value = os.environ.get(var, "").strip()
+        if value:
+            limits.append((label, value))
+    return {"name": name, "limits": limits}
+
+
+def _render_resource_profile_section(profile: dict | None) -> str:
+    """Render the Resource Profile section: name + per-service memory limits.
+
+    Empty string when profile is None — the page omits the section entirely
+    on dev clones. When the profile is set but no `*_MEM_LIMIT` env vars
+    propagated (older deploys / partial wiring), render the name alone with
+    an info row instead of an empty table.
+    """
+    import html
+
+    if profile is None:
+        return ""
+    name = html.escape(profile["name"])
+    limits: list[tuple[str, str]] = profile["limits"]
+    head = (
+        '<li class="r-pass"><span class="icon">✓</span>'
+        f"Active profile: <strong>{name}</strong></li>"
+    )
+    if not limits:
+        body = (
+            '<li class="r-info"><span class="icon">ℹ</span>'
+            "Per-service memory limits not propagated to this container."
+            "</li>"
+        )
+    else:
+        body = "".join(
+            '<li class="r-info"><span class="icon">·</span>'
+            f"{html.escape(svc)}: <code>{html.escape(lim)}</code></li>"
+            for svc, lim in limits
+        )
+    return f"<section><h2>Resource Profile</h2><ul>{head}{body}</ul></section>"
+
+
 def _read_status_snapshot() -> tuple[dict | None, float | None]:
     """Read the JSON snapshot file. Returns (data, age_seconds) or (None, None).
 
@@ -2666,6 +2728,13 @@ def _status_to_html(
     # already in the Compose / Snapcast sections.
     if show_snapclients:
         sec_html_parts.append(_render_snapcast_clients_section(snapclients))
+
+    # Resource profile — env-driven, no I/O. Section hides itself on dev
+    # clones where SNAPMULTI_PROFILE isn't set, so the page stays clean on
+    # manual `docker compose up` without deploy.sh.
+    profile_html = _render_resource_profile_section(_get_resource_profile())
+    if profile_html:
+        sec_html_parts.append(profile_html)
 
     if age_s is not None:
         if age_s < 60:

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -2423,8 +2423,6 @@ def _render_resource_profile_section(profile: dict | None) -> str:
     propagated (older deploys / partial wiring), render the name alone with
     an info row instead of an empty table.
     """
-    import html
-
     if profile is None:
         return ""
     name = html.escape(profile["name"])

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -199,6 +199,7 @@ apply_resource_profile() {
 # For: Pi Zero 2 W, Pi 3, systems with <2GB RAM
 # Measured baseline (idle): snapserver 87M, shairport 18M, librespot 22M,
 #   mpd 90M (6k songs), mympd 8M, metadata 52M, tidal 32M
+SNAPMULTI_PROFILE=minimal
 SNAPSERVER_MEM_LIMIT=128M
 SNAPSERVER_MEM_RESERVE=64M
 SNAPSERVER_CPU_LIMIT=0.5
@@ -236,6 +237,7 @@ EOF
 #   Headroom check: 1895 MB total RAM, sum of limits previously 1120 MB +
 #   200 MB host overhead = 1320 MB worst-case; raising MPD by 128 MB still
 #   leaves ~450 MB free in the worst case. Bumped to 384 MB for safety.
+SNAPMULTI_PROFILE=standard
 SNAPSERVER_MEM_LIMIT=192M
 SNAPSERVER_MEM_RESERVE=96M
 SNAPSERVER_CPU_LIMIT=1.0
@@ -268,6 +270,7 @@ EOF
 # For: Pi 4 4GB+, Pi 5, systems with 8GB+ RAM
 # Measured baseline (idle): snapserver 87M, shairport 18M, librespot 22M,
 #   mpd 90M (6k songs), mympd 8M, metadata 52M, tidal 32M
+SNAPMULTI_PROFILE=performance
 SNAPSERVER_MEM_LIMIT=256M
 SNAPSERVER_MEM_RESERVE=128M
 SNAPSERVER_CPU_LIMIT=2.0

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -451,6 +451,87 @@ class TestSnapcastClientsRender:
         assert "&lt;script&gt;" in html_str
 
 
+class TestResourceProfile:
+    """`_get_resource_profile()` + `_render_resource_profile_section()` — env-driven,
+    pure functions. Tests pin: (a) hide on dev clones; (b) name-only when limits
+    missing; (c) full table when limits propagated; (d) XSS defence on env values
+    (in case a malicious .env lands on a device — same hardening as other sections).
+    """
+
+    def test_empty_env_returns_none(self, metadata_service_module, monkeypatch):
+        monkeypatch.delenv("SNAPMULTI_PROFILE", raising=False)
+        assert metadata_service_module._get_resource_profile() is None
+
+    def test_whitespace_only_env_returns_none(
+        self, metadata_service_module, monkeypatch
+    ):
+        monkeypatch.setenv("SNAPMULTI_PROFILE", "   ")
+        assert metadata_service_module._get_resource_profile() is None
+
+    def test_name_only_when_limits_missing(self, metadata_service_module, monkeypatch):
+        monkeypatch.setenv("SNAPMULTI_PROFILE", "standard")
+        for _, var in metadata_service_module._PROFILE_SERVICE_LIMITS:
+            monkeypatch.delenv(var, raising=False)
+        profile = metadata_service_module._get_resource_profile()
+        assert profile == {"name": "standard", "limits": []}
+
+    def test_full_propagation_yields_ordered_limits(
+        self, metadata_service_module, monkeypatch
+    ):
+        monkeypatch.setenv("SNAPMULTI_PROFILE", "performance")
+        monkeypatch.setenv("SNAPSERVER_MEM_LIMIT", "256M")
+        monkeypatch.setenv("MPD_MEM_LIMIT", "384M")
+        monkeypatch.setenv("METADATA_MEM_LIMIT", "128M")
+        for _, var in metadata_service_module._PROFILE_SERVICE_LIMITS:
+            if var not in {"SNAPSERVER_MEM_LIMIT", "MPD_MEM_LIMIT", "METADATA_MEM_LIMIT"}:
+                monkeypatch.delenv(var, raising=False)
+        profile = metadata_service_module._get_resource_profile()
+        assert profile is not None
+        # Order follows _PROFILE_SERVICE_LIMITS (snapserver before mpd before metadata),
+        # not the order env vars were set in.
+        assert profile["limits"] == [
+            ("snapserver", "256M"),
+            ("mpd", "384M"),
+            ("metadata", "128M"),
+        ]
+
+    def test_render_none_yields_empty_string(self, metadata_service_module):
+        assert metadata_service_module._render_resource_profile_section(None) == ""
+
+    def test_render_name_only_uses_info_row(self, metadata_service_module):
+        html_str = metadata_service_module._render_resource_profile_section(
+            {"name": "minimal", "limits": []}
+        )
+        assert "<h2>Resource Profile</h2>" in html_str
+        assert "Active profile: <strong>minimal</strong>" in html_str
+        assert "Per-service memory limits not propagated" in html_str
+
+    def test_render_with_limits_lists_each_service(self, metadata_service_module):
+        html_str = metadata_service_module._render_resource_profile_section(
+            {
+                "name": "standard",
+                "limits": [("snapserver", "192M"), ("mpd", "384M")],
+            }
+        )
+        assert "Active profile: <strong>standard</strong>" in html_str
+        assert "<code>192M</code>" in html_str
+        assert "<code>384M</code>" in html_str
+        # Service labels appear in the order given.
+        assert html_str.index("snapserver") < html_str.index("mpd")
+
+    def test_render_escapes_profile_name_and_limits(self, metadata_service_module):
+        html_str = metadata_service_module._render_resource_profile_section(
+            {
+                "name": "<script>alert(1)</script>",
+                "limits": [("svc&", "<b>192M</b>")],
+            }
+        )
+        assert "<script>alert(1)</script>" not in html_str
+        assert "&lt;script&gt;" in html_str
+        assert "<b>192M</b>" not in html_str
+        assert "&lt;b&gt;192M&lt;/b&gt;" in html_str
+
+
 class TestSnapcastClientsCacheAndRouting:
     """Cache TTL + handle_status routing — gates on regressions the parser/renderer
     tests can't catch (e.g. wiring change that bypasses the cache or skips the fetch).

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -483,7 +483,11 @@ class TestResourceProfile:
         monkeypatch.setenv("MPD_MEM_LIMIT", "384M")
         monkeypatch.setenv("METADATA_MEM_LIMIT", "128M")
         for _, var in metadata_service_module._PROFILE_SERVICE_LIMITS:
-            if var not in {"SNAPSERVER_MEM_LIMIT", "MPD_MEM_LIMIT", "METADATA_MEM_LIMIT"}:
+            if var not in {
+                "SNAPSERVER_MEM_LIMIT",
+                "MPD_MEM_LIMIT",
+                "METADATA_MEM_LIMIT",
+            }:
                 monkeypatch.delenv(var, raising=False)
         profile = metadata_service_module._get_resource_profile()
         assert profile is not None


### PR DESCRIPTION
## Why

The active server resource profile (`minimal` / `standard` / `performance`) is determined automatically by `deploy.sh` based on board RAM and applied as a block of `*_MEM_LIMIT` env vars in `/opt/snapmulti/.env`. Operators can only see *which* profile is active by SSH-ing in and grepping the `# Profile: …` comment line. Surface it on `/status` next to the existing Compose / Snapcast / Snapcast-Clients panels.

## What

| Layer | Change |
|---|---|
| `scripts/deploy.sh` | Writes `SNAPMULTI_PROFILE=<name>` inside each `# Hardware Profile: BEGIN…END` block (name was previously a comment only) |
| `docker-compose.yml` | Propagates `SNAPMULTI_PROFILE` + the 7 `*_MEM_LIMIT` vars to the `metadata` container (same pattern as `SNAPMULTI_RELEASE`) |
| `metadata-service.py` | `_get_resource_profile()` reads env at request time — no subprocess, no file I/O; `_render_resource_profile_section()` returns empty string when `SNAPMULTI_PROFILE` is empty so the section hides itself on dev clones |
| `tests/test_metadata_service.py` | 8 new unit tests pin: hidden on empty/whitespace, name-only fallback when limits don't propagate, ordered-limits assembly, XSS escaping on profile name + limit values |

## Section layout (rendered)

```
Resource Profile
✓ Active profile: standard
· snapserver: 192M
· airplay:    64M
· spotify:    256M
· mpd:        384M
· mympd:      64M
· metadata:   128M
· tidal:      96M
```

## Validation

- Done locally: `uv run pytest tests/test_metadata_service.py` → 56 passed (8 new); `uv run ruff check` clean; `bash -n scripts/deploy.sh` clean; `docker compose config -q` clean
- Deferred to release-gate: live render verification on snapvideo (server-with-display) after PR merges