### PR TITLE
feat(metadata): list MPD HTTP stream + MPD protocol on landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Landing page (`GET /` on `:8083`) now lists the MPD HTTP stream + MPD protocol endpoints**. The metadata-service landing page listed Snapweb, myMPD, and the status/version/metadata/health APIs but omitted two system endpoints MPD already exposes on every install: the direct MP3 HTTP stream on `:8000` (`config/mpd.conf` `httpd` output — browser/VLC playable, bypasses Snapcast) and the native MPD protocol on `:6600` (for clients like `mpc`, `ncmpcpp`, MALP). Both ports are already documented in `docs/USAGE.md`; this surfaces them on the discovery page. No new ports opened — display-only.
+
 ### Fixed
 - **`deploy.sh` — mympd memory limit bumped `128M` → `192M` (performance profile only)**. A Pi 4 8GB with a 78k-song NFS library was OOM-killed twice on the first boot post-reflash during the initial myMPD cover-cache + WebradioDB build at the 128M cgroup cap; steady-state observed at 78M (61%). Bumping to 192M gives ~50% headroom over observed steady so first-boot transients on large libraries don't trip the cap. Minimal and standard profiles left untouched (no observed OOM there yet). The performance profile gains a comment block noting that mympd is sized for the first-boot transient, not the `8M idle` baseline already documented above.
 

--- a/docker/metadata-service/metadata-service.py
+++ b/docker/metadata-service/metadata-service.py
@@ -3216,6 +3216,11 @@ async def handle_root_redirect(request: web.Request) -> web.Response:
         ),
         ("myMPD", f"http://{bare_host}:8180", "Browse and play your music library"),
         (
+            "MPD HTTP stream",
+            f"http://{bare_host}:8000",
+            "Direct MP3 stream of the MPD source (browser/VLC, bypasses Snapcast)",
+        ),
+        (
             "Status page",
             f"http://{bare_host}:8083/status",
             "Containers, audio chain, network, mDNS",
@@ -3243,6 +3248,11 @@ async def handle_root_redirect(request: web.Request) -> web.Response:
             "Metadata WebSocket",
             f"ws://{bare_host}:8082",
             "Live track + cover-art stream",
+        ),
+        (
+            "MPD protocol",
+            f"{bare_host}:6600",
+            "Native MPD control for clients like mpc, ncmpcpp, MALP",
         ),
     ]
 


### PR DESCRIPTION
| Field | Value |
|---|---|
| Page | metadata-service landing page (`GET /` on `:8083`) |
| Added | MPD HTTP stream `:8000` (web), MPD protocol `:6600` (api) |
| New ports | None — both already exposed + documented |
| Image rebuild | Yes on next tag (`metadata-service.py` is baked into `snapmulti-metadata`) |

## Why

The landing page lists Snapweb, myMPD, and the metadata APIs but omitted two system endpoints MPD already serves on every install:

- **MPD HTTP stream `:8000`** — `config/mpd.conf` `httpd` output (LAME MP3 192k, `44100:16:2`). Browser/VLC playable, bypasses Snapcast. → `web_services`.
- **MPD protocol `:6600`** — native control for `mpc`, `ncmpcpp`, MALP. → `api_endpoints`.

## Verified live (snapvideo)

```
:8000 → HTTP/1.1 200 OK, Content-Type: audio/mpeg
:6600 → OK MPD 0.24.0
```

Both ports already in `docs/USAGE.md` (mpd row + MPD-clients row) — this only surfaces them on the discovery page. Display-only, no config/port change.

## Note

No test added: the metadata test suite mocks aiohttp away and doesn't exercise the `GET /` route; the change is two static list entries with zero branching. CHANGELOG updated under `[Unreleased] → Added`.