### PR TITLE
docs(advanced): finalize MPD_START_PERIOD section — drop stale install.conf example

### DIFF
--- a/docs/ADVANCED.it.md
+++ b/docs/ADVANCED.it.md
@@ -63,12 +63,16 @@ Default:
 | floor verificatore install | `180s` | Hardcoded in `verify_services` |
 | grace stabilità healthcheck | `120s` | Hardcoded in `verify_services` (copre l'intervallo di 30 s di Docker fra health-probe + il second-sample check di `verify_compose_stack`) |
 
-```ini
-# install.conf — scritto sulla SD boot da prepare-sd.sh
-MPD_START_PERIOD=3600s   # 1 ora — copre scan NFS a freddo di librerie grandi
+`deploy.sh` deriva `MPD_START_PERIOD` puramente da `MUSIC_SOURCE` e lo scrive in `/opt/snapmulti/.env`. Un valore pre-impostato in `install.conf` viene silenziosamente ignorato, quindi l'unico override efficace è modificare `.env` direttamente **dopo** il primo boot fallito:
+
+```sh
+# /opt/snapmulti/.env — scritto da deploy.sh; alza dopo il primo install fallito
+sudo sed -i 's/^MPD_START_PERIOD=.*/MPD_START_PERIOD=3600s/' /opt/snapmulti/.env
+sudo rm /var/lib/snapmulti-installer/.install-failed
+sudo bash /boot/firmware/snapmulti/firstboot.sh   # idempotente — riprende dalla fase fallita
 ```
 
-Si propaga da `firstboot.sh` → `deploy.sh` → docker-compose dentro lo `start_period` dell'healthcheck di MPD. **Modalità di fallimento se salti il bump**: `verify_services` esce non-zero → marker `.install-failed` → `setup_readonly_fs` non viene mai eseguito → overlay non si attiva al boot 2. Il `Restart=on-failure` di systemd porta comunque su i container autonomamente dopo che l'install si è arreso, quindi il dispositivo SEMBRA sano dalla rete — ma l'install è incompleto. Recovery: riflasha con la variabile ambiente impostata, OPPURE segui il percorso di completamento manuale in [TROUBLESHOOTING.it.md — Install marcato fallito ma i container girano](TROUBLESHOOTING.it.md#install-marcato-fallito-ma-i-container-girano).
+**Modalità di fallimento se salti il bump**: `verify_services` esce non-zero → marker `.install-failed` → `setup_readonly_fs` non viene mai eseguito → overlay non si attiva al boot 2. Il `Restart=on-failure` di systemd porta comunque su i container autonomamente dopo che l'install si è arreso, quindi il dispositivo SEMBRA sano dalla rete — ma l'install è incompleto e il root è su ext4 scrivibile. Vedi [TROUBLESHOOTING.it.md — Install marcato fallito ma i container girano](TROUBLESHOOTING.it.md#install-marcato-fallito-ma-i-container-girano) per la procedura di recupero completa.
 
 ## Configurazione personalizzata — file `.env`
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -63,12 +63,16 @@ Defaults:
 | install verifier floor | `180s` | Hardcoded in `verify_services` |
 | healthcheck stability grace | `120s` | Hardcoded in `verify_services` (covers Docker's 30 s health-probe interval + `verify_compose_stack` second-sample check) |
 
-```ini
-# install.conf — written to the SD card boot partition by prepare-sd.sh
-MPD_START_PERIOD=3600s   # 1 hour — covers cold NFS scans of large libraries
+`deploy.sh` derives `MPD_START_PERIOD` purely from `MUSIC_SOURCE` and writes it to `/opt/snapmulti/.env`. A value pre-set in `install.conf` is silently ignored, so the only effective override is to edit `.env` directly **after** the first failed boot:
+
+```sh
+# /opt/snapmulti/.env — written by deploy.sh; raise after first failed install
+sudo sed -i 's/^MPD_START_PERIOD=.*/MPD_START_PERIOD=3600s/' /opt/snapmulti/.env
+sudo rm /var/lib/snapmulti-installer/.install-failed
+sudo bash /boot/firmware/snapmulti/firstboot.sh   # idempotent — resumes from the failed phase
 ```
 
-This propagates through `firstboot.sh` → `deploy.sh` → docker-compose into MPD's healthcheck `start_period`. **Failure mode if you skip this**: `verify_services` exits non-zero → `.install-failed` marker → `setup_readonly_fs` never runs → overlay never activates at boot 2. systemd's `Restart=on-failure` still brings the containers up autonomously after the install gives up, so the device LOOKS healthy from the network — but the install is incomplete. Recovery: re-reflash with the env var set, OR follow the manual completion path in [TROUBLESHOOTING.md — Install marked failed but containers run](TROUBLESHOOTING.md#install-marked-failed-but-containers-run).
+**Failure mode if you skip this**: `verify_services` exits non-zero → `.install-failed` marker → `setup_readonly_fs` never runs → overlay never activates at boot 2. systemd's `Restart=on-failure` still brings the containers up autonomously after the install gives up, so the device LOOKS healthy from the network — but the install is incomplete and root is on writable ext4. See [TROUBLESHOOTING.md — Install marked failed but containers run](TROUBLESHOOTING.md#install-marked-failed-but-containers-run) for the full recovery procedure.
 
 ## Custom config — `.env` files
 


### PR DESCRIPTION
## Summary

External review found the `### MPD_START_PERIOD` subsection on `docs/ADVANCED.md` + `.it.md` still showed a code block with `# install.conf` + `MPD_START_PERIOD=3600s`, followed by `This propagates through firstboot.sh → deploy.sh → docker-compose`. Both contradicted the line-50 callout (added in #593): `deploy.sh:712-715` derives `MPD_START_PERIOD` purely from `MUSIC_SOURCE` and ignores any `install.conf` pre-set.

Replace the code block + paragraph with the same `/opt/snapmulti/.env` post-failure recovery already documented in `INSTALL-FLOW.md:123` + `TROUBLESHOOTING.md:190`.

## Files

| File | Change |
|------|--------|
| `docs/ADVANCED.md`:66-71 | install.conf example → .env recovery snippet + accurate failure-mode wording |
| `docs/ADVANCED.it.md`:66-71 | IT mirror |

## Validation

Done locally:
- 5-doc cross-check (`grep -nF "sed -i 's/^MPD_START_PERIOD"`) — same one-liner in `ADVANCED{,.it}.md` + `TROUBLESHOOTING{,.it}.md` + `INSTALL-FLOW.md`
- `sh -n` on the recovery snippet
- No residual `# install.conf` + `MPD_START_PERIOD=` example outside the legitimate v0.7.8.10 SSOT section (line 194+, about IMAGE_TAG)

Deferred to release-gate: none (doc-only).

The `[Unreleased]` CHANGELOG bullet from #593 (`MPD_START_PERIOD recovery procedure aligned across all docs … the contradiction is resolved at the live-doc level`) is now accurate.