### PR TITLE
release: v0.8.3 — CHANGELOG roll + manifest bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] — 2026-07-26
+
+> **v0.8.3 — script + upstream-image refresh, no snapMULTI rebuild.** Image set unchanged (`0.7.7`); the two upstream bumps (myMPD 25.2.2, go-librespot v0.7.4) are compose-tag pulls and the two changed baked files (`metadata-service.py`, `tidal-meta-bridge.sh`) are bind-mounted, so a reflash from this tag delivers everything without rebuilding snapMULTI images. Release-gate validated live: `device-smoke.sh --both` green on a fresh snapvideo flash (0 WARN / 0 ERROR, 10/10 containers healthy, full MPD metadata + artwork, pre-built db recovered, new `Audio liveness` + DSCP boot-gate checks passing on real hardware).
+
 ### Changed
 - **go-librespot bumped `v0.7.3` → `v0.7.4`**. Upstream reliability + mDNS fixes relevant to snapMULTI: skip tracks Spotify refuses an audio key for instead of freezing playback, avoid duplicate EOF events on loop-context playlist end (fixes spurious multi-track skipping), harden the Avahi backend for renaming, and allow changing the Zeroconf name when no session is active. Drop-in upstream image — no snapMULTI-side config change. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`. Closes #620.
 - **myMPD bumped `25.1.1` → `25.2.2`**. Rolls up three upstream releases: `25.2.0` (hardened MPD connection handling + unexpected-disconnect recovery, double-linked-list rework, improved UTF-8 validation, WebradioDB update buttons), `25.2.1` (OpenSSL 4.0 compatibility, Mongoose update), `25.2.2` (placeholder-image init fix, libmpdclient fix). Drop-in — no snapMULTI-side config change. References updated in `docker-compose.yml`, `CLAUDE.md`, `THIRD-PARTY-NOTICES.md`, `docs/HARDWARE.{md,it.md}`. Closes #613, #619, #624.

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.8.2",
+  "snapmulti_release": "v0.8.3",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
| Field | Value |
|---|---|
| Tag | `v0.8.3` |
| Image set | `0.7.7` (unchanged, no rebuild) |
| Scope | CHANGELOG roll + release-manifest bump |

## Content since v0.8.2

- **Deps**: myMPD 25.1.1 → 25.2.2 (#630), go-librespot v0.7.3 → v0.7.4 (#631) — both upstream, compose-tag pulls
- **Bug fixes**: audio-liveness smoke (#422/#632), tidal album panel-junction (#523/#639), DSCP boot-gate (#555/#640), mympd OOM mem bump (#618)
- **Added**: landing-page MPD HTTP-stream + MPD-protocol endpoints (#628)
- **CI**: 6 Dependabot bumps

## No rebuild needed

Bind-mounted `metadata-service.py` + `tidal-meta-bridge.sh` and upstream compose tags deliver everything on reflash. `image_set` stays `0.7.7`.

## Release-gate (ADR-005)

`device-smoke.sh --both` green on a **fresh snapvideo flash** from this content: 0 WARN / 0 ERROR, 10/10 containers healthy, full MPD metadata + artwork, pre-built db recovered (78k songs), new Audio-liveness + DSCP boot-gate checks passing on real hardware.

## Plan after merge

1. ff-only merge to main
2. Tag `v0.8.3`, push
3. Wait build-push manifest gate
4. **Stop** — no `gh release create` until explicit publish.