### PR TITLE
release: v0.8.2 — myMPD 25.1.1 dep bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-06-07
+
+> **v0.8.2 dep bump** — single upstream image refresh, no snapMULTI rebuild. Image set unchanged (`0.7.7`). No config or behaviour change on the snapMULTI side — reflash from this tag (or `docker compose pull && up -d` on existing installs) picks up the new myMPD image.
+
 ### Changed
-- **myMPD bumped `25.0.2` → `25.1.1`**. Upstream bug-fix release: adds missing MPD idle events (`neighbor`, `mount`) to the myMPD event list, embeds latest `libmpdclient`, ships TLS chain support via updated Mongoose, improves the `mympd-config` script, and rolls in translation updates. No config changes required on the snapMULTI side — drop-in replacement. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`.
+- **myMPD bumped `25.0.2` → `25.1.1`** (#610). Upstream bug-fix release: adds missing MPD idle events (`neighbor`, `mount`) to the myMPD event list, embeds latest `libmpdclient`, ships TLS chain support via updated Mongoose, improves the `mympd-config` script, and rolls in translation updates. No config changes required on the snapMULTI side — drop-in replacement. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`.
 
 ### Documentation
 - **`docs/INSTALL-FLOW.md` + `.it.md` — install pipeline overview for technical users / contributors**. New page explains the host → cloud-init → `firstboot.sh` → reboot pipeline at three levels (one-sentence overview, ASCII timeline, four-mode comparison table) without duplicating the beginner walk-through in `INSTALL.md` or the architecture reference in `USAGE.md`. Cross-linked from `INSTALL.{md,it.md}`, `ADVANCED.{md,it.md}`, `USAGE.{md,it.md}`, `TROUBLESHOOTING.{md,it.md}`, and added to the docs table in `README.{md,it.md}` (single row) — no README expansion. CLAUDE.md SSOT table extended with the new owner row + a corresponding "internal install-pipeline changes → INSTALL-FLOW.md only" rule so future drift between code and the new page surfaces during the doc-update step.

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.8.1",
+  "snapmulti_release": "v0.8.2",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
| Field | Value |
|---|---|
| Tag | `v0.8.2` |
| Image set | `0.7.7` (unchanged, no rebuild) |
| Scope | CHANGELOG roll + release-manifest bump |
| Carries | PR #610 (myMPD 25.0.2 → 25.1.1) |

## Plan after merge

1. ff-only merge to main
2. Tag `v0.8.2`, push
3. Wait build-push manifest gate
4. **Stop**. No `gh release create` — tag-only until explicit publish.