### PR TITLE
chore(deps): bump go-librespot v0.7.3 -> v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **go-librespot bumped `v0.7.3` → `v0.7.4`**. Upstream reliability + mDNS fixes relevant to snapMULTI: skip tracks Spotify refuses an audio key for instead of freezing playback, avoid duplicate EOF events on loop-context playlist end (fixes spurious multi-track skipping), harden the Avahi backend for renaming, and allow changing the Zeroconf name when no session is active. Drop-in upstream image — no snapMULTI-side config change. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`. Closes #620.
 - **myMPD bumped `25.1.1` → `25.2.2`**. Rolls up three upstream releases: `25.2.0` (hardened MPD connection handling + unexpected-disconnect recovery, double-linked-list rework, improved UTF-8 validation, WebradioDB update buttons), `25.2.1` (OpenSSL 4.0 compatibility, Mongoose update), `25.2.2` (placeholder-image init fix, libmpdclient fix). Drop-in — no snapMULTI-side config change. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`. Closes #613, #619, #624.
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ ARM-only audio source using `edgecrush3r/tidal-connect` as base image (Raspbian 
 
 ## Conventions
 
-- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `lollonet/snapmulti-tidal:<image-set>` (ARM only) + `ghcr.io/devgianlu/go-librespot:v0.7.3` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.2.2` (upstream)
+- **Docker images**: snapMULTI images use the pinned `image_set` from `release-manifest.json` (Docker Hub, built in CI when `requires_image_rebuild=true`) + `lollonet/snapmulti-tidal:<image-set>` (ARM only) + `ghcr.io/devgianlu/go-librespot:v0.7.4` (upstream) + `ghcr.io/jcorporation/mympd/mympd:25.2.2` (upstream)
 - **Multi-arch**: linux/amd64 (studio) + linux/arm64 (ci-runner-x86), native builds on self-hosted runners
 - **Config paths**: all config in `config/`, all scripts in `scripts/`, shared libs in `scripts/common/`
 - **Deployment**: tag push (`v*`) triggers build → manifest → deploy

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -52,7 +52,7 @@ recipe.
 - Project: <https://github.com/devgianlu/go-librespot>
 - Author: devgianlu
 - License: LGPL-3.0
-- Version pinned: `v0.7.3` (`ghcr.io/devgianlu/go-librespot:v0.7.3` in
+- Version pinned: `v0.7.4` (`ghcr.io/devgianlu/go-librespot:v0.7.4` in
   `docker-compose.yml`, image used as-is, not rebuilt)
 - Note: Spotify Connect protocol is reverse-engineered; snapMULTI does not
   bundle any Spotify proprietary code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
   # Open Spotify app → Connect to a device → Select "<hostname> Spotify"
   # Metadata + playback control via meta_go-librespot.py (Snapcast plugin)
   librespot:
-    image: ghcr.io/devgianlu/go-librespot:v0.7.3
+    image: ghcr.io/devgianlu/go-librespot:v0.7.4
     container_name: librespot
     restart: unless-stopped
     network_mode: host

--- a/docs/HARDWARE.it.md
+++ b/docs/HARDWARE.it.md
@@ -255,7 +255,7 @@ Configurazione del firewall (regole `ufw`) e setup QoS / `cake` qdisc sono docum
 |----------|------------|
 | `lollonet/snapmulti-server:<image-set>` | ~80–120 MB |
 | `lollonet/snapmulti-airplay:<image-set>` | ~30–50 MB |
-| `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
+| `ghcr.io/devgianlu/go-librespot:v0.7.4` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
 | `ghcr.io/jcorporation/mympd/mympd:25.2.2` | ~30–50 MB |

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -255,7 +255,7 @@ Firewall configuration (`ufw` rules) and QoS / `cake` qdisc setup are documented
 |-------|------|
 | `lollonet/snapmulti-server:<image-set>` | ~80–120 MB |
 | `lollonet/snapmulti-airplay:<image-set>` | ~30–50 MB |
-| `ghcr.io/devgianlu/go-librespot:v0.7.3` | ~30–50 MB |
+| `ghcr.io/devgianlu/go-librespot:v0.7.4` | ~30–50 MB |
 | `lollonet/snapmulti-mpd:<image-set>` | ~50–80 MB |
 | `lollonet/snapmulti-metadata:<image-set>` | ~60–80 MB |
 | `ghcr.io/jcorporation/mympd/mympd:25.2.2` | ~30–50 MB |


### PR DESCRIPTION
| Field | Value |
|---|---|
| From → To | `v0.7.3` → `v0.7.4` |
| Risk | Low — drop-in upstream image, no config change |
| Tag verified | `v0.7.4` manifest HTTP 200 on ghcr.io |

## Why this one is worth it

Not just a version tick — the 0.7.4 fixes hit areas snapMULTI actually exercises:

- **Skip tracks Spotify refuses an audio key for instead of freezing** — prevents a playback freeze/stall.
- **Avoid duplicate EOF events on loop-context playlist end** — fixes spurious multi-track skipping.
- **Harden Avahi backend for renaming** + **allow changing Zeroconf name with no active session** — mDNS/Avahi robustness, an area we've had fleet issues with.

## Files

`docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`, `CHANGELOG.md`.

Closes #620.