### PR TITLE
chore(deps): bump myMPD 25.1.1 -> 25.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **myMPD bumped `25.1.1` → `25.2.2`**. Rolls up three upstream releases: `25.2.0` (hardened MPD connection handling + unexpected-disconnect recovery, double-linked-list rework, improved UTF-8 validation, WebradioDB update buttons), `25.2.1` (OpenSSL 4.0 compatibility, Mongoose update), `25.2.2` (placeholder-image init fix, libmpdclient fix). Drop-in — no snapMULTI-side config change. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`. Closes #613, #619, #624.
+
 ### Added
 - **Landing page (`GET /` on `:8083`) now lists the MPD HTTP stream + MPD protocol endpoints**. The metadata-service landing page listed Snapweb, myMPD, and the status/version/metadata/health APIs but omitted two system endpoints MPD already exposes on every install: the direct MP3 HTTP stream on `:8000` (`config/mpd.conf` `httpd` output — browser/VLC playable, bypasses Snapcast) and the native MPD protocol on `:6600` (for clients like `mpc`, `ncmpcpp`, MALP). Both ports are already documented in `docs/USAGE.md`; this surfaces them on the discovery page. No new ports opened — display-only.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ ARM-only audio source using `edgecrush3r/tidal-connect` as base image (Raspbian 
 
 ## Conventions
 
-- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `lollonet/snapmulti-tidal:<image-set>` (ARM only) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.1.1` (upstream)
+- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `lollonet/snapmulti-tidal:<image-set>` (ARM only) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.2.2` (upstream)
 - **Multi-arch**: linux/amd64 (studio) + linux/arm64 (ci-runner-x86), native builds on self-hosted runners
 - **Config paths**: all config in `config/`, all scripts in `scripts/`, shared libs in `scripts/common/`
 - **Deployment**: tag push (`v*`) triggers build → manifest → deploy

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -33,7 +33,7 @@ recipe.
 - Project: <https://github.com/jcorporation/myMPD>
 - Author: jcorporation
 - License: GPL-2.0-or-later
-- Version: upstream `ghcr.io/jcorporation/mympd/mympd:25.1.1` (image used as-is,
+- Version: upstream `ghcr.io/jcorporation/mympd/mympd:25.2.2` (image used as-is,
   not rebuilt by snapMULTI)
 
 ## Streaming sources

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
           memory: ${SPOTIFY_MEM_RESERVE:-128M}
 
   mympd:
-    image: ghcr.io/jcorporation/mympd/mympd:25.1.1
+    image: ghcr.io/jcorporation/mympd/mympd:25.2.2
     container_name: mympd
     restart: unless-stopped
     network_mode: host

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -258,7 +258,7 @@ Configurazione del firewall (regole `ufw`) e setup QoS / `cake` qdisc sono docum
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:25.1.1` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:25.2.2` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:<image-set>` | ~200–300 MB |
 
 **Immagini client** (dalla directory [client](../client/)):

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -258,7 +258,7 @@ Firewall configuration (`ufw` rules) and QoS / `cake` qdisc setup are documented
 | `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
-| `ghcr.io/jcorporation/mympd/mympd:25.1.1` | ~30–50 MB |
+| `ghcr.io/jcorporation/mympd/mympd:25.2.2` | ~30–50 MB |
 | `lollonet/snapmulti-tidal:<image-set>` | ~200–300 MB |
 
 **Client images** (from [client](../client/) directory):


### PR DESCRIPTION
| Field | Value |
|---|---|
| From → To | `25.1.1` → `25.2.2` |
| Change type | 3 upstream releases (2 bug-fix + 1 small feature) |
| Risk | Low — drop-in, no config change |
| Tag verified | `25.2.2` manifest HTTP 200 on ghcr.io |

## What changed upstream

- **25.2.0** — hardened MPD connection handling + unexpected-disconnect recovery, double-linked-list rework, improved UTF-8 validation, WebradioDB update buttons in maintenance modal
- **25.2.1** — OpenSSL 4.0 compatibility, Mongoose update
- **25.2.2** — placeholder-image init fix, libmpdclient fix

The 25.2.0 connection-hardening is mildly relevant to us (myMPD ↔ MPD over the container network).

## Files

`docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`, `CHANGELOG.md`.

## Housekeeping

Closes the stale upstream-bump tracker issues #613 (25.1.1 — already shipped in #610), #619 (25.2.1), #624 (25.2.2).