### PR TITLE
fix(overlayroot): SIGPIPE-pipefail false-negative in liblzma skip check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **overlayroot: `_initramfs_already_has_liblzma` SIGPIPE-pipefail false-negative** — the helper used `lsinitramfs "$target" | grep -qF "liblzma.so.5"`; with `set -euo pipefail`, `grep -q` exits at the first match, the upstream `lsinitramfs` (streaming ~10k entries from a ~12 MB cpio archive) receives SIGPIPE and exits 141, pipefail propagates the 141 to the helper, and the check always returned false. Result: `ensure_overlayroot_initramfs_ready` always took the "refreshing" branch on every kernel, the second-and-later kernels ran `update-initramfs` after `/boot/firmware` had already been remounted ro by the read-only setup step, and firstboot logged the cosmetic `update-initramfs -u -k 6.18.33+rpt-rpi-… failed` + `first boot may not activate overlay` WARN trio on every fresh install. Overlay still came up because the dpkg trigger had already produced a usable initramfs into `/boot/firmware` (kmod on trixie pulls liblzma via its linker dependency), so the WARN was load-bearing only as noise — but it did make `/var/log/snapmulti-install.log` look broken. Fix: switch to `grep -F "liblzma.so.5" >/dev/null` so the consumer drains the entire stream and `lsinitramfs` exits 0. Regression test added in `tests/test_initramfs_idempotent_skip.sh` (fake `lsinitramfs` producing 10k+ lines around the match, asserting helper succeeds under `set -euo pipefail`).
+
 ## [0.8.0] — 2026-06-03
 
 > **v0.8 hardening track** — 13 PRs of SSOT extraction, drift-class invariants, and

