### PR TITLE
fix(progress): ETA label width misaligned the elapsed/bar row in install TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Install TUI ETA misaligned the elapsed/bar row** — PR #556 added the `" / ~NN min"` ETA label to the elapsed row but kept `bar_width = _box_width - 12` (fixed overhead from before the ETA existed). The bar overflowed the right border whenever ETA was shown; header and step rows stayed aligned because their layout doesn't reference `bar_width`. Fix: compute the ETA label and its width BEFORE `bar_width`, subtract it from the bar's available space. The math now lands at `2 + 5 + eta + 2 + 1 + bar + 1 = box - 1` (consistent 1-col padding for both ETA-on and ETA-off cases).
+
 ## [0.7.9.7] — 2026-06-01
 
 > Script-only patch (image_set stays 0.7.7). Closes the production reboot loop on Ethernet+WiFi-off hosts (#566 — observed 4 reboots in 40 min on snapvideo), reconciles Avahi `allow-interfaces` at every boot to handle topology changes (#565), fixes the boot-tune eth0 DHCP race that left both interfaces active (#564). Adds the WiFi watchdog for BCM43455 firmware wedges (#563), nightly MPD-NFS rescan (#562), and the `/status` Resource Profile section (#561). All live-deployed and validated on the full fleet (snapvideo + snapdigi + pizero) before tag.

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -141,9 +141,20 @@ render_progress() {
     (( pct < 0 )) && pct=0
     (( pct > 100 )) && pct=100
 
-    # Build progress bar (fills available width minus elapsed label)
-    # "  00:00  [####----]" = 12 chars overhead
-    local bar_width=$(( _box_width - 12 ))
+    # ETA label needs to be computed BEFORE bar_width — its width eats into
+    # the bar's available space. PR #556 added the ETA without subtracting
+    # its length here, which pushed the bar past the right border and
+    # misaligned the elapsed row vs the header/step rows.
+    local _eta_label=""
+    if [[ -n "${EXPECTED_TOTAL_MIN:-}" ]]; then
+        _eta_label=" / ~${EXPECTED_TOTAL_MIN} min"
+    fi
+    local _eta_width=${#_eta_label}
+
+    # Build progress bar (fills available width minus elapsed + eta label)
+    # "  00:00  [####----]" = 12 chars overhead (2 indent + 5 mm:ss + 2 gap
+    # + 1 '[' + 1 ']' + 1 trailing).  Plus the ETA label width when shown.
+    local bar_width=$(( _box_width - 12 - _eta_width ))
     (( bar_width < 20 )) && bar_width=20
     local filled=$(( pct * bar_width / 100 ))
     local empty=$(( bar_width - filled ))
@@ -173,10 +184,7 @@ render_progress() {
         printf '  | \033[1m%-*.*s\033[0m |\n' "$_inner_width" "$_inner_width" "$PROGRESS_TITLE"
         printf '  +%s+\n' "$hline"
         # \033[37m not \033[2m — framebuffer console lacks dim support.
-        local _eta_label=""
-        if [[ -n "${EXPECTED_TOTAL_MIN:-}" ]]; then
-            _eta_label=" / ~${EXPECTED_TOTAL_MIN} min"
-        fi
+        # _eta_label was computed above (before bar_width) so the bar fits.
         printf '  \033[36m%02d:%02d\033[0m\033[37m%s\033[0m  \033[33m[%s]\033[0m\n' \
             $((elapsed/60)) $((elapsed%60)) "$_eta_label" "$bar"
         printf '  %3d%% %s\n' "$pct" "$spinner"

--- a/scripts/common/progress.sh
+++ b/scripts/common/progress.sh
@@ -141,10 +141,7 @@ render_progress() {
     (( pct < 0 )) && pct=0
     (( pct > 100 )) && pct=100
 
-    # ETA label needs to be computed BEFORE bar_width — its width eats into
-    # the bar's available space. PR #556 added the ETA without subtracting
-    # its length here, which pushed the bar past the right border and
-    # misaligned the elapsed row vs the header/step rows.
+    # ETA label must be computed BEFORE bar_width — its width eats into the bar's available space.
     local _eta_label=""
     if [[ -n "${EXPECTED_TOTAL_MIN:-}" ]]; then
         _eta_label=" / ~${EXPECTED_TOTAL_MIN} min"


### PR DESCRIPTION
## Why

PR #556 added the ETA label (\` / ~NN min\`) to the elapsed row of the install TUI but kept the legacy \`bar_width = _box_width - 12\` (fixed overhead from before the ETA existed). When the ETA was shown, the bar overflowed the right border, making the elapsed row wider than the header and step rows above it.

| Row | Width composition | Pre-fix |
|------|-------------------|---------|
| Header | \`+----...----+\` = \`box\` | aligned |
| Elapsed | \`2 + 5 + eta + 2 + 1 + bar + 1\` = \`box - 1 + eta_width\` (oops) | **overflowed by eta_width** |
| Step row | \`box\` | aligned |

## What

\`scripts/common/progress.sh\` — compute the ETA label and its width BEFORE \`bar_width\`, then subtract \`eta_width\` from the bar's available space. Also drop the duplicate \`_eta_label\` declaration inside the inner printf block.

## Math (box=100 example)

| ETA state | bar_width | total visible | padding |
|-----------|-----------|---------------|---------|
| off | 88 | 99 | 1 col right |
| on (10 chars) | 78 | 99 | 1 col right |
| on (12 chars) | 76 | 99 | 1 col right |

The min-bar clamp (\`< 20 → 20\`) still applies after the new subtraction, so very small consoles degrade gracefully.

## Validation

- Done locally: \`shellcheck -S warning\` clean (pre-existing SC1003 on line 271 unrelated to this diff), \`bash -n\` clean, math checked in 3 width scenarios
- \`/review --quick\` (code-reviewer agent): CLEAN
- Deferred to release-gate: visual confirmation on \`/dev/tty1\` during next reflash