### PR TITLE
release: v0.8.4 — system-vitals + CI/doc polish (script-only, no rebuild)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.4] — 2026-08-22
+
+> **v0.8.4 — system-vitals readout + CI/doc polish, no snapMULTI rebuild.** Image set unchanged (`0.7.7`): the new system-vitals badge ships as a bind-mounted `metadata-service.py` / `fb_display.py` plus staged smoke-script changes, so a reflash from this tag delivers it without rebuilding any image. Also rolls up the doc-vs-software audit (#652), the client-`.env` smoke fix, and a CI-efficiency pass (concurrency-cancel + docs-only skips). No source, port, or container-security change.
+
 ### Changed
 - **CI — cancel superseded runs + skip the security scan on docs-only PRs**. Added `concurrency: cancel-in-progress` to `validate`, `security`, `build-test`, and `claude-code-review`, so a new push to a PR cancels the in-flight run instead of running both to completion (the latest run is what a required check reads, so this is safe). `validate`'s push trigger narrowed from `['**']` to `[main]` — feature-branch validation is covered by the `pull_request` event, eliminating the branch-push + PR double run. `security` (not a required check) now `paths-ignore`s `**.md` / `docs/**`, so docs-only PRs skip it. `validate` and `claude-review` are required checks, so they intentionally keep running on every PR — path-skipping a required check would block merge. No `$` impact (the repo is public — hosted runners are free); the win is faster feedback and less self-hosted-runner load.
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapmulti_release": "v0.8.3",
+  "snapmulti_release": "v0.8.4",
   "image_set": "0.7.7",
   "requires_image_rebuild": false
 }


### PR DESCRIPTION
Release prep for **v0.8.4**. Rolls `[Unreleased]` → `[0.8.4]` and bumps `release-manifest.json` `snapmulti_release` to `v0.8.4`.

**Script + docs only — no image rebuild:** `image_set` stays `0.7.7`, `requires_image_rebuild` stays `false`. The vitals badge is a bind-mounted `metadata-service.py` / `fb_display.py` + staged smoke-script change, so a reflash from this tag delivers everything without rebuilding snapMULTI images. On tag push, the build-push manifest gate runs and the build/manifest jobs skip.

**What ships:**
- System-vitals badge — SoC temp · CPU load · 24 h audio-resync — on `/status` and the fb-display HDMI line (#670)
- CI efficiency — `concurrency: cancel-in-progress` + docs-only skips (#671)
- `check_env.sh` smoke now validates the client `.env`
- Doc-vs-software audit fixes (#652)

## Validation
- `device-smoke.sh --both` release gate (ADR-005) runs at reflash time on real hardware; the vitals were already validated live on snapvideo (badge + fb-display line rendering, resync clean).
- After merge → tag `v0.8.4` → wait for the build-push gate. **No `gh release create` / publish** until explicitly requested (tag-without-publish).

Opened as **draft** — ready once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)