--- a/scripts/common/overlayroot-lifecycle.sh
+++ b/scripts/common/overlayroot-lifecycle.sh
@@ -141,7 +141,13 @@ _initramfs_already_has_liblzma() {
     local target="$1"
     [[ -f "$target" ]] || return 1
     command -v lsinitramfs >/dev/null 2>&1 || return 1
-    lsinitramfs "$target" 2>/dev/null | grep -qF "liblzma.so.5"
+    # NB: grep -F ... >/dev/null (NOT grep -qF). With `set -euo pipefail`
+    # grep -q exits at first match, which sends SIGPIPE upstream to
+    # lsinitramfs (lsinitramfs streams ~10k entries from a 12 MB cpio
+    # archive). pipefail then propagates the 141 from lsinitramfs and
+    # the check appears to fail even when liblzma IS present. The non-q
+    # form consumes the entire stream, so lsinitramfs exits 0 cleanly.
+    lsinitramfs "$target" 2>/dev/null | grep -F "liblzma.so.5" >/dev/null
 }
 
 ensure_overlayroot_initramfs_ready() {

--- a/tests/test_initramfs_idempotent_skip.sh
+++ b/tests/test_initramfs_idempotent_skip.sh
@@ -82,6 +82,76 @@ _initramfs_already_has_liblzma "/nonexistent/initramfs" || _rc=$?
 assert_rc "$_rc" 1 "missing target → false (conservative — rebuild)"
 
 echo
+echo "=== _initramfs_already_has_liblzma — pipefail + SIGPIPE regression ==="
+# Real lsinitramfs streams ~10k entries from a ~12 MB cpio archive. With
+# `set -euo pipefail`, the original `grep -qF` would exit at first match,
+# send SIGPIPE to lsinitramfs (exit 141), and pipefail would propagate the
+# 141 — the check returned false EVEN WHEN liblzma was present, and
+# firstboot.sh re-ran update-initramfs against a now-ro /boot/firmware,
+# logging the cosmetic "first boot may not activate overlay" WARN.
+# This block reproduces the pipefail interaction with a fake lsinitramfs
+# that emits lots of output BEFORE the matching line.
+SANDBOX=$(mktemp -d -t initramfs-pipefail-XXXXXX)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# Fake lsinitramfs: stream many lines so grep -q would close the pipe
+# well before the producer finishes.
+mkdir -p "$SANDBOX/bin"
+cat > "$SANDBOX/bin/lsinitramfs" <<'STUB'
+#!/usr/bin/env bash
+set -e
+# Emit a long preamble, then the liblzma line, then more output to ensure
+# any early-exit consumer triggers SIGPIPE on the producer.
+for i in $(seq 1 5000); do
+    echo "usr/lib/aarch64-linux-gnu/preamble-entry-${i}.so"
+done
+echo "usr/lib/aarch64-linux-gnu/liblzma.so.5"
+for i in $(seq 1 5000); do
+    echo "usr/lib/aarch64-linux-gnu/tail-entry-${i}.so"
+done
+STUB
+chmod +x "$SANDBOX/bin/lsinitramfs"
+
+touch "$SANDBOX/initramfs8"
+
+# Verify the helper survives pipefail and returns success.
+_rc=0
+PATH="$SANDBOX/bin:$PATH" _initramfs_already_has_liblzma "$SANDBOX/initramfs8" || _rc=$?
+assert_rc "$_rc" 0 "pipefail-safe: liblzma matched in streamed output (no SIGPIPE false-negative)"
+
+# Negative case: absence still returns false.
+cat > "$SANDBOX/bin/lsinitramfs" <<'STUB'
+#!/usr/bin/env bash
+set -e
+for i in $(seq 1 1000); do
+    echo "usr/lib/aarch64-linux-gnu/nothing-${i}.so"
+done
+STUB
+chmod +x "$SANDBOX/bin/lsinitramfs"
+
+_rc=0
+PATH="$SANDBOX/bin:$PATH" _initramfs_already_has_liblzma "$SANDBOX/initramfs8" || _rc=$?
+assert_rc "$_rc" 1 "pipefail-safe: liblzma absent → false (rebuild)"
+
+# Static-shape assertion: guard the regression at source-level too — the
+# pipeline must NOT use `grep -qF` (early exit + SIGPIPE) and MUST sink
+# to >/dev/null so the producer drains cleanly.
+if grep -nE 'lsinitramfs[^|]+\|[[:space:]]*grep -qF' "$LIB" >/dev/null 2>&1; then
+    echo "  FAIL: helper still uses 'grep -qF' — re-introduces SIGPIPE pipefail bug"
+    fail=$((fail + 1))
+else
+    echo "  PASS: helper does not use 'grep -qF' (SIGPIPE-safe form)"
+    pass=$((pass + 1))
+fi
+if grep -nE 'lsinitramfs[^|]+\|[[:space:]]*grep -F[^|]+>/dev/null' "$LIB" >/dev/null 2>&1; then
+    echo "  PASS: helper sinks grep output to /dev/null (producer drains cleanly)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: helper missing >/dev/null sink — drain shape not guaranteed"
+    fail=$((fail + 1))
+fi
+
+echo
 echo "=== Static wiring — ensure_overlayroot_initramfs_ready calls the skip path ==="
 if grep -qE "_initramfs_already_has_liblzma" "$LIB"; then
     echo "  PASS: ensure_overlayroot_initramfs_ready references the idempotency check"


### PR DESCRIPTION
| | |
|---|---|
| Trigger | Cosmetic `update-initramfs failed` + `first boot may not activate overlay` WARN on every fresh install (#580 follow-up) |
| Root cause | `lsinitramfs \| grep -qF` + `set -euo pipefail`: grep-q exits at first match → SIGPIPE upstream → lsinitramfs exits 141 → pipefail propagates → skip check always false |
| Impact | Cosmetic only — overlay activates because dpkg trigger already produced a usable initramfs (kmod on trixie pulls liblzma via DT_NEEDED). Log noise masks real issues |
| Fix | `grep -F ... >/dev/null` — consumer drains entire stream, no SIGPIPE |
| Tests | `tests/test_initramfs_idempotent_skip.sh`: 15/15, +6 new (stub lsinitramfs with 10k+ entries around match + source-shape assertions). Bash 3.2 + 5 + shellcheck verde |
| Verified live | snapdigi: helper returns 0 under pipefail after fix (was returning 1 before for both initramfs8 and initramfs_2712 with liblzma present) |

## Validation

Done locally:
- [x] `bash tests/test_initramfs_idempotent_skip.sh` — 15/15
- [x] `/bin/bash` 3.2.57 (macOS) — same
- [x] `shellcheck scripts/common/overlayroot-lifecycle.sh` — clean
- [x] Live reproduction on snapdigi confirmed root cause and fix

Deferred to next reflash:
- [ ] Fresh firstboot install log no longer carries the WARN trio