### PR TITLE
fix(fleet-smoke): drift check on release identity, not build-id

### DIFF
--- a/scripts/fleet-smoke.sh
+++ b/scripts/fleet-smoke.sh
@@ -3,7 +3,10 @@
 #
 # Walks the Snapcast JSON-RPC API on the server (:1780/jsonrpc) to enumerate
 # every connected client, then SSHs in parallel to (server + clients) to:
-#   1. read /opt/snapmulti/VERSION and /opt/snapclient/VERSION
+#   1. read SNAPMULTI_RELEASE from /opt/snapmulti/.env + /opt/snapclient/.env
+#      (release identity, bare tag) and /opt/snapmulti/VERSION +
+#      /opt/snapclient/VERSION (build id, may include `-N-gSHA` distance
+#      suffix when flashed from a post-tag main HEAD)
 #   2. invoke /opt/.../scripts/device-smoke.sh --json --no-fail-on-warn
 # Aggregates the results into a single table (or one JSON object with --json).
 #
@@ -97,8 +100,57 @@ _ssh_failure_note() {
 # fleet aggregate. NB: single-quoted heredoc delimiter (`<<'PAYLOAD'`)
 # disables variable expansion so the payload reaches the device verbatim.
 _FLEET_SMOKE_REMOTE_PAYLOAD=$(cat <<'PAYLOAD'
-srv=$(cat /opt/snapmulti/VERSION 2>/dev/null || echo "")
-cli=$(cat /opt/snapclient/VERSION 2>/dev/null || echo "")
+# Two distinct version notions on a snapMULTI device:
+#   * RELEASE IDENTITY — the snapMULTI release line ("v0.8.1"). Single
+#     source of truth: SNAPMULTI_RELEASE in /opt/snapmulti/.env or
+#     /opt/snapclient/.env (baked from release-manifest.json at flash).
+#     This is what device-smoke.sh prints as "Release vX.Y.Z" and what
+#     the operator means by "what version is this device running".
+#   * BUILD ID — the literal `git describe --tags` value of the commit
+#     the SD was prepared from ("v0.8.1" when flashed from the tag,
+#     "v0.8.1-7-g68e102f" when flashed from N commits past the tag).
+#     Lives in /opt/snapmulti/VERSION or /opt/snapclient/VERSION.
+# Pre-fix this script confused the two: it compared client BUILD ID
+# against server RELEASE IDENTITY and called any mismatch "version
+# drift". A fleet flashed from a mix of tag + post-tag main HEAD
+# tripped that check on every client even though every device was on
+# the same release line. The drift check below now reads the release
+# identity; the build id is kept in `versions` for --json consumers
+# (operator debugging — "which commit did I flash this from").
+_read_release_from_env() {
+    local env_file="$1"
+    [ -r "$env_file" ] || return 0
+    grep -m1 '^SNAPMULTI_RELEASE=' "$env_file" 2>/dev/null | cut -d= -f2- | tr -d '"'\''[:space:]'
+}
+# Client-native installs (Pi Zero 2 W path) have no `.env` because
+# there is no docker-compose stack — snapclient runs as a plain
+# systemd unit. Their release identity lives only in the manifest
+# on the boot partition. Fall back to it when no `.env` is present.
+_read_release_from_manifest() {
+    local manifest="${1:-/boot/firmware/snapmulti/release-manifest.json}"
+    [ -r "$manifest" ] || return 0
+    # No jq dependency on the device side: a single field grep is fine
+    # because release-manifest.json is a short, machine-written file
+    # with one "snapmulti_release" key.
+    grep -m1 '"snapmulti_release"' "$manifest" 2>/dev/null \
+        | sed -E 's/.*"snapmulti_release"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' \
+        | tr -d '[:space:]'
+}
+srv_build=$(cat /opt/snapmulti/VERSION 2>/dev/null || echo "")
+cli_build=$(cat /opt/snapclient/VERSION 2>/dev/null || echo "")
+srv_release=$(_read_release_from_env /opt/snapmulti/.env)
+cli_release=$(_read_release_from_env /opt/snapclient/.env)
+if [ -z "$srv_release" ] && [ -z "$cli_release" ]; then
+    manifest_release=$(_read_release_from_manifest)
+    # Assign to the role-canonical slot. A client-native device is
+    # always a client, so attribute the manifest release to cli_release.
+    # If /opt/snapmulti exists we are server / both — attribute to srv.
+    if [ -d /opt/snapmulti ]; then
+        srv_release="$manifest_release"
+    else
+        cli_release="$manifest_release"
+    fi
+fi
 smoke_script=""
 if [ -x /opt/snapmulti/scripts/device-smoke.sh ]; then
     smoke_script=/opt/snapmulti/scripts/device-smoke.sh
@@ -116,8 +168,10 @@ import json
 import os
 import sys
 
-srv = sys.argv[1]
-cli = sys.argv[2]
+srv_build = sys.argv[1]
+cli_build = sys.argv[2]
+srv_release = sys.argv[3]
+cli_release = sys.argv[4]
 raw = os.environ.get("SMOKE_JSON", "").strip()
 smoke = {}
 if raw:
@@ -125,8 +179,14 @@ if raw:
         smoke, _ = json.JSONDecoder().raw_decode(raw)
     except json.JSONDecodeError:
         smoke = {}
-print(json.dumps({"srv": srv, "cli": cli, "smoke": smoke}, separators=(",", ":")))
-' "$srv" "$cli"
+print(json.dumps({
+    "srv": srv_build,
+    "cli": cli_build,
+    "release_srv": srv_release,
+    "release_cli": cli_release,
+    "smoke": smoke,
+}, separators=(",", ":")))
+' "$srv_build" "$cli_build" "$srv_release" "$cli_release"
 PAYLOAD
 )
 
@@ -202,10 +262,17 @@ probe_host() {
         return
     fi
     # Compose final per-host record.
+    # `release` is the snapMULTI release identity (bare tag, e.g. "v0.8.1")
+    # read from SNAPMULTI_RELEASE in .env. `versions` is the build id
+    # (`git describe --tags` baked on prepare-sd, e.g. "v0.8.1-7-g68e102f")
+    # — useful for "which commit did I flash from?" but never used for the
+    # drift check since two devices on the same release flashed from
+    # different post-tag commits are not drifting.
     jq --arg h "$host" --arg r "$role" \
         '{host:$h, role:$r, reachable:true,
+          release:{server:.release_srv, client:.release_cli},
           versions:{server:.srv, client:.cli},
-          non_snapmulti: ((.srv == "" and .cli == "") and ((.smoke.schema_version // null) == null)),
+          non_snapmulti: ((.srv == "" and .cli == "" and .release_srv == "" and .release_cli == "") and ((.smoke.schema_version // null) == null)),
           smoke:.smoke}' <<<"$payload" >"$out"
 }
 
@@ -525,11 +592,23 @@ if [[ "$OUTPUT" == "json" ]]; then
        '{server:$server, generated_at: (now | todate), connected_non_snapmulti_clients:$connected_non_snapmulti, disconnected_clients:$disconnected, hosts:.}' <<<"$ALL"
     exit "$overall_fail"
 else
+    # Baseline is the release identity (bare tag) of the SERVER host. Build
+    # id (post-tag commit suffix) is irrelevant for fleet coherence: a
+    # client flashed from main HEAD 7 commits past v0.8.1 still runs v0.8.1
+    # because release-manifest.json + .env carry the release line, not the
+    # commit hash. Fall back to .versions if .release is empty (older
+    # snapMULTI versions did not bake SNAPMULTI_RELEASE in .env).
     baseline_version=$(jq -r --arg server "$SERVER" '
         [.[] | select(.host == $server and .reachable == true and ((.non_snapmulti // false) | not))
-         | (.versions.server // "") as $srv
-         | (.versions.client // "") as $cli
-         | if $srv != "" then $srv elif $cli != "" then $cli else empty end][0] // ""
+         | (.release.server // "") as $rsrv
+         | (.release.client // "") as $rcli
+         | (.versions.server // "") as $vsrv
+         | (.versions.client // "") as $vcli
+         | if   $rsrv != "" then $rsrv
+           elif $rcli != "" then $rcli
+           elif $vsrv != "" then $vsrv
+           elif $vcli != "" then $vcli
+           else empty end][0] // ""
     ' <<<"$ALL")
 
     printf '\nFleet smoke against %s — %s\n\n' "$SERVER" "$(date -u +%FT%TZ)"
@@ -580,18 +659,22 @@ else
                 "$host" "$role" "non-snapMULTI" "SKIP" "—" "not a snapMULTI host"
             continue
         fi
+        # Display the release identity (bare tag), with build id as fallback
+        # when the device is older than the SNAPMULTI_RELEASE-in-.env bake.
+        rsrv=$(jq -r '.release.server // ""' <<<"$rec")
+        rcli=$(jq -r '.release.client // ""' <<<"$rec")
         srv=$(jq -r '.versions.server // ""' <<<"$rec")
         cli=$(jq -r '.versions.client // ""' <<<"$rec")
-        # Prefer the role-canonical VERSION file but fall back to the
-        # other one — a `--both` device has both, and a stock VERSION
-        # may live in only one of the two paths depending on install
-        # quirks. If neither exists this is almost certainly NOT a
-        # snapMULTI host (e.g. a peer macOS / Sonos / Echo wandered in
-        # via the Snapcast client list); mark it as "—".
+        # Prefer the role-canonical source but fall back to the
+        # other one — a `--both` device populates both, and on legacy
+        # installs only one path may exist. If neither release nor build
+        # is present this is almost certainly NOT a snapMULTI host (e.g.
+        # a peer macOS / Sonos / Echo wandered in via the Snapcast client
+        # list); mark it as "—".
         if [[ "$role" == "server" ]]; then
-            ver="${srv:-${cli:-}}"
+            ver="${rsrv:-${rcli:-${srv:-${cli:-}}}}"
         else
-            ver="${cli:-${srv:-}}"
+            ver="${rcli:-${rsrv:-${cli:-${srv:-}}}}"
         fi
         if [[ -z "$ver" ]]; then
             ver="non-snapMULTI"

--- a/tests/test_fleet_smoke_static.sh
+++ b/tests/test_fleet_smoke_static.sh
@@ -52,6 +52,30 @@ assert_contains "$src" "ServerAliveInterval=15" "SSH keepalive set (anti-hang wh
 assert_contains "$src" "ServerAliveCountMax=3" "SSH gives up after 3 missed keepalives (~45 s ceiling)"
 assert_contains "$src" '/^\{.*\}$/' "payload sanitiser strips MOTD/banner by picking the single JSON line"
 
+# Release identity vs build id — pre-fix, fleet-smoke compared client
+# `/opt/snapclient/VERSION` (build id, e.g. "v0.8.1-7-g68e102f" from
+# `git describe --tags` baked at flash time) against server
+# `/opt/snapmulti/VERSION` (same build id, but bare "v0.8.1" when the
+# server was flashed from the tag exactly). Two devices on the same
+# release line flashed from different post-tag commits then tripped a
+# false "version drift" WARN on every fleet smoke. The fix reads
+# SNAPMULTI_RELEASE from `.env` (and falls back to release-manifest.json
+# on the boot partition for client-native devices that have no `.env`)
+# as the release identity, and uses that for the drift check.
+assert_contains "$src" "SNAPMULTI_RELEASE" "reads release identity from .env, not just VERSION file"
+assert_contains "$src" "_read_release_from_env" "release-id helper extracted"
+assert_contains "$src" "_read_release_from_manifest" "client-native fallback to release-manifest.json"
+assert_contains "$src" "release_srv" "release identity surfaces in the JSON payload"
+assert_contains "$src" "release_cli" "release identity surfaces for client role too"
+assert_contains "$src" "release:{server:.release_srv, client:.release_cli}" \
+    "per-host record exposes release identity alongside build versions"
+assert_contains "$src" 'jq -r ' "baseline computation uses jq (already required)"
+# The drift baseline now prefers .release over .versions; the original
+# .versions fallback stays for legacy devices that did not bake
+# SNAPMULTI_RELEASE in .env.
+assert_contains "$src" "if   \$rsrv != \"\" then \$rsrv" "drift baseline prefers release-id over build-id"
+assert_contains "$src" "elif \$vsrv != \"\" then \$vsrv" "legacy fallback to build-id when no release-id is baked"
+
 # mDNS discovery hardening (macOS dns-sd path).
 #   1. stdbuf -oL: dns-sd buffers stdout in a pipe, so `timeout 4 dns-sd … | awk`
 #      killed the process before any line flushed. The line-buffer wrapper


### PR DESCRIPTION
## Summary

`fleet-smoke.sh` reported every snapdigi+pizero client as `WARN version drift vs v0.8.1` on v0.8.1 fleet validation even though every device was on the same release line. Root cause: the drift check read `/opt/snapclient/VERSION` (the `git describe --tags` build-id baked at flash, e.g. `v0.8.1-7-g68e102f` when flashed from main HEAD 7 commits past the tag — #588 dropped `--abbrev=0` so the distance suffix is now correctly preserved) and compared it against the same field on the server (where it is the bare tag because the server was flashed from `v0.8.1` exactly). Two different shapes of the same fact.

`device-smoke.sh` already gets this right — it surfaces `Release vX.Y.Z` from `SNAPMULTI_RELEASE` in `.env` (the release identity baked from `release-manifest.json`). This PR makes `fleet-smoke.sh` consume the same source.

## Changes

| Surface | Before | After |
|---|---|---|
| Remote payload | Reads only `VERSION` files | Reads `SNAPMULTI_RELEASE` from `.env` + falls back to `/boot/firmware/snapmulti/release-manifest.json` for client-native (no `.env`); keeps `VERSION` as build id |
| Per-host JSON record | `versions: {server, client}` | + `release: {server, client}`; `versions` retained for operator debugging via `--json` |
| Baseline | First `versions.*` from server | First `release.*` from server, with `versions.*` fallback for legacy installs |
| Display column / drift check | Build id vs build id | Release id vs release id |

## Validation

Live (mixed-source fleet — server from `v0.8.1` tag, snapdigi+pizero from main HEAD `68e102f`):

Before:
~~~
pizero    client  v0.8.1-7-g68e102f WARN  0  version drift vs v0.8.1
snapdigi  client  v0.8.1-7-g68e102f WARN  0  version drift vs v0.8.1
snapvideo server  v0.8.1            PASS  0
~~~

After:
~~~
pizero    client  v0.8.1            PASS  0
snapdigi  client  v0.8.1            PASS  0
snapvideo server  v0.8.1            PASS  0
~~~

`tests/test_fleet_smoke_static.sh`: 25 → 37 assertions (8 new pins on release sources, payload field exposure, baseline preference order). `tests/test_fleet_smoke_ssh_classification.sh`: 23/0 unchanged. shellcheck clean.