### PR TITLE
fix(deploy): bump mympd memory limit 128M -> 192M (performance profile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`deploy.sh` — mympd memory limit bumped `128M` → `192M` (performance profile only)**. snapvideo (Pi 4 8GB, 78k-song NFS library) was OOM-killed twice on the first boot post-reflash during initial myMPD cover-cache + WebradioDB build at the 128M cgroup cap; steady-state observed at 78M (61%). Bumping to 192M gives ~50% headroom over observed steady so first-boot transients on large libraries don't trip the cap. Minimal and standard profiles left untouched (no observed OOM there yet). The outdated `mympd 8M idle` baseline comment in the performance profile is updated with the observed steady-state.
+
 ## [0.8.2] — 2026-06-07
 
 > **v0.8.2 dep bump** — single upstream image refresh, no snapMULTI rebuild. Image set unchanged (`0.7.7`). No config or behaviour change on the snapMULTI side — reflash from this tag (or `docker compose pull && up -d` on existing installs) picks up the new myMPD image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **`deploy.sh` — mympd memory limit bumped `128M` → `192M` (performance profile only)**. snapvideo (Pi 4 8GB, 78k-song NFS library) was OOM-killed twice on the first boot post-reflash during initial myMPD cover-cache + WebradioDB build at the 128M cgroup cap; steady-state observed at 78M (61%). Bumping to 192M gives ~50% headroom over observed steady so first-boot transients on large libraries don't trip the cap. Minimal and standard profiles left untouched (no observed OOM there yet). The outdated `mympd 8M idle` baseline comment in the performance profile is updated with the observed steady-state.
+- **`deploy.sh` — mympd memory limit bumped `128M` → `192M` (performance profile only)**. A Pi 4 8GB with a 78k-song NFS library was OOM-killed twice on the first boot post-reflash during the initial myMPD cover-cache + WebradioDB build at the 128M cgroup cap; steady-state observed at 78M (61%). Bumping to 192M gives ~50% headroom over observed steady so first-boot transients on large libraries don't trip the cap. Minimal and standard profiles left untouched (no observed OOM there yet). The performance profile gains a comment block noting that mympd is sized for the first-boot transient, not the `8M idle` baseline already documented above.
 
 ## [0.8.2] — 2026-06-07
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -270,6 +270,10 @@ EOF
 # For: Pi 4 4GB+, Pi 5, systems with 8GB+ RAM
 # Measured baseline (idle): snapserver 87M, shairport 18M, librespot 22M,
 #   mpd 90M (6k songs), mympd 8M, metadata 52M, tidal 32M
+# 2026-06-19 snapvideo (Pi 4 8GB, 78k-song NFS library): mympd OOM-killed
+#   twice on first boot at 128M cap during initial cache build; steady-state
+#   78M (61%) once cache warms. Bumped to 192M (50% headroom over observed
+#   steady) so first-boot transients don't trigger OOM on large libraries.
 SNAPMULTI_PROFILE=performance
 SNAPSERVER_MEM_LIMIT=256M
 SNAPSERVER_MEM_RESERVE=128M
@@ -283,8 +287,8 @@ SPOTIFY_CPU_LIMIT=1.0
 MPD_MEM_LIMIT=384M
 MPD_MEM_RESERVE=192M
 MPD_CPU_LIMIT=2.0
-MYMPD_MEM_LIMIT=128M
-MYMPD_MEM_RESERVE=64M
+MYMPD_MEM_LIMIT=192M
+MYMPD_MEM_RESERVE=96M
 MYMPD_CPU_LIMIT=0.5
 METADATA_MEM_LIMIT=128M
 METADATA_MEM_RESERVE=64M

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -270,10 +270,10 @@ EOF
 # For: Pi 4 4GB+, Pi 5, systems with 8GB+ RAM
 # Measured baseline (idle): snapserver 87M, shairport 18M, librespot 22M,
 #   mpd 90M (6k songs), mympd 8M, metadata 52M, tidal 32M
-# 2026-06-19 snapvideo (Pi 4 8GB, 78k-song NFS library): mympd OOM-killed
-#   twice on first boot at 128M cap during initial cache build; steady-state
-#   78M (61%) once cache warms. Bumped to 192M (50% headroom over observed
-#   steady) so first-boot transients don't trigger OOM on large libraries.
+# First-boot cover-cache + WebradioDB build on large NFS libraries can
+#   overshoot the steady-state usage (observed: ~78k-song library reaches
+#   78M steady but >128M during transient build). mympd cap sized for the
+#   transient, not the steady baseline.
 SNAPMULTI_PROFILE=performance
 SNAPSERVER_MEM_LIMIT=256M
 SNAPSERVER_MEM_RESERVE=128M


### PR DESCRIPTION
| Field | Value |
|---|---|
| Symptom | mympd OOM-killed twice on first boot post-reflash |
| Host observed | snapvideo (Pi 4 8GB, 78k-song NFS library) |
| Cgroup cap before | 128 MB |
| Cgroup cap after | 192 MB |
| Steady-state observed | 78 MB (61% of new cap, 41% of new cap) |
| Profiles affected | performance only |

## Evidence

`dmesg -T` on snapvideo, day of v0.8.2 reflash:

```
[Tue Jun  9 11:43:36 2026] Memory cgroup out of memory: Killed process 2052 (mympd)
[Tue Jun  9 11:45:33 2026] Memory cgroup out of memory: Killed process 71832 (mympd)
```

`docker stats --no-stream mympd` 10 days later, steady-state:

```
mympd  78.86MiB / 128MiB  61.61%
```

The transient peak during first-boot cover-cache + WebradioDB build overshoots the 128M cap; once cache warms, usage settles at 78M. Bumping to 192M gives ~50% headroom over observed steady so the transient does not trip the cap.

## Scope

Narrow on purpose: only the `performance` profile is touched (`scripts/deploy.sh:286-287`). Minimal and standard profiles untouched — no OOM observed there yet. Will revisit if reports surface on Pi 4 2GB (standard) or Pi 3 1GB (minimal).

The outdated `mympd 8M idle` baseline comment in the performance profile is updated with the observed steady-state.