### PR TITLE
chore(deps): bump myMPD 25.0.2 -> 25.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **myMPD bumped `25.0.2` → `25.1.1`**. Upstream bug-fix release: adds missing MPD idle events (`neighbor`, `mount`) to the myMPD event list, embeds latest `libmpdclient`, ships TLS chain support via updated Mongoose, improves the `mympd-config` script, and rolls in translation updates. No config changes required on the snapMULTI side — drop-in replacement. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`.
+
 ### Documentation
 - **`docs/INSTALL-FLOW.md` + `.it.md` — install pipeline overview for technical users / contributors**. New page explains the host → cloud-init → `firstboot.sh` → reboot pipeline at three levels (one-sentence overview, ASCII timeline, four-mode comparison table) without duplicating the beginner walk-through in `INSTALL.md` or the architecture reference in `USAGE.md`. Cross-linked from `INSTALL.{md,it.md}`, `ADVANCED.{md,it.md}`, `USAGE.{md,it.md}`, `TROUBLESHOOTING.{md,it.md}`, and added to the docs table in `README.{md,it.md}` (single row) — no README expansion. CLAUDE.md SSOT table extended with the new owner row + a corresponding "internal install-pipeline changes → INSTALL-FLOW.md only" rule so future drift between code and the new page surfaces during the doc-update step.
 - **State-backup scope corrected — whole myMPD workdir, not just `state/` subdir**. `ADVANCED.{md,it.md}` + `USAGE.{md,it.md}` updated to reflect `backup-snapmulti-state.sh:152` (`backup_mympd_workdir` snapshots `/opt/snapmulti/mympd/workdir` in full — state + config + smartpls + scripts + pics). User-customised smart playlists / themes / scripts now correctly documented as surviving a reflash.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ ARM-only audio source using `edgecrush3r/tidal-connect` as base image (Raspbian 
 
 ## Conventions
 
-- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `lollonet/snapmulti-tidal:<image-set>` (ARM only) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.0.2` (upstream)
+- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `lollonet/snapmulti-tidal:<image-set>` (ARM only) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.1.1` (upstream)
 - **Multi-arch**: linux/amd64 (studio) + linux/arm64 (ci-runner-x86), native builds on self-hosted runners
 - **Config paths**: all config in `config/`, all scripts in `scripts/`, shared libs in `scripts/common/`
 - **Deployment**: tag push (`v*`) triggers build → manifest → deploy

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -33,7 +33,7 @@ recipe.
 - Project: <https://github.com/jcorporation/myMPD>
 - Author: jcorporation
 - License: GPL-2.0-or-later
-- Version: upstream `ghcr.io/jcorporation/mympd/mympd:25.0.2` (image used as-is,
+- Version: upstream `ghcr.io/jcorporation/mympd/mympd:25.1.1` (image used as-is,
   not rebuilt by snapMULTI)
 
 ## Streaming sources

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
           memory: ${SPOTIFY_MEM_RESERVE:-128M}
 
   mympd:
-    image: ghcr.io/jcorporation/mympd/mympd:25.0.2
+    image: ghcr.io/jcorporation/mympd/mympd:25.1.1
     container_name: mympd
     restart: unless-stopped
     network_mode: host

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -258,7 +258,7 @@ Configurazione del firewall (regole `ufw`) e setup QoS / `cake` qdisc sono docum
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:25.0.2` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:25.1.1` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:<image-set>` | ~200–300 MB |
 
 **Immagini client** (dalla directory [client](../client/)):

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -258,7 +258,7 @@ Firewall configuration (`ufw` rules) and QoS / `cake` qdisc setup are documented
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:25.0.2` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:25.1.1` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:<image-set>` | ~200–300 MB |
 
 **Client images** (from [client](../client/) directory):


### PR DESCRIPTION
| Field | Value |
|---|---|
| Upstream release | [v25.1.1](https://github.com/jcorporation/myMPD/releases/tag/v25.1.1) (2026-06-03) |
| Change type | Bug-fix release |
| Risk | Low — drop-in replacement, no config changes |

## What changed upstream

- Adds missing MPD idle events (`neighbor`, `mount`) to myMPD event list
- Embeds latest `libmpdclient`
- Mongoose update for TLS chain support
- `mympd-config` script improvements
- Translation updates

## Files

`docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`, `CHANGELOG.md`.