### PR TITLE
fix(boot-tune): wait for eth0 DHCP before disabling WiFi (race fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **boot-tune.sh race against eth0 DHCP — both eth0 and wlan0 left active, dual-mDNS risk** — `snapmulti-boot-tune.service` runs `After=docker.service` only. On hosts where NetworkManager activates eth0 DHCP in the same boot window (observed on snapvideo 2026-05-31: eth0 `activated` at 01:16:45 ↔ boot-tune started at 01:16:45 same second), the one-shot `ip -4 addr show eth0` probe saw eth0 without an IP yet → kept WiFi ON → both interfaces came up with IPs → dual-mDNS risk + `192.168.63.4 conflict with eth0 MAC DC:A6:32:B4:C6:16` in NM logs. Fix: gate the probe on `/sys/class/net/eth0/carrier == 1` (cable plugged in), then loop for up to 15 s waiting for DHCP to actually assign an IP. WiFi-only hosts (no eth0) short-circuit cleanly. 10 new static invariants pin the carrier gate, the bounded loop (≥ 10 s), the `break` on first IP, and the unchanged `wifi off` / `wifi on` branches.
+
 ### Added
 - **`/status` Resource Profile section** — new "Resource Profile" panel surfaces the active server profile (`minimal` / `standard` / `performance`) and the per-service memory limits (`SNAPSERVER_MEM_LIMIT`, `MPD_MEM_LIMIT`, etc.) `deploy.sh` wrote to `.env`. Env-driven (no subprocess, no file I/O): `deploy.sh` writes `SNAPMULTI_PROFILE=<name>` inside each `# Hardware Profile: BEGIN…END` block; `docker-compose.yml` propagates that plus the `*_MEM_LIMIT` set to the `metadata` container. Dev clones / manual `docker compose up` (where `SNAPMULTI_PROFILE` is empty) hide the section entirely. 8 new unit tests cover the env reader and renderer (XSS escaping on profile name and limit values).
 

--- a/scripts/boot-tune.sh
+++ b/scripts/boot-tune.sh
@@ -58,10 +58,12 @@ if command -v nmcli &>/dev/null; then
     fi
     eth_ip=""
     if [[ "$eth_carrier" == "1" ]]; then
-        for _ in $(seq 1 15); do
+        for i in $(seq 1 15); do
             eth_ip=$(ip -4 addr show eth0 2>/dev/null | awk '/inet /{print $2; exit}' || true)
             [[ -n "$eth_ip" ]] && break
-            sleep 1
+            # Don't sleep on the last iteration — it would add ~1 s of
+            # boot delay for nothing (the loop is about to exit anyway).
+            [[ "$i" -lt 15 ]] && sleep 1
         done
     fi
     if [[ -n "$eth_ip" ]]; then

--- a/scripts/boot-tune.sh
+++ b/scripts/boot-tune.sh
@@ -40,7 +40,30 @@ done
 # 2026-05-10 on pi-zero — snapmulti-boot-tune.service was failing in
 # 87 ms with no diagnostic in the journal, every boot.
 if command -v nmcli &>/dev/null; then
-    eth_ip=$(ip -4 addr show eth0 2>/dev/null | awk '/inet /{print $2; exit}' || true)
+    # Race condition guard: NetworkManager activates eth0 DHCP in the same
+    # window where this service runs (After=docker.service is too loose).
+    # Observed on snapvideo 2026-05-31: eth0 DHCP `activated` at 01:16:45
+    # ↔ boot-tune started at 01:16:45 (same second). The probe below
+    # then saw eth0 without an IP yet → kept WiFi ON → both interfaces
+    # came up with IPs → dual-mDNS risk + `192.168.63.4 conflict with
+    # eth0 MAC` in NetworkManager logs.
+    #
+    # Carrier means "cable plugged in"; the IP probe waits for DHCP to
+    # actually complete. 15 s covers any modern DHCP server on a healthy
+    # LAN; on WiFi-only devices (no eth0) carrier is 0/missing and the
+    # loop is skipped entirely.
+    eth_carrier=0
+    if [[ -e /sys/class/net/eth0/carrier ]]; then
+        eth_carrier=$(cat /sys/class/net/eth0/carrier 2>/dev/null || echo 0)
+    fi
+    eth_ip=""
+    if [[ "$eth_carrier" == "1" ]]; then
+        for _ in $(seq 1 15); do
+            eth_ip=$(ip -4 addr show eth0 2>/dev/null | awk '/inet /{print $2; exit}' || true)
+            [[ -n "$eth_ip" ]] && break
+            sleep 1
+        done
+    fi
     if [[ -n "$eth_ip" ]]; then
         # Ethernet has an IP — safe to disable WiFi
         nmcli radio wifi off 2>/dev/null \

--- a/tests/test_boot_tune_eth0_race.sh
+++ b/tests/test_boot_tune_eth0_race.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Static invariants on the eth0-DHCP wait in boot-tune.sh.
+#
+# Why pin these statically:
+# - The race between boot-tune.service start and NetworkManager
+#   eth0-DHCP-activated is exactly the kind of timing bug that
+#   silently passes CI (no network in the test environment) but
+#   breaks production. Observed on snapvideo 2026-05-31: both
+#   eth0+wlan0 active, dual-mDNS risk, `conflict detected for
+#   192.168.63.4 with host DC:A6:32:B4:C6:16` in NetworkManager
+#   logs (the eth0 MAC of the same Pi).
+# - A future refactor that "simplifies" the wait loop back to the
+#   one-shot IP probe would re-introduce the bug. Lock it in.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../scripts/boot-tune.sh"
+
+pass=0
+fail=0
+
+check() {
+    local desc="$1" condition="$2"
+    if eval "$condition" >/dev/null 2>&1; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "== boot-tune.sh eth0-DHCP race guard =="
+check "script exists" "[[ -f '$SCRIPT' ]]"
+check "checks /sys/class/net/eth0/carrier before probing IP" "grep -q '/sys/class/net/eth0/carrier' '$SCRIPT'"
+check "skips IP probe when carrier is missing/zero (WiFi-only host short-circuit)" "awk '/eth_carrier=0/{a=1} a && /\\[\\[ \"\\\$eth_carrier\" == \"1\" \\]\\]/{b=1; exit} END{exit !b}' '$SCRIPT'"
+check "uses a loop with bounded retries (DHCP completion wait)" "grep -qE 'for .* in \\\$\\(seq 1 [0-9]+\\)' '$SCRIPT'"
+check "loop bound is at least 10 s (DHCP timeout headroom)" "grep -oE 'seq 1 [0-9]+' '$SCRIPT' | awk '{n=\$3; exit !(n>=10)}'"
+check "loop exits on first IP found (break)" "awk '/for .* in \\\$\\(seq 1/{f=1} f && /break/{ok=1; exit} END{exit !ok}' '$SCRIPT'"
+check "sleeps 1 s per iteration (loop bound = max wait in seconds)" "awk '/for .* in \\\$\\(seq 1/{f=1} f && /sleep 1$/{ok=1; exit} END{exit !ok}' '$SCRIPT'"
+check "nmcli radio wifi off still fires when IP found" "grep -q 'nmcli radio wifi off' '$SCRIPT'"
+check "nmcli radio wifi on still fires on the else branch" "grep -q 'nmcli radio wifi on' '$SCRIPT'"
+check "logger trace mentions 'single mDNS' (observability for the dual-iface fix)" "grep -q 'single mDNS' '$SCRIPT'"
+
+echo
+echo "Results: $pass passed, $fail failed"
+exit $fail


### PR DESCRIPTION
## Why

`snapmulti-boot-tune.service` was supposed to disable WiFi when Ethernet is active (avoid dual mDNS, per [pattern_avahi_dual_publish_race](docs/decisions/...)). On snapvideo 2026-05-31 it didn't:

```
01:16:45  NetworkManager: dhcp4 (eth0): state changed activated
01:16:45  systemd[1]: Starting snapmulti-boot-tune.service
01:16:45  device (wlan0): conflict detected for IP 192.168.63.4
                          with host DC:A6:32:B4:C6:16  (eth0 MAC, same Pi)
01:16:46  boot-tune: finished — WiFi NOT disabled
...
03:38     wlan0 still UP (.4), eth0 UP (.81)  → dual mDNS risk
```

Race: `ip -4 addr show eth0` ran in the same second as the DHCP `activated` event, saw an empty address list, fell through to the "no eth IP → leave WiFi on" branch.

## What

| File | Change |
|------|--------|
| `scripts/boot-tune.sh` | Gate the IP probe on `/sys/class/net/eth0/carrier == 1` (cable plugged in). Then loop up to **15 s** waiting for `ip -4 addr show eth0` to actually return an IP. WiFi-only hosts (no eth0) short-circuit cleanly. |
| `tests/test_boot_tune_eth0_race.sh` | **10 static invariants** — carrier gate, bounded loop (≥ 10 s), `break` on first IP, 1 s sleep per iteration, unchanged `wifi off` / `wifi on` branches, `single mDNS` logger trace. |
| `CHANGELOG.md` | `### Fixed` entry under `[Unreleased]`. |

## Design choices

- **Carrier as the gate, IP-presence as the wait.** Carrier means "cable plugged in physically"; IP means "DHCP completed". Cable without DHCP gives `carrier=1 + no IP` (dumb switch). That's the case we want to wait for, not skip.
- **15 s ceiling.** Any DHCP server on a healthy LAN replies well under 5 s. 15 s gives headroom for a busy server / slow STP convergence without holding boot-tune indefinitely. Past the ceiling, the script keeps WiFi on — same fallback as before.
- **No `network-online.target` dependency.** Pi Zero and similar WiFi-only hosts don't always reach `network-online.target` quickly (or at all if WiFi config is being applied); blocking on it would make those installs hang.

## Validation

- Done locally: 10/10 invariants pass, shellcheck + bash -n clean
- Live evidence: snapvideo today is the exact failure mode being fixed. Manual recovery is `sudo nmcli radio wifi off` on the running host. The fix lands at next reboot — no need to live-patch the active